### PR TITLE
Changed OpenSSL package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ from GitHub. You may make your own fork project from our project.
 - libncurses-dev
 - libreadline-dev
 - make
-- openssl-dev
+- libssl-dev
 
 ### 2. Redhat/CentOS
 - gcc


### PR DESCRIPTION
Changes proposed in this pull request:
 - Corrected package name for OpenSSL dependency

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

Option 1
-
