### PR TITLE
Add DH groups 2048,3072,4096 to IPSec_IKE

### DIFF
--- a/src/Cedar/IPsec_IkePacket.c
+++ b/src/Cedar/IPsec_IkePacket.c
@@ -2559,7 +2559,7 @@ IKE_ENGINE *NewIkeEngine()
 	IKE_ENGINE *e = ZeroMalloc(sizeof(IKE_ENGINE));
 	IKE_CRYPTO *des, *des3, *aes;
 	IKE_HASH *sha1, *md5;
-	IKE_DH *dh1, *dh2, *dh5;
+	IKE_DH *dh1, *dh2, *dh5, *dh2048, *dh3072, *dh4096;
 	UINT des_key_sizes[] =
 	{
 		8,
@@ -2601,6 +2601,9 @@ IKE_ENGINE *NewIkeEngine()
 	dh1 = NewIkeDh(e, IKE_DH_1_ID, IKE_DH_1_STRING, 96);
 	dh2 = NewIkeDh(e, IKE_DH_2_ID, IKE_DH_2_STRING, 128);
 	dh5 = NewIkeDh(e, IKE_DH_5_ID, IKE_DH_5_STRING, 192);
+	dh2048 = NewIkeDh(e, IKE_DH_2048_ID, IKE_DH_2048_STRING, 256);
+	dh3072 = NewIkeDh(e, IKE_DH_3072_ID, IKE_DH_3072_STRING, 384);
+	dh4096 = NewIkeDh(e, IKE_DH_4096_ID, IKE_DH_4096_STRING, 512);
 
 	// Define the IKE algorithm
 	e->IkeCryptos[IKE_P1_CRYPTO_DES_CBC] = des;
@@ -2620,6 +2623,9 @@ IKE_ENGINE *NewIkeEngine()
 	e->IkeDhs[IKE_P1_DH_GROUP_768_MODP] = e->EspDhs[IKE_P2_DH_GROUP_768_MODP] = dh1;
 	e->IkeDhs[IKE_P1_DH_GROUP_1024_MODP] = e->EspDhs[IKE_P2_DH_GROUP_1024_MODP] = dh2;
 	e->IkeDhs[IKE_P1_DH_GROUP_1536_MODP] = e->EspDhs[IKE_P2_DH_GROUP_1536_MODP] = dh5;
+	e->IkeDhs[IKE_P1_DH_GROUP_2048_MODP] = e->EspDhs[IKE_P2_DH_GROUP_2048_MODP] = dh14;
+	e->IkeDhs[IKE_P1_DH_GROUP_3072_MODP] = e->EspDhs[IKE_P2_DH_GROUP_3072_MODP] = dh15;
+	e->IkeDhs[IKE_P1_DH_GROUP_4096_MODP] = e->EspDhs[IKE_P2_DH_GROUP_4096_MODP] = dh16;
 
 	return e;
 }
@@ -3133,6 +3139,14 @@ DH_CTX *IkeDhNewCtx(IKE_DH *d)
 	case IKE_DH_5_ID:
 		return DhNewGroup5();
 	}
+	case IKE_DH_2048_ID:
+		return DhNew2048();
+
+	case IKE_DH_3072_ID:
+		return DhNew3072();
+
+	case IKE_DH_4096_ID:
+		return DhNew4096();
 
 	return NULL;
 }

--- a/src/Cedar/IPsec_IkePacket.c
+++ b/src/Cedar/IPsec_IkePacket.c
@@ -2623,9 +2623,9 @@ IKE_ENGINE *NewIkeEngine()
 	e->IkeDhs[IKE_P1_DH_GROUP_768_MODP] = e->EspDhs[IKE_P2_DH_GROUP_768_MODP] = dh1;
 	e->IkeDhs[IKE_P1_DH_GROUP_1024_MODP] = e->EspDhs[IKE_P2_DH_GROUP_1024_MODP] = dh2;
 	e->IkeDhs[IKE_P1_DH_GROUP_1536_MODP] = e->EspDhs[IKE_P2_DH_GROUP_1536_MODP] = dh5;
