### PR TITLE
Allow specific SSL/TLS versions to be disabled

### DIFF
--- a/src/Cedar/Cedar.c
+++ b/src/Cedar/Cedar.c
@@ -1803,6 +1803,8 @@ CEDAR *NewCedar(X *server_x, K *server_k)
 
 	c->BuildInfo = CopyStr(tmp);
 
+	c->DisableSslVersions = SSL_OPT_DEFAULT;
+
 	return c;
 }
 

--- a/src/Cedar/Cedar.h
+++ b/src/Cedar/Cedar.h
@@ -415,8 +415,11 @@
 #define NAME_SSL_VERSION_SSL_V2	"SSL_V2"	// SSLv2
 #define NAME_SSL_VERSION_SSL_V3	"SSL_V3"	// SSLv3
 #define NAME_SSL_VERSION_TLS_V1_0	"TLS_V1_0"	// TLS v1.0
-#define NAME_SSL_VERSION_TLS_V1_0	"TLS_V1_1"	// TLS v1.1
-#define NAME_SSL_VERSION_TLS_V1_0	"TLS_V1_2"	// TLS v1.2
+#define NAME_SSL_VERSION_TLS_V1_1	"TLS_V1_1"	// TLS v1.1
+#define NAME_SSL_VERSION_TLS_V1_2	"TLS_V1_2"	// TLS v1.2
+
+// OpenSSL SSL Context Option Flags default
+#define SSL_OPT_DEFAULT	0x0
 
 //////////////////////////////////////////////////////////////////////
 // 
@@ -1065,7 +1068,7 @@ typedef struct CEDAR
 	LOCK *FifoBudgetLock;			// Fifo budget lock
 	UINT FifoBudget;				// Fifo budget
 	bool AcceptOnlyTls;				// Accept only TLS (Disable SSL)
-	UINT DisableSslVersions = 0x0;	// Bitmap of SSL Version to disable
+	UINT DisableSslVersions;	// Bitmap of SSL Version to disable
 	char OpenVPNDefaultClientOption[MAX_SIZE];	// OpenVPN Default Client Option String
 } CEDAR;
 

--- a/src/Cedar/Cedar.h
+++ b/src/Cedar/Cedar.h
@@ -404,7 +404,19 @@
 #define	KEEP_ALIVE_MAGIC				0xffffffff
 #define	MAX_KEEPALIVE_SIZE				512
 
+// SSL/TLS Versions
+#define SSL_VERSION_SSL_V2	0x01	// SSLv2
+#define SSL_VERSION_SSL_V3	0x02	// SSLv3
+#define SSL_VERSION_TLS_V1_0	0x04	// TLS v1.0
+#define SSL_VERSION_TLS_V1_1	0x08	// TLS v1.1
+#define SSL_VERSION_TLS_V1_2	0x10	// TLS v1.2
 
+// SSL/TLS Version Names
+#define NAME_SSL_VERSION_SSL_V2	"SSL_V2"	// SSLv2
+#define NAME_SSL_VERSION_SSL_V3	"SSL_V3"	// SSLv3
+#define NAME_SSL_VERSION_TLS_V1_0	"TLS_V1_0"	// TLS v1.0
+#define NAME_SSL_VERSION_TLS_V1_0	"TLS_V1_1"	// TLS v1.1
+#define NAME_SSL_VERSION_TLS_V1_0	"TLS_V1_2"	// TLS v1.2
 
 //////////////////////////////////////////////////////////////////////
 // 
@@ -1053,6 +1065,7 @@ typedef struct CEDAR
 	LOCK *FifoBudgetLock;			// Fifo budget lock
 	UINT FifoBudget;				// Fifo budget
 	bool AcceptOnlyTls;				// Accept only TLS (Disable SSL)
+	UINT DisableSslVersions = 0x0;	// Bitmap of SSL Version to disable
 	char OpenVPNDefaultClientOption[MAX_SIZE];	// OpenVPN Default Client Option String
 } CEDAR;
 

--- a/src/Cedar/Connection.c
+++ b/src/Cedar/Connection.c
@@ -3137,10 +3137,8 @@ void ConnectionAccept(CONNECTION *c)
 
 	// Start the SSL communication
 	Debug("StartSSL()\n");
-	if (c->Cedar->AcceptOnlyTls)
-	{
-		s->AcceptOnlyTls = true;
-	}
+	s->DisableSslVersions = c->Cedar->DisableSslVersions;
+
 	if (StartSSL(s, x, k) == false)
 	{
 		// Failed

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -6167,23 +6167,23 @@ void SiLoadServerCfg(SERVER *s, FOLDER *f)
 			UINT i;		
 			for (i = 0;i < sslVersions->NumTokens;i++)
 			{
-				if (strcmp(tmp, NAME_SSL_VERSION_SSL_V2)) 
+				if (strcmp(tmp, NAME_SSL_VERSION_SSL_V2)) {
 					c->DisableSslVersions |= SSL_VERSION_SSL_V2;
 					continue;
 				}
-				if (strcmp(tmp, NAME_SSL_VERSION_SSL_V3)) 
+				if (strcmp(tmp, NAME_SSL_VERSION_SSL_V3)) {
 					c->DisableSslVersions |= SSL_VERSION_SSL_V3;
 					continue;
 				}
-				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_0)) 
+				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_0)) { 
 					c->DisableSslVersions |= SSL_VERSION_TLS_V1_0;
 					continue;
 				}
