### PR TITLE
Fixed a typo

### DIFF
--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -1054,7 +1054,7 @@ void UnixGetOsInfo(OS_INFO *info)
 			}
 			else
 			{
-				info->OsVersion = CopyStr("Unknown Liunx Version");
+				info->OsVersion = CopyStr("Unknown Linux Version");
 				info->OsVendorName = CopyStr("Unknown Vendor");
 			}
 		}


### PR DESCRIPTION
Fixed a typo visible in the server info ("Liunx" => "Linux")
