### PR TITLE
Try to autodetect OS and CPU instead of requiring user input

### DIFF
--- a/configure
+++ b/configure
@@ -16,66 +16,96 @@ echo
 
 echo 'Welcome to the corner-cutting configure script !'
 echo
-echo 'Select your operating system below:'
-echo ' 1: Linux'
-echo ' 2: FreeBSD'
-echo ' 3: Solaris'
-echo ' 4: Mac OS X'
-echo ' 5: OpenBSD'
-echo
-echo -n 'Which is your operating system (1 - 5) ? : '
-read TMP
-echo
+
 OS=""
-if test "$TMP" = "1"
-then
+case "`uname -s`" in
+Linux)
 	OS="linux"
-fi
-if test "$TMP" = "2"
-then
+	;;
+FreeBSD)
 	OS="freebsd"
-fi
-if test "$TMP" = "3"
-then
+	;;
+SunOS)
 	OS="solaris"
-fi
-if test "$TMP" = "4"
-then
+	;;
+Darwin)
 	OS="macos"
-fi
-if test "$TMP" = "5"
-then
+	;;
+OpenBSD)
 	OS="openbsd"
-fi
+	;;
+*)
+	echo 'Select your operating system below:'
+	echo ' 1: Linux'
+	echo ' 2: FreeBSD'
+	echo ' 3: Solaris'
+	echo ' 4: Mac OS X'
+	echo ' 5: OpenBSD'
+	echo
+	echo -n 'Which is your operating system (1 - 5) ? : '
+	read TMP
+	echo
+	if test "$TMP" = "1"
+	then
+		OS="linux"
+	fi
+	if test "$TMP" = "2"
+	then
+		OS="freebsd"
+	fi
+	if test "$TMP" = "3"
+	then
+		OS="solaris"
+	fi
+	if test "$TMP" = "4"
+	then
+		OS="macos"
+	fi
+	if test "$TMP" = "5"
+	then
+		OS="openbsd"
+	fi
 
-if test "$OS" = ""
-then
-	echo "Wrong number."
-	exit 1
-fi
+	if test "$OS" = ""
+	then
+		echo "Wrong number."
+		exit 1
+	fi
+	;;
+esac
 
-echo 'Select your CPU bits below:'
-echo ' 1: 32-bit'
-echo ' 2: 64-bit'
-echo
-echo -n 'Which is the type of your CPU (1 - 2) ? : '
-read TMP
-echo
 CPU=""
-if test "$TMP" = "1"
-then
-	CPU="32bit"
-fi
-if test "$TMP" = "2"
-then
-	CPU="64bit"
-fi
+case "`uname -m`" in
+x86_64|amd64|aarch64|arm64|armv8*|mips64|ppc64|sparc64|alpha|ia64)
+	CPU=64bit
+	;;
+i?86|x86pc|i86pc|armv4*|armv5*|armv6*|armv7*)
+	CPU=32bit
+	;;
+*)
+	echo 'Select your CPU bits below:'
+	echo ' 1: 32-bit'
+	echo ' 2: 64-bit'
+	echo
+	echo -n 'Which is the type of your CPU (1 - 2) ? : '
+	read TMP
+	echo
+	if test "$TMP" = "1"
+	then
+		CPU="32bit"
+	fi
+	if test "$TMP" = "2"
+	then
+		CPU="64bit"
+	fi
 
-if test "$CPU" = ""
-then
-	echo "Wrong number."
-	exit 1
-fi
+	if test "$CPU" = ""
+	then
+		echo "Wrong number."
+		exit 1
+	fi
+	;;
+esac
 
 cp src/makefiles/${OS}_${CPU}.mak Makefile
 


### PR DESCRIPTION
This tries to autodetect the OS and CPU instead of unconditionally requiring user input -- and falls back to the user prompts if autodetection didn't work
