### PR TITLE
Adding to check for armv6l so Debian package can be built on Raspberry P...

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,3 +20,5 @@ override_dh_auto_install:
 configure_config:
 	if [ $(shell uname -m) = 'x86_64' ]; then echo "1\n2\n" | ./configure; fi
 	if [ $(shell uname -m) = 'i686' ]; then echo "1\n1\n" | ./configure; fi
+	if [ $(shell uname -m) = 'armv6l' ]; then echo "1\n1\n" | ./configure; fi
+


### PR DESCRIPTION
Current rules for Debian package fails on armv6l, namely Raspberry Pi. Adding this check will allow the package creation to continue.
