### PR TITLE
Stop Radius Delay from counting to next_resend

### DIFF
--- a/src/Cedar/IPsec_PPP.c
+++ b/src/Cedar/IPsec_PPP.c
@@ -1749,8 +1749,12 @@ PPP_PACKET *PPPRecvResponsePacket(PPP_SESSION *p, PPP_PACKET *req, USHORT expect
 
 			if (pp->IsControl && PPP_CODE_IS_REQUEST(pp->Protocol, pp->Lcp->Code))
 			{
+				// Record current resend because next steps may take a while
+				UINT64 currentresend = next_resend - now;
 				// Process when the received packet is a request packet
 				response = PPPProcessRequestPacket(p, pp);
+				// Increase next resend because this may have taken a while
+				next_resend = Tick64() + currentresend;
 				FreePPPPacket(pp);
 
 				if (response == NULL)


### PR DESCRIPTION
Hi, 

I have found a bug in the IPSec_PPP module, where the packet re-transmission timer is still counting while it is waiting on the radius server. 

This causes the MSCHAP start packet to be sent twice, even after authentication has successfully concluded. As it has moved on to IPCP, when the reply comes in from the client, the session is terminated and the connection fails. Therefore, if the radius AUTH takes longer than 1000ms, SSTP/IPsec (PPP-based protocols) fail.

My solution to this is to backup the timer values when a request is received.

I choose Contribution option (1)

Thanks,
Noah
