### PR TITLE
Fixes 11 vulnerabilities found by Max Planck Institute for Molecular Genetics and Mr. Guido Vranken

### DIFF
--- a/AUTHORS.TXT
+++ b/AUTHORS.TXT
@@ -145,6 +145,10 @@ CONTRIBUTORS on GitHub:
   - macvk
     https://github.com/macvk
 
+  - Guido Vranken
+    https://github.com/guidovranken
+
+
 JOIN THE SOFTETHER VPN DEVELOPMENT
 ----------------------------------
 

--- a/src/Cedar/IPsec_L2TP.c
+++ b/src/Cedar/IPsec_L2TP.c
@@ -792,6 +792,12 @@ L2TP_PACKET *ParseL2TPPacket(UDPPACKET *p)
 			size -= 2;
 
 			a.DataSize = a.Length - 6;
+
+			if (a.DataSize > size)
+			{
+				goto LABEL_ERROR;
+			}
+
 			a.Data = Clone(buf, a.DataSize);
 
 			buf += a.DataSize;

--- a/src/Cedar/IPsec_PPP.c
+++ b/src/Cedar/IPsec_PPP.c
@@ -291,7 +291,7 @@ void PPPThread(THREAD *thread, void *param)
 						ReadBuf(b, client_response_buffer, 49);
 
 						Zero(username_tmp, sizeof(username_tmp));
-						ReadBuf(b, username_tmp, sizeof(username_tmp));
+						ReadBuf(b, username_tmp, sizeof(username_tmp) - 1);
 
 						Debug("First MS-CHAPv2: id=%s\n", username_tmp);
 
@@ -977,7 +977,7 @@ PPP_PACKET *PPPProcessRequestPacket(PPP_SESSION *p, PPP_PACKET *req)
 					ReadBuf(b, client_response_buffer, 49);
 
 					Zero(username_tmp, sizeof(username_tmp));
-					ReadBuf(b, username_tmp, sizeof(username_tmp));
+					ReadBuf(b, username_tmp, sizeof(username_tmp) - 1);
 
 					client_challenge_16 = client_response_buffer + 0;
 					client_response_24 = client_response_buffer + 16 + 8;

