### PR TITLE
Using client parameter in function CtConnect

### DIFF
--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -6661,7 +6661,7 @@ bool CtConnect(CLIENT *c, RPC_CLIENT_CONNECT *connect)
 				CiSetError(c, ERR_ACCOUNT_ACTIVE);
 			}
 			else if (r->ClientAuth->AuthType == CLIENT_AUTHTYPE_SECURE &&
-				client->UseSecureDeviceId == 0)
+				c->UseSecureDeviceId == 0)
 			{
 				// Secure device is not specified
 				CiSetError(c, ERR_NO_SECURE_DEVICE_SPECIFIED);

--- a/src/Cedar/Interop_OpenVPN.c
+++ b/src/Cedar/Interop_OpenVPN.c
@@ -1151,14 +1151,17 @@ UINT OvsParseKeyMethod2(OPENVPN_KEY_METHOD_2 *ret, UCHAR *data, UINT size, bool 
 					// Random2
 					if (ReadBuf(b, ret->Random2, sizeof(ret->Random2)) == sizeof(ret->Random2))
 					{
-						// String
-						if (OvsReadStringFromBuf(b, ret->OptionString, sizeof(ret->OptionString)) &&
-							OvsReadStringFromBuf(b, ret->Username, sizeof(ret->Username)) &&
-							OvsReadStringFromBuf(b, ret->Password, sizeof(ret->Password)) &&
-							OvsReadStringFromBuf(b, ret->PeerInfo, sizeof(ret->PeerInfo)))
-						{
-							read_size = b->Current;
-						}
+                        // String
+                        if (OvsReadStringFromBuf(b, ret->OptionString, sizeof(ret->OptionString)) &&
+                            OvsReadStringFromBuf(b, ret->Username, sizeof(ret->Username)) &&
+                            OvsReadStringFromBuf(b, ret->Password, sizeof(ret->Password)))
+                        {
+                            if (!OvsReadStringFromBuf(b, ret->PeerInfo, sizeof(ret->PeerInfo)))
+                            {
+                                Zero(ret->PeerInfo, sizeof(ret->PeerInfo));
+                            }
+                            read_size = b->Current;
+                        }
 					}
 				}
 			}


### PR DESCRIPTION
Using the global client variable might lead to strange behavoir if multiple clients are allocated and to crashes in the case the client was not initialized with CtStartClient()
