### PR TITLE
fix LogFileGet won't save to SAVEPATH

### DIFF
--- a/src/Cedar/Command.c
+++ b/src/Cedar/Command.c
@@ -9995,7 +9995,7 @@ UINT PsLogFileGet(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 		return ERR_INVALID_PARAMETER;
 	}
 
-	filename = GetParamStr(o, "SAVE");
+	filename = GetParamStr(o, "SAVEPATH");
 
 	c->Write(c, _UU("CMD_LogFileGet_START"));
 


### PR DESCRIPTION
["LogFileGet": ログファイルのダウンロード](https://ja.softether.org/4-docs/1-manual/6/6.3#6.3.56_.22LogFileGet.22:_.E3.83.AD.E3.82.B0.E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB.E3.81.AE.E3.83.80.E3.82.A6.E3.83.B3.E3.83.AD.E3.83.BC.E3.83.89) にある`/SAVEPATH` パラメータがうまく動いていないのを修正

ref http://www.vpnusers.com/viewtopic.php?t=2750
