### PR TITLE
Support For Radius Realm

### DIFF
--- a/src/Cedar/Hub.h
+++ b/src/Cedar/Hub.h
@@ -424,6 +424,7 @@ struct HUB
 	UINT RadiusRetryInterval;			// Radius retry interval
 	BUF *RadiusSecret;					// Radius shared key
 	char RadiusSuffixFilter[MAX_SIZE];	// Radius suffix filter
+	bool RadiusIncludeRealm;		// Radius - Should be use hub name as realm
 	volatile bool Halt;					// Halting flag
 	bool Offline;						// Offline
 	bool BeingOffline;					// Be Doing Offline

--- a/src/Cedar/Hub.h
+++ b/src/Cedar/Hub.h
@@ -424,7 +424,7 @@ struct HUB
 	UINT RadiusRetryInterval;			// Radius retry interval
 	BUF *RadiusSecret;					// Radius shared key
 	char RadiusSuffixFilter[MAX_SIZE];	// Radius suffix filter
-	char *RadiusRealm;		// Radius realm (optional)
+	char RadiusRealm[MAX_SIZE];		// Radius realm (optional)
 	volatile bool Halt;					// Halting flag
 	bool Offline;						// Offline
 	bool BeingOffline;					// Be Doing Offline

--- a/src/Cedar/Hub.h
+++ b/src/Cedar/Hub.h
@@ -424,7 +424,7 @@ struct HUB
 	UINT RadiusRetryInterval;			// Radius retry interval
 	BUF *RadiusSecret;					// Radius shared key
 	char RadiusSuffixFilter[MAX_SIZE];	// Radius suffix filter
-	bool RadiusIncludeRealm;		// Radius - Should be use hub name as realm
+	char *RadiusRealm;		// Radius realm (optional)
 	volatile bool Halt;					// Halting flag
 	bool Offline;						// Offline
 	bool BeingOffline;					// Be Doing Offline

--- a/src/Cedar/Sam.c
+++ b/src/Cedar/Sam.c
@@ -211,7 +211,18 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 					AUTHRADIUS *auth = (AUTHRADIUS *)u->AuthData;
 					if (ast || auth->RadiusUsername == NULL || UniStrLen(auth->RadiusUsername) == 0)
 					{
-						name = CopyStrToUni(username);
+						if( h->RadiusIncludeRealm )
+						{	
+							char name_and_realm[MAX_SIZE];
+							name_and_realm = StrCpy(name_and_realm, MAX_SIZE, username);
+							name_and_realm = StrCpy(name_and_realm, (MAX_SIZE - StrLen(name_and_realm)), "@");
+							name_and_realm = StrCpy(name_and_realm, (MAX_SIZE - StrLen(name_and_realm)), hub.name);
+							name = CopyStrToUni(name_and_realm);
+						}
+						else
+						{
+							name = CopyStrToUni(username);
+						}
 					}
 					else
 					{

--- a/src/Cedar/Sam.c
+++ b/src/Cedar/Sam.c
@@ -211,12 +211,12 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 					AUTHRADIUS *auth = (AUTHRADIUS *)u->AuthData;
 					if (ast || auth->RadiusUsername == NULL || UniStrLen(auth->RadiusUsername) == 0)
 					{
-						if( h->RadiusIncludeRealm )
+						if( h->RadiusRealm && (StrLen(h->RadiusRealm) > 0) )
 						{	
 							char name_and_realm[MAX_SIZE];
 							StrCpy(name_and_realm, MAX_SIZE, username);
 							StrCat(name_and_realm, (MAX_SIZE - StrLen(name_and_realm)), "@");
-							StrCat(name_and_realm, (MAX_SIZE - StrLen(name_and_realm)), hub->Name);
+							StrCat(name_and_realm, (MAX_SIZE - StrLen(name_and_realm)), h->RadiusRealm);
 							name = CopyStrToUni(name_and_realm);
 						}
 						else

--- a/src/Cedar/Sam.c
+++ b/src/Cedar/Sam.c
@@ -214,9 +214,9 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 						if( h->RadiusIncludeRealm )
 						{	
 							char name_and_realm[MAX_SIZE];
-							name_and_realm = StrCpy(name_and_realm, MAX_SIZE, username);
-							name_and_realm = StrCpy(name_and_realm, (MAX_SIZE - StrLen(name_and_realm)), "@");
-							name_and_realm = StrCpy(name_and_realm, (MAX_SIZE - StrLen(name_and_realm)), hub.name);
+							StrCpy(name_and_realm, MAX_SIZE, username);
+							StrCat(name_and_realm, (MAX_SIZE - StrLen(name_and_realm)), "@");
+							StrCat(name_and_realm, (MAX_SIZE - StrLen(name_and_realm)), hub->Name);
 							name = CopyStrToUni(name_and_realm);
 						}
 						else

--- a/src/Cedar/Sam.c
+++ b/src/Cedar/Sam.c
@@ -211,7 +211,7 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 					AUTHRADIUS *auth = (AUTHRADIUS *)u->AuthData;
 					if (ast || auth->RadiusUsername == NULL || UniStrLen(auth->RadiusUsername) == 0)
 					{
-						if( h->RadiusRealm && (StrLen(h->RadiusRealm) > 0) )
+						if( IsEmptyStr(h->RadiusRealm) == false )
 						{	
 							char name_and_realm[MAX_SIZE];
 							StrCpy(name_and_realm, MAX_SIZE, username);

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -4926,7 +4926,7 @@ void SiWriteHubCfg(FOLDER *f, HUB *h)
 		CfgAddInt(f, "RadiusServerPort", h->RadiusServerPort);
 		CfgAddInt(f, "RadiusRetryInterval", h->RadiusRetryInterval);
 		CfgAddStr(f, "RadiusSuffixFilter", h->RadiusSuffixFilter);
-		CfgAddBool(f, "RadiusIncludeRealm", h->RadiusIncludeRealm);
+		CfgAddStr(f, "RadiusRealm", h->RadiusRealm);
 	}
 	Unlock(h->RadiusOptionLock);
 
@@ -5092,7 +5092,7 @@ void SiLoadHubCfg(SERVER *s, FOLDER *f, char *name)
 			interval = CfgGetInt(f, "RadiusRetryInterval");
 
 			CfgGetStr(f, "RadiusSuffixFilter", h->RadiusSuffixFilter, sizeof(h->RadiusSuffixFilter));
-			h->RadiusIncludeRealm = CfgGetBool(f, "RadiusIncludeRealm");
+			CfgGetStr(f, "RadiusRealm", h->RadiusRealm, sizeof(h->RadiusRealm));
 
 			if (interval == 0)
 			{

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -4926,6 +4926,7 @@ void SiWriteHubCfg(FOLDER *f, HUB *h)
 		CfgAddInt(f, "RadiusServerPort", h->RadiusServerPort);
 		CfgAddInt(f, "RadiusRetryInterval", h->RadiusRetryInterval);
 		CfgAddStr(f, "RadiusSuffixFilter", h->RadiusSuffixFilter);
+		CfgAddBool(f, "RadiusIncludeRealm", h->RadiusIncludeRealm);
 	}
 	Unlock(h->RadiusOptionLock);
 
@@ -5091,6 +5092,7 @@ void SiLoadHubCfg(SERVER *s, FOLDER *f, char *name)
 			interval = CfgGetInt(f, "RadiusRetryInterval");
 
 			CfgGetStr(f, "RadiusSuffixFilter", h->RadiusSuffixFilter, sizeof(h->RadiusSuffixFilter));
+			h->RadiusIncludeRealm = CfgGetBool(f, "RadiusIncludeRealm");
 
 			if (interval == 0)
 			{


### PR DESCRIPTION
This adds the ability to specify (in the configuration file) a realm to be used for Radius authentication.  Realms are specified on a per-Hub basis.
