### PR TITLE
Added armv5tel for debian/rules and made pushed routes work correct with OpenVPN

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,4 +21,5 @@ configure_config:
 	if [ $(shell uname -m) = 'x86_64' ]; then echo "1\n2\n" | ./configure; fi
 	if [ $(shell uname -m) = 'i686' ]; then echo "1\n1\n" | ./configure; fi
 	if [ $(shell uname -m) = 'armv6l' ]; then echo "1\n1\n" | ./configure; fi
+	if [ $(shell uname -m) = 'armv5tel' ]; then echo "1\n1\n" | ./configure; fi
 

--- a/src/Cedar/Interop_OpenVPN.c
+++ b/src/Cedar/Interop_OpenVPN.c
@@ -2114,8 +2114,8 @@ void OvsRecvPacket(OPENVPN_SERVER *s, LIST *recv_packet_list, UINT protocol)
 											if (r->Exists)
 											{
 												Format(l3_options, sizeof(l3_options),
-													",route %r %r vpn_gateway",
-													&r->Network, &r->SubnetMask);
+													",route %r %r %r",
+													&r->Network, &r->SubnetMask, &r->Gateway);
 
 												StrCat(option_str, sizeof(option_str), l3_options);
 											}


### PR DESCRIPTION
Armv5tel is for building Debian package on SheevaPlug.
Also, static routes not working properly with OpenVPN as gateway address gets replaced by vpn_gateway. So, you cannot direct all traffic to VPN and make some nets to go through net_gateway.
By the way, even with this fix you have to specify IP address as gateway in config file and cannot use openvpn's vpn_gateway and net_gateway keywords.