-				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_1)) 
+				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_1)) {
 					c->DisableSslVersions |= SSL_VERSION_TLS_V1_1;
 					continue;
 				}
-				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_2)) 
+				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_2)) {
 					c->DisableSslVersions |= SSL_VERSION_TLS_V1_2;
 					continue;
 				}

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -6157,6 +6157,39 @@ void SiLoadServerCfg(SERVER *s, FOLDER *f)
 
 		// AcceptOnlyTls
 		c->AcceptOnlyTls = CfgGetBool(f, "AcceptOnlyTls");
+		if (c->AcceptOnlyTls) {
+			c->DisableSslVersions |= SSL_VERSION_SSL_V2;
+			c->DisableSslVersions |= SSL_VERSION_SSL_V3;
+		}
+
+		if (CfgGetStr(f, "DisableSslVersions", tmp, sizeof(tmp))) {
+			TOKEN_LIST *sslVersions= ParseToken(tmp, ", ");
+			UINT i;		
+			for (i = 0;i < sslVersions->NumTokens;i++)
+			{
+				if (strcmp(tmp, NAME_SSL_VERSION_SSL_V2)) 
+					c->DisableSslVersions |= SSL_VERSION_SSL_V2;
+					continue;
+				}
+				if (strcmp(tmp, NAME_SSL_VERSION_SSL_V3)) 
+					c->DisableSslVersions |= SSL_VERSION_SSL_V3;
+					continue;
+				}
+				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_0)) 
+					c->DisableSslVersions |= SSL_VERSION_TLS_V1_0;
+					continue;
+				}
+				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_1)) 
+					c->DisableSslVersions |= SSL_VERSION_TLS_V1_1;
+					continue;
+				}
+				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_2)) 
+					c->DisableSslVersions |= SSL_VERSION_TLS_V1_2;
+					continue;
+				}
+			}
+			FreeToken(sslVersions);
+		}
 	}
 	Unlock(c->lock);
 
@@ -6466,6 +6499,8 @@ void SiWriteServerCfg(FOLDER *f, SERVER *s)
 		CfgAddBool(f, "DisableCoreDumpOnUnix", s->DisableCoreDumpOnUnix);
 
 		CfgAddBool(f, "AcceptOnlyTls", c->AcceptOnlyTls);