--- a/src/Cedar/Interop_OpenVPN.c
+++ b/src/Cedar/Interop_OpenVPN.c
@@ -2845,7 +2845,7 @@ bool OvsPerformTcpServer(CEDAR *cedar, SOCK *sock)
 			{
 				void *ptr = FifoPtr(tcp_recv_fifo);
 				USHORT packet_size = READ_USHORT(ptr);
-				if (packet_size <= OPENVPN_TCP_MAX_PACKET_SIZE)
+				if (packet_size != 0 && packet_size <= OPENVPN_TCP_MAX_PACKET_SIZE)
 				{
 					UINT total_len = (UINT)packet_size + sizeof(USHORT);
 					if (r >= total_len)

--- a/src/Cedar/Radius.c
+++ b/src/Cedar/Radius.c
@@ -1827,6 +1827,13 @@ bool RadiusLogin(CONNECTION *c, char *server, UINT port, UCHAR *secret, UINT sec
 		if (encrypted_password == NULL)
 		{
 			// Encryption failure
+
+			// Release the ip_list
+			for(i = 0; i < LIST_NUM(ip_list); i++)
+			{
+				IP *tmp_ip = LIST_DATA(ip_list, i);
+				Free(tmp_ip);
+			}
 			ReleaseList(ip_list);
 			return false;
 		}

--- a/src/Cedar/Virtual.c
+++ b/src/Cedar/Virtual.c
@@ -2250,6 +2250,7 @@ BUF *NnReadDnsRecord(BUF *buf, bool answer, USHORT *ret_type, USHORT *ret_class)
 		data = Malloc(data_len);
 		if (ReadBuf(buf, data, data_len) != data_len)
 		{
+			Free(data);
 			return false;
 		}
 

--- a/src/Mayaqua/Memory.c
+++ b/src/Mayaqua/Memory.c
@@ -4313,6 +4313,21 @@ void Copy(void *dst, void *src, UINT size)
 	memcpy(dst, src, size);
 }
 
+// Memory move
+void Move(void *dst, void *src, UINT size)
+{
+	// Validate arguments
+	if (dst == NULL || src == NULL || size == 0 || dst == src)
+	{
+		return;
+	}
+
+	// KS
+	KS_INC(KS_COPY_COUNT);
+
+	memmove(dst, src, size);
+}
+
 // Memory comparison
 int Cmp(void *p1, void *p2, UINT size)
 {

--- a/src/Mayaqua/Memory.h
+++ b/src/Mayaqua/Memory.h
@@ -284,6 +284,7 @@ void *InternalReAlloc(void *addr, UINT size);
 void InternalFree(void *addr);
 
 void Copy(void *dst, void *src, UINT size);
+void Move(void *dst, void *src, UINT size);
 int Cmp(void *p1, void *p2, UINT size);
 int CmpCaseIgnore(void *p1, void *p2, UINT size);
 void ZeroMem(void *addr, UINT size);

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -7373,7 +7373,7 @@ bool StrToIP6(IP *ip, char *str)
 	if (StartWith(tmp, "[") && EndWith(tmp, "]"))
 	{
 		// If the string is enclosed in square brackets, remove brackets
-		StrCpy(tmp, sizeof(tmp), &tmp[1]);
+		StrCpyAllowOverlap(tmp, sizeof(tmp), &tmp[1]);
 
 		if (StrLen(tmp) >= 1)
 		{
@@ -12691,6 +12691,14 @@ bool RecvAll(SOCK *sock, void *data, UINT size, bool secure)
 		{
 			return false;
 		}
+		if (ret == SOCK_LATER)
+		{
+			// I suppose that this is safe because the RecvAll() function is used only 
+			// if the sock->AsyncMode == true. And the Recv() function may return
+			// SOCK_LATER only if the sock->AsyncMode == false. Therefore the call of 
+			// Recv() function in the RecvAll() function never returns SOCK_LATER.
+			return false;
+		}
 		recv_size += ret;
 		if (recv_size >= size)
 		{
@@ -17597,7 +17605,7 @@ void IPToInAddr6(struct in6_addr *addr, IP *ip)
 		return;
 	}
 
-	Zero(addr, sizeof(struct in_addr));
+	Zero(addr, sizeof(struct in6_addr));
 
 	if (IsIP6(ip))
 	{

--- a/src/Mayaqua/Pack.c
+++ b/src/Mayaqua/Pack.c
@@ -354,7 +354,7 @@ VALUE *ReadValue(BUF *b, UINT type)
 		break;
 	case VALUE_STR:			// ANSI string
 		len = ReadBufInt(b);
-		if ((len + 1) > MAX_VALUE_SIZE)
+		if (len > (MAX_VALUE_SIZE - 1))
 		{
 			// Size over
 			break;

--- a/src/Mayaqua/Str.c
+++ b/src/Mayaqua/Str.c
@@ -3346,6 +3346,54 @@ UINT StrCpy(char *dst, UINT size, char *src)
 
 	return len;
 }
+UINT StrCpyAllowOverlap(char *dst, UINT size, char *src)
+{
+	UINT len;
+	// Validate arguments
+	if (dst == src)
+	{
+		return StrLen(src);
+	}
+	if (dst == NULL || src == NULL)
+	{
+		if (src == NULL && dst != NULL)
+		{
+			if (size >= 1)
+			{
+				dst[0] = '\0';
+			}
+		}
+		return 0;
+	}
+	if (size == 1)
+	{
+		dst[0] = '\0';
+		return 0;
+	}
+	if (size == 0)
+	{
+		// Ignore the length
+		size = 0x7fffffff;
+	}
+
+	// Check the length
+	len = StrLen(src);
+	if (len <= (size - 1))
+	{
+		Move(dst, src, len + 1);
+	}
+	else
+	{
+		len = size - 1;
+		Move(dst, src, len);
+		dst[len] = '\0';
+	}
+
+	// KS
+	KS_INC(KS_STRCPY_COUNT);
+
+	return len;
+}
 
 // Check whether the string buffer is within the specified size
 bool StrCheckSize(char *str, UINT size)

--- a/src/Mayaqua/Str.h
+++ b/src/Mayaqua/Str.h
@@ -135,6 +135,7 @@ UINT StrSize(char *str);
 bool StrCheckLen(char *str, UINT len);
 bool StrCheckSize(char *str, UINT size);
 UINT StrCpy(char *dst, UINT size, char *src);
+UINT StrCpyAllowOverlap(char *dst, UINT size, char *src);
 UINT StrCat(char *dst, UINT size, char *src);
 UINT StrCatLeft(char *dst, UINT size, char *src);
 char ToLower(char c);

--- a/src/bin/hamcore/authors.txt
+++ b/src/bin/hamcore/authors.txt
@@ -139,6 +139,16 @@ CONTRIBUTORS on GitHub:
   - Guanzhong Chen
     https://github.com/quantum5
 
+  - Nguyen Hong Quan
+    https://github.com/hongquan
+
+  - macvk
+    https://github.com/macvk
+
+  - Guido Vranken
+    https://github.com/guidovranken
+
+
 JOIN THE SOFTETHER VPN DEVELOPMENT
 ----------------------------------
 


### PR DESCRIPTION
There are 11 vulnerabilities on SoftEther VPN. There vulnerabilities are found by the source code audit process conducted by Max Planck Institute for Molecular Genetics and Mr. Guido Vranken in late 2017. This patch fixes all of these vulnerabilities.

7 missing memory boundaries checks and similar memory problems. There are no risk of arbitrary code execution or intrusion on these bugs in my analysis. However, these problems may lead to crash the running server process. So these bugs must be fixed.

- Buffer overread in ParseL2TPPacket()
- Memory corruption in IcmpParseResult
- Missing bounds check in ParseUDP() can lead to invalid memory access
- Out-of-bounds read in IPsec_PPP.c (unterminated string buffer)
- Overlapping parameters to memcpy() via StrToIp6()
- PACK ReadValue() crash vulnerability
- Potential use of uninitialized memory via IPToInAddr6()

4 memory leaks. While the amount of leakage is very small per time, these bugs can finally cause process crash by out of memory. So these bugs must be fixed.

- Memory leak in NnReadDnsRecord
- Memory leak in RadiusLogin()
- Memory leak via ParsePacketIPv4WithDummyMacHeader
- Remote memory leak in OpenVPN server code

1 coding improvement. This is not a bug, however, I fixed the code to avoid furture misunderstanding.

- RecvAll can return success on failure (leading to use of uninitialized memory)

Contributors for this bugfix:
- Max Planck Institute for Molecular Genetics
- Mr. Guido Vranken