### PR TITLE
Use correct sizeof value

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -1618,7 +1618,7 @@ UINT StGetHubMsg(ADMIN *a, RPC_MSG *t)
 	else
 	{
 		FreeRpcMsg(t);
-		Zero(t, sizeof(t));
+		Zero(t, sizeof(RPC_MSG));
 
 		t->Msg = GetHubMsg(h);
 
@@ -6303,7 +6303,7 @@ UINT StGetLink(ADMIN *a, RPC_CREATE_LINK *t)
 
 	StrCpy(hubname, sizeof(hubname), t->HubName);
 	FreeRpcCreateLink(t);
-	Zero(t, sizeof(t));
+	Zero(t, sizeof(RPC_CREATE_LINK));
 	StrCpy(t->HubName, sizeof(t->HubName), hubname);
 
 	Lock(k->lock);
@@ -7749,7 +7749,7 @@ UINT StGetHubRadius(ADMIN *a, RPC_RADIUS *t)
 		return ERR_HUB_NOT_FOUND;
 	}
 
-	Zero(t, sizeof(t));
+	Zero(t, sizeof(RPC_RADIUS));
 	//GetRadiusServer(h, t->RadiusServerName, sizeof(t->RadiusServerName),
 	//	&t->RadiusPort, t->RadiusSecret, sizeof(t->RadiusSecret));
 	GetRadiusServerEx(h, t->RadiusServerName, sizeof(t->RadiusServerName),

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -1359,7 +1359,7 @@ void GetServerCaps(SERVER *s, CAPSLIST *t)
 			GetServerCapsMain(s, s->CapsListCache);
 		}
 
-		Copy(t, s->CapsListCache, sizeof(s->CapsListCache));
+		Copy(t, s->CapsListCache, sizeof(CAPSLIST));
 	}
 	Unlock(s->CapsCacheLock);
 }


### PR DESCRIPTION
Because `sizeof(t) == sizeof(void *)` and Zero() clears only first 4/8 bytes of struct.
