### PR TITLE
Using client parameter in function CtConnect

### DIFF
--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -6663,7 +6663,7 @@ bool CtConnect(CLIENT *c, RPC_CLIENT_CONNECT *connect)
 				CiSetError(c, ERR_ACCOUNT_ACTIVE);
 			}
 			else if (r->ClientAuth->AuthType == CLIENT_AUTHTYPE_SECURE &&
-				client->UseSecureDeviceId == 0)
+				c->UseSecureDeviceId == 0)
 			{
 				// Secure device is not specified
 				CiSetError(c, ERR_NO_SECURE_DEVICE_SPECIFIED);


### PR DESCRIPTION
Changes proposed in this pull request:
 - Using the pointer to the client that is passed by the function parameter and not the global client pointer to avoid problems if the global pointer is not used.

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- I choose option 1
