### PR TITLE
Solaris: use DLPI style 1 attachment and check for /dev/net used by Illumos and Solaris 10+.

### DIFF
--- a/src/Cedar/BridgeUnix.h
+++ b/src/Cedar/BridgeUnix.h
@@ -201,7 +201,7 @@ ETH *OpenEth(char *name, bool local, bool tapmode, char *tapaddr);
 ETH *OpenEthLinux(char *name, bool local, bool tapmode, char *tapaddr);
 ETH *OpenEthSolaris(char *name, bool local, bool tapmode, char *tapaddr);
 ETH *OpenEthPcap(char *name, bool local, bool tapmode, char *tapaddr);
-bool ParseUnixEthDeviceName(char *dst_devname, UINT dst_devname_size, UINT *dst_devid, char *src_name);
+bool ParseUnixEthDeviceName(char *dst_devname, UINT dst_devname_size, char *src_name);
 void CloseEth(ETH *e);
 CANCEL *EthGetCancel(ETH *e);
 UINT EthGetPacket(ETH *e, void **data);


### PR DESCRIPTION

Changes proposed in this pull request:
 - Switch from DLPI style 2 to DLPI style 1 attachment, based on opening network device (/dev/bge0) rather than root device (/dev/bge)
 - Prefer devices located in /dev/net, if present, which is used by Illumos and Solaris 10+
 - Should allow SoftEther to work properly with vanity nics and Crossbow vnics present on Solaris 10+ and Illumos while retaining compatibility with older Solaris versions (provided that network interface has its own device node).

You may use this patch as necessary (contribution option 1).