### PR TITLE
initial fix for clang warnings

### DIFF
--- a/src/Cedar/Logging.c
+++ b/src/Cedar/Logging.c
@@ -2406,7 +2406,7 @@ bool MakeLogFileName(LOG *g, char *name, UINT size, char *dir, char *prefix, UIN
 	if (strcmp(old_datestr, tmp) != 0)
 	{
 		ret = true;
-		strcpy(old_datestr, tmp);
+		StrCpy(old_datestr, MAX_SIZE, tmp);
 	}
 
 	snprintf(name, size, "%s%s%s%s%s.log", dir,

--- a/src/Cedar/WebUI.c
+++ b/src/Cedar/WebUI.c
@@ -326,7 +326,7 @@ static wchar_t *WpListener(WEBUI *wu, LIST *params)
 	WU_CONTEXT *context = WuGetContext(wu->Contexts, sessionkey);
 	char *cmd = (char*)StrMapSearch(params, "CMD");
 	RPC_LISTENER t;
-	UINT retcode;
+	UINT retcode = ERR_NO_ERROR;
 
 	if(context == NULL)
 	{

--- a/src/Mayaqua/Cfg.c
+++ b/src/Mayaqua/Cfg.c
@@ -2243,23 +2243,29 @@ void CfgDeleteFolder(FOLDER *f)
 
 	// Remove all subfolders
 	num = LIST_NUM(f->Folders);
-	ff = Malloc(sizeof(FOLDER *) * num);
-	Copy(ff, f->Folders->p, sizeof(FOLDER *) * num);
-	for (i = 0;i < num;i++)
+	if (num  != 0)
 	{
-		CfgDeleteFolder(ff[i]);
+		ff = Malloc(sizeof(FOLDER *) * num);
+		Copy(ff, f->Folders->p, sizeof(FOLDER *) * num);
+		for (i = 0;i < num;i++)
+		{
+			CfgDeleteFolder(ff[i]);
+		}
+		Free(ff);
 	}
-	Free(ff);
 
 	// Remove all items
 	num = LIST_NUM(f->Items);
-	tt = Malloc(sizeof(ITEM *) * num);
-	Copy(tt, f->Items->p, sizeof(ITEM *) * num);
-	for (i = 0;i < num;i++)
+	if (num != 0)
 	{
-		CfgDeleteItem(tt[i]);
+		tt = Malloc(sizeof(ITEM *) * num);
+		Copy(tt, f->Items->p, sizeof(ITEM *) * num);
+		for (i = 0;i < num;i++)
+		{
+			CfgDeleteItem(tt[i]);
+		}
+		Free(tt);
 	}
-	Free(tt);
 
 	// Memory release
 	Free(f->Name);


### PR DESCRIPTION
Bug reported by the clang static analyzer.

Description: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119
File: /home/tc/git/softetherVPN/src/Cedar/Logging.c
Line: 2409

Description: The left operand of '==' is a garbage value
File: /home/tc/git/softetherVPN/src/Cedar/WebUI.c
Line: 369

Description: Access to field 'p' results in a dereference of a null pointer (loaded from field 'Items')
File: /home/tc/git/softetherVPN/src/Mayaqua/Cfg.c
Line: 2257