+
+		CfgAddStr(f, "DisableSslVersions", c->DisableSslVersions);
 
 		// Disable session reconnect
 		CfgAddBool(f, "DisableSessionReconnect", GetGlobalServerFlag(GSF_DISABLE_SESSION_RECONNECT));

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -6167,23 +6167,24 @@ void SiLoadServerCfg(SERVER *s, FOLDER *f)
 			UINT i;		
 			for (i = 0;i < sslVersions->NumTokens;i++)
 			{
-				if (strcmp(tmp, NAME_SSL_VERSION_SSL_V2)) {
+				char *sslVersion=sslVersions->Token[i];
+				if (StrCmp(sslVersion, NAME_SSL_VERSION_SSL_V2)==0) {
 					c->DisableSslVersions |= SSL_VERSION_SSL_V2;
 					continue;
 				}
-				if (strcmp(tmp, NAME_SSL_VERSION_SSL_V3)) {
+				if (StrCmp(sslVersion, NAME_SSL_VERSION_SSL_V3)==0) {
 					c->DisableSslVersions |= SSL_VERSION_SSL_V3;
 					continue;
 				}
-				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_0)) { 
+				if (StrCmp(sslVersion, NAME_SSL_VERSION_TLS_V1_0)==0) { 
 					c->DisableSslVersions |= SSL_VERSION_TLS_V1_0;
 					continue;
 				}
-				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_1)) {
+				if (StrCmp(sslVersion, NAME_SSL_VERSION_TLS_V1_1)==0) {
 					c->DisableSslVersions |= SSL_VERSION_TLS_V1_1;
 					continue;
 				}
-				if (strcmp(tmp, NAME_SSL_VERSION_TLS_V1_2)) {
+				if (StrCmp(sslVersion, NAME_SSL_VERSION_TLS_V1_2)==0) {
 					c->DisableSslVersions |= SSL_VERSION_TLS_V1_2;
 					continue;
 				}
@@ -6500,7 +6501,40 @@ void SiWriteServerCfg(FOLDER *f, SERVER *s)
 
 		CfgAddBool(f, "AcceptOnlyTls", c->AcceptOnlyTls);
 
-		CfgAddStr(f, "DisableSslVersions", c->DisableSslVersions);
+		{
+			char tmp[MAX_SIZE];
+			tmp[0] = 0;
+			if (c->DisableSslVersions & SSL_VERSION_SSL_V2) {
+				StrCat(tmp, sizeof(tmp), NAME_SSL_VERSION_SSL_V2);
+				StrCat(tmp, sizeof(tmp), ",");
+			}
+			if (c->DisableSslVersions & SSL_VERSION_SSL_V3) {
+				StrCat(tmp, sizeof(tmp), NAME_SSL_VERSION_SSL_V3);
+				StrCat(tmp, sizeof(tmp), ",");
+			}
+			if (c->DisableSslVersions & SSL_VERSION_TLS_V1_0) {
+				StrCat(tmp, sizeof(tmp), NAME_SSL_VERSION_TLS_V1_0);
+				StrCat(tmp, sizeof(tmp), ",");
+			}
+			if (c->DisableSslVersions & SSL_VERSION_TLS_V1_1) {
+				StrCat(tmp, sizeof(tmp), NAME_SSL_VERSION_TLS_V1_1);
+				StrCat(tmp, sizeof(tmp), ",");
+			}
+			if (c->DisableSslVersions & SSL_VERSION_TLS_V1_2) {
+				StrCat(tmp, sizeof(tmp), NAME_SSL_VERSION_TLS_V1_2);
+				StrCat(tmp, sizeof(tmp), ",");
+			}
+                        if (StrLen(tmp) >= 1)
+                        {
+                                if (tmp[StrLen(tmp) - 1] == ',')
+                                {
+                                        tmp[StrLen(tmp) - 1] = 0;
+                                }
+                        }
+			CfgAddStr(f, "DisableSslVersions", tmp);
+		}
+
+		
 
 		// Disable session reconnect
 		CfgAddBool(f, "DisableSessionReconnect", GetGlobalServerFlag(GSF_DISABLE_SESSION_RECONNECT));

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -12966,15 +12966,24 @@ bool StartSSLEx(SOCK *sock, X *x, K *priv, bool client_tls, UINT ssl_timeout, ch
 	{
 		if (sock->ServerMode)
 		{
-			if (sock->AcceptOnlyTls == false)
-			{
-				SSL_CTX_set_ssl_version(ssl_ctx, SSLv23_method());
+			SSL_CTX_set_ssl_version(ssl_ctx, SSLv23_method());
+			long ssl_opt_flags=0x0L;
+			if (sock->DisableSslVersions & SSL_VERSION_SSL_V2) {
+				ssl_opt_flags |= SSL_OP_NO_SSLv2;
 			}
-			else
-			{
-				SSL_CTX_set_ssl_version(ssl_ctx, TLSv1_method());
+			if (sock->DisableSslVersions & SSL_VERSION_SSL_V3) {
+				ssl_opt_flags |= SSL_OP_NO_SSLv3;
 			}
-
+			if (sock->DisableSslVersions & SSL_VERSION_TLS_V1_0) {
+				ssl_opt_flags |= SSL_OP_NO_TLSv1;
+			}
+			if (sock->DisableSslVersions & SSL_VERSION_TLS_V1_1) {
+				ssl_opt_flags |= SSL_OP_NO_TLSv1_1;
+			}
+			if (sock->DisableSslVersions & SSL_VERSION_TLS_V1_2) {
+				ssl_opt_flags |= SSL_OP_NO_TLSv1_2;
+			}
+			SSL_CTX_set_options(ssl_ctx, ssl_opt_flags);
 			Unlock(openssl_lock);
 			AddChainSslCertOnDirectory(ssl_ctx);
 			Lock(openssl_lock);

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -155,6 +155,7 @@
 #ifdef	UNIX_MACOS
 #include <sys/event.h>
 #endif	// UNIX_MACOS
+#include <Cedar/Cedar.h>
 
 #ifdef	OS_WIN32
 NETWORK_WIN32_FUNCTIONS *w32net;

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -313,6 +313,7 @@ struct SOCK
 	UINT Reverse_MyServerPort;		// Self port number when using the reverse socket
 	UCHAR Ssl_Init_Async_SendAlert[2];	// Initial state of SSL send_alert
 	bool AcceptOnlyTls;			// Accept only TLS (disable SSLv3)
+	UINT DisableSslVersions;	// Bitmap of SSL Version to disable
 	bool RawIP_HeaderIncludeFlag;
 
 #ifdef	ENABLE_SSL_LOGGING


### PR DESCRIPTION
Here is a patch to disable a specific SSL/TLS version to be used on server. The AcceptOnlyTls setting had also been changed to use the same mechanism to disable SSL versions 2 and 3.
