### PR TITLE
Fix systemd scripts to match new installation directory.

### DIFF
--- a/systemd/softether-vpnbridge.service
+++ b/systemd/softether-vpnbridge.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=SoftEther VPN Bridge
 After=network.target auditd.service
-ConditionPathExists=!/opt/vpnbridge/do_not_run
+ConditionPathExists=!/usr/vpnbridge/do_not_run
 
 [Service]
 Type=forking
-ExecStart=/opt/vpnbridge/vpnbridge start
-ExecStop=/opt/vpnbridge/vpnbridge stop
+ExecStart=/usr/vpnbridge/vpnbridge start
+ExecStop=/usr/vpnbridge/vpnbridge stop
 KillMode=process
 Restart=on-failure
 
@@ -15,7 +15,7 @@ PrivateTmp=yes
 ProtectHome=yes
 ProtectSystem=full
 ReadOnlyDirectories=/
-ReadWriteDirectories=-/opt/vpnbridge
+ReadWriteDirectories=-/usr/vpnbridge
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SYS_NICE CAP_SYS_ADMIN CAP_SETUID
 
 [Install]

--- a/systemd/softether-vpnclient.service
+++ b/systemd/softether-vpnclient.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=SoftEther VPN Client
 After=network.target auditd.service
-ConditionPathExists=!/opt/vpnclient/do_not_run
+ConditionPathExists=!/usr/vpnclient/do_not_run
 
 [Service]
 Type=forking
-EnvironmentFile=-/opt/vpnclient
-ExecStart=/opt/vpnclient/vpnclient start
-ExecStop=/opt/vpnclient/vpnclient stop
+EnvironmentFile=-/usr/vpnclient
+ExecStart=/usr/vpnclient/vpnclient start
+ExecStop=/usr/vpnclient/vpnclient stop
 KillMode=process
 Restart=on-failure
 
@@ -16,7 +16,7 @@ PrivateTmp=yes
 ProtectHome=yes
 ProtectSystem=full
 ReadOnlyDirectories=/
-ReadWriteDirectories=-/opt/vpnclient
+ReadWriteDirectories=-/usr/vpnclient
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SYS_NICE CAP_SYS_ADMIN CAP_SETUID
 
 [Install]

--- a/systemd/softether-vpnserver.service
+++ b/systemd/softether-vpnserver.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=SoftEther VPN Server
 After=network.target auditd.service
-ConditionPathExists=!/opt/vpnserver/do_not_run
+ConditionPathExists=!/usr/vpnserver/do_not_run
 
 [Service]
 Type=forking
-EnvironmentFile=-/opt/vpnserver
-ExecStart=/opt/vpnserver/vpnserver start
-ExecStop=/opt/vpnserver/vpnserver stop
+EnvironmentFile=-/usr/vpnserver
+ExecStart=/usr/vpnserver/vpnserver start
+ExecStop=/usr/vpnserver/vpnserver stop
 KillMode=process
 Restart=on-failure
 
@@ -16,7 +16,7 @@ PrivateTmp=yes
 ProtectHome=yes
 ProtectSystem=full
 ReadOnlyDirectories=/
-ReadWriteDirectories=-/opt/vpnserver
+ReadWriteDirectories=-/usr/vpnserver
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SYS_NICE CAP_SYS_ADMIN CAP_SETUID
 
 [Install]


### PR DESCRIPTION
Change the directory called in the vpnbridge, vpnclient, and vpnserver service scripts.
The old scripts called the files in the /opt directory, however we install to the /usr directory.
This was preventing the systemd scripts from functioning correctly.

This patch may be applied as per option 1.
