### PR TITLE
Initial Commit of gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ cmake-build-debug/
 src/bin/BuiltHamcoreFiles/
 tmp/
 
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.cproject
+.project
+.settings/
+CMakeLists.txt
+Makefile
+bin/
+cmake-build-debug/
+src/bin/BuiltHamcoreFiles/
+tmp/
+
+


### PR DESCRIPTION
Changes proposed in this pull request:
 - Adds initial .gitignore file
 - This files ignores known files by different IDEs like eclipse and intellij as well as files generated by SE Compilation like tmp/ and hamcore files
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- Option 1
