### PR TITLE
Support Debian package build on ARMv7l architecture

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,4 +21,5 @@ configure_config:
 	if [ $(shell uname -m) = 'x86_64' ]; then echo "1\n2\n" | ./configure; fi
 	if [ $(shell uname -m) = 'i686' ]; then echo "1\n1\n" | ./configure; fi
 	if [ $(shell uname -m) = 'armv6l' ]; then echo "1\n1\n" | ./configure; fi
+	if [ $(shell uname -m) = 'armv7l' ]; then echo "1\n1\n" | ./configure; fi
 


### PR DESCRIPTION
It now does not build as `debian/rules` does not launch the `configure` script. This should fix that.
