### PR TITLE
Fix for Debian Package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,7 @@ override_dh_auto_install:
 	make install
 
 configure_config:
-	if [ $(shell uname -m) = 'x86_64' ]; then echo "1\n2\n" | ./configure; fi
-	if [ $(shell uname -m) = 'i686' ]; then echo "1\n1\n" | ./configure; fi
-	if [ $(shell uname -m) = 'armv6l' ]; then echo "1\n1\n" | ./configure; fi
+	if [ $(shell uname -m) = 'x86_64' ]; then echo -e "1\n2\n" | ./configure; fi
+	if [ $(shell uname -m) = 'i686' ]; then echo -e "1\n1\n" | ./configure; fi
+	if [ $(shell uname -m) = 'armv6l' ]; then echo -e "1\n1\n" | ./configure; fi
 


### PR DESCRIPTION
Fixing error for Debian GNU/Linux 7 
During install launching: $ debuild binary 

Select your operating system below:
 1: Linux
 2: FreeBSD
 3: Solaris
 4: Mac OS X
 5: OpenBSD

Which is your operating system (1 - 5) ? : 
Wrong number.
make[1]: **\* [configure_config] Error 1
make[1]: Leaving directory `/usr/local/src/SoftEtherVPN'
make: **\* [binary] Error 2
debuild: fatal error at line 1333:
couldn't exec debian/rules:
