### PR TITLE
Client Manager supporting /hostname and /password

### DIFF
--- a/src/Cedar/CMInner.h
+++ b/src/Cedar/CMInner.h
@@ -136,6 +136,7 @@ typedef struct CM
 	HWND hStatusBar;
 	REMOTE_CLIENT *Client;
 	char *server_name;
+	char *password;
 	wchar_t *import_file_name;
 	bool HideStatusBar;
 	bool HideTrayIcon;


### PR DESCRIPTION
VPN Client Managerでリモートへ接続する際に対象となるホストとパスワードを指定できるようにしました。

e.g.: vpncmgr.exe /hostnane example.com /password hoge

マージされる場合、オプションは1でお願いします。
