### PR TITLE
travis-ci: enable ccache for build speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ language: c
 
 compiler: [ gcc, clang ]
 
+cache:
+  ccache: true
+
+before_script:
+  - mkdir -p "${HOME}/bin"
+  - ln -s "$(which ccache)" "${HOME}/bin/${CC}"
+  - PATH="${HOME}/bin:${PATH}"
+
 script:
   - ./configure
   - make


### PR DESCRIPTION
Changes proposed in this pull request:
 - 
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

-

option 1