-	e->IkeDhs[IKE_P1_DH_GROUP_2048_MODP] = e->EspDhs[IKE_P2_DH_GROUP_2048_MODP] = dh14;
-	e->IkeDhs[IKE_P1_DH_GROUP_3072_MODP] = e->EspDhs[IKE_P2_DH_GROUP_3072_MODP] = dh15;
-	e->IkeDhs[IKE_P1_DH_GROUP_4096_MODP] = e->EspDhs[IKE_P2_DH_GROUP_4096_MODP] = dh16;
+	e->IkeDhs[IKE_P1_DH_GROUP_2048_MODP] = e->EspDhs[IKE_P2_DH_GROUP_2048_MODP] = dh2048;
+	e->IkeDhs[IKE_P1_DH_GROUP_3072_MODP] = e->EspDhs[IKE_P2_DH_GROUP_3072_MODP] = dh3072;
+	e->IkeDhs[IKE_P1_DH_GROUP_4096_MODP] = e->EspDhs[IKE_P2_DH_GROUP_4096_MODP] = dh4096;
 
 	return e;
 }
@@ -3138,7 +3138,7 @@ DH_CTX *IkeDhNewCtx(IKE_DH *d)
 
 	case IKE_DH_5_ID:
 		return DhNewGroup5();
-	}
+
 	case IKE_DH_2048_ID:
 		return DhNew2048();
 
@@ -3147,6 +3147,7 @@ DH_CTX *IkeDhNewCtx(IKE_DH *d)
 
 	case IKE_DH_4096_ID:
 		return DhNew4096();
+	}
 
 	return NULL;
 }

--- a/src/Cedar/IPsec_IkePacket.h
+++ b/src/Cedar/IPsec_IkePacket.h
@@ -259,6 +259,9 @@ struct IKE_TRANSFORM_VALUE
 #define IKE_P1_DH_GROUP_768_MODP			1
 #define IKE_P1_DH_GROUP_1024_MODP			2
 #define IKE_P1_DH_GROUP_1536_MODP			5
+#define IKE_P1_DH_GROUP_2048_MODP			14
+#define IKE_P1_DH_GROUP_3072_MODP			15
+#define IKE_P1_DH_GROUP_4096_MODP			16
 
 // Phase 1: The expiration date type in IKE transform value
 #define IKE_P1_LIFE_TYPE_SECONDS			1
@@ -272,6 +275,9 @@ struct IKE_TRANSFORM_VALUE
 #define IKE_P2_DH_GROUP_768_MODP			1
 #define IKE_P2_DH_GROUP_1024_MODP			2
 #define IKE_P2_DH_GROUP_1536_MODP			5
+#define IKE_P2_DH_GROUP_2048_MODP			14
+#define IKE_P2_DH_GROUP_3072_MODP			15
+#define IKE_P2_DH_GROUP_4096_MODP			16
 
 // Phase 2: The encapsulation mode in IPsec transform value
 #define IKE_P2_CAPSULE_TUNNEL				1
@@ -539,6 +545,15 @@ struct IKE_P1_KEYSET
 
 #define	IKE_DH_5_ID								2
 #define	IKE_DH_5_STRING							"MODP 1536 (Group 5)"
+
+#define IKE_DH_2048_ID							14
+#define IKE_DH_2048_STRING						"MODP 2048 (Group 14)"
+
+#define IKE_DH_3072_ID							15
+#define IKE_DH_3072_STRING						"MODP 3072 (Group 15)"
+
+#define IKE_DH_4096_ID							16
+#define IKE_DH_4096_STRING						"MODP 4096 (Group 16)"
 
 
 // Encryption algorithm for IKE


### PR DESCRIPTION
Added definition for the DH groups 2048,3072,4096.
This is necessary to implement IPSec tunneling as well as IKEv2
I used the names: group2048 instead of group14 amd analog for other names. The same has been done by dnobori in commit 4df2eb4f