### PR TITLE
Fixed RSA key bits wrong calculation for certain x509 certificate

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -4011,14 +4011,22 @@ X *X509ToX(X509 *x509)
 	type = k->pkey->type;
 
 	FreeBuf(b);
-
+	
+	//Fixed to get actual RSA key bits
+	x->bits = EVP_PKEY_bits(k->pkey);
+	
 	FreeK(k);
 
 	if (type == EVP_PKEY_RSA)
 	{
 		x->is_compatible_bit = true;
 
-		switch (size)
+		if(x->bits != 1024 && x->bits != 1536 && x->bits != 2048 && x->bits != 3072 && x->bits != 4096)
+			x->is_compatible_bit = false;
+		else
+			x->is_compatible_bit = true;
+		
+		/*switch (size)
 		{
 		case 162:
 			x->bits = 1024;
@@ -4043,7 +4051,7 @@ X *X509ToX(X509 *x509)
 		default:
 			x->is_compatible_bit = false;
 			break;
-		}
+		}*/
 	}
 
 	return x;


### PR DESCRIPTION
I try to import few Trusted CA certificates and some of it gave error. After i'm go through the code and found wrong calculation RSA bits in file Mayaqua/encrypt.c in function X *X509ToX(X509 *x509). This patch I'm already make little changes to solved it. Below sample Trusted certificate have result error for u to test. This certificate own by one of the trusted CA in our country. Hope the patch can help other people have same issue with me.

-----BEGIN CERTIFICATE-----
MIIFWDCCBECgAwIBAgIBBDANBgkqhkiG9w0BAQsFADB/MQswCQYDVQQGEwJteTEL
MAkGA1UECgwCVE0xNDAyBgNVBAsMK1RNIEFwcGxpZWQgQnVzaW5lc3MgQ2VydGlm
aWNhdGlvbiBBdXRob3JpdHkxLTArBgNVBAMMJFRNIEFwcGxpZWQgQnVzaW5lc3Mg
Um9vdCBDZXJ0aWZpY2F0ZTAeFw0xMTEwMTAwODEzMjdaFw0zMDEwMTAwODQzMjda
MF8xCzAJBgNVBAYTAm15MQswCQYDVQQKDAJUTTENMAsGA1UECwwEVE1DQTE0MDIG
A1UEAwwrVE0gQXBwbGllZCBCdXNpbmVzcyBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0
eTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAJKH3uHUl7yCjQArG6bg
EzA02td0bf304ZRWu0QMfgID6EeHCItvryJzZwUcqj5CW9LlGW2XeuEv/GNGXfAn
8CNQm7kGksUJj91PgfIA7L9pi6MhaWjvtexkcB/5/0b8G0TF6h7RdBZd1jOrcXKB
+L918GXUwTABQMxzK2Qtsbq+w5l2BsHvmO2BhEtegyGmRK67FFMbIJx+G7ES9F7w
Ez7rFsSnsjvrzWZUKZOpeFkvIakjb92zcg5LqrUPSPJbSWEwNWK4xQOgWcYOizw4
T99sFGLJ9kVMSrXs5NwMiIZ45x4I/VU4zh0gmt+AQD4NUB6NqjG7D7yyO0eI4oFW
xU8CAQOjggH/MIIB+zCBqwYDVR0jBIGjMIGggBRAGvu0ljeWg98sOxTtHMbL3iBt
CKGBhKSBgTB/MQswCQYDVQQGEwJteTELMAkGA1UECgwCVE0xNDAyBgNVBAsMK1RN
IEFwcGxpZWQgQnVzaW5lc3MgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxLTArBgNV
BAMMJFRNIEFwcGxpZWQgQnVzaW5lc3MgUm9vdCBDZXJ0aWZpY2F0ZYIBATAdBgNV
HQ4EFgQUgCgsGxY+LDACoROmeErBgCQzSbIwCwYDVR0PBAQDAgHGMIGGBgNVHSAE
fzB9MHsGBFUdIAAwczBFBggrBgEFBQcCAjA5GjdUTSBBcHBsaWVkIEJ1c2luZXNz
IENlcnRpZmljYXRpb24gQXV0aG9yaXR5IENlcnRpZmljYXRlMCoGCCsGAQUFBwIB
Fh5odHRwOi8vd3d3LnRtY2EuY29tLm15L2Nwcy5odG0wDwYDVR0TAQH/BAUwAwEB
/zAMBgNVHSQEBTADgAEAMHcGA1UdHwRwMG4wbKBqoGiGZmxkYXA6Ly9sZGFwLnRt
Y2EuY29tLm15OjM4OS9jbj1hcmwxZHAxLG91PUFSTCxvdT1UTSBBcHBsaWVkIEJ1
c2luZXNzIENlcnRpZmljYXRpb24gQXV0aG9yaXR5LG89VE0sYz1teTANBgkqhkiG
9w0BAQsFAAOCAQEAKsGPcNE09e7xhT2/sk6mZbeVMUYpKcrWrj6lbkXTIJH6lmf4
8ZLNE3VjcsL9IT0gbiNDpvqDeAzEGxDd5KAYGy1c8pS2Wgwy5ww1l3n6khd2ZpeB
0OyVQFK3MAf5HcqAz0DyqjQOOIxhGTOmY88z6x3IMUcu9otI75oCtq/tj7hTIChU
OO5LWnNBmelAIJIdH15p1amL640vtjmv6TWkfu9/kVWmrZARppgjKYzGvMlmlkEV
+qByj/yNRc/o0y0O72fuv2sXhTuQ+B53d51O6tyGC6bySEZTqa7l1VAHdTh6QFM/
HJLlNa8VYDQ+hVNECSoU2lJf662qH0DPMvjeYA==
-----END CERTIFICATE-----