### PR TITLE
travis-ci: add "dh build-arch" step, fix debian packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 sudo: required
 dist: trusty
-os: linux
-language: c
-compiler:
-- gcc
-- clang
-script:
-- "./configure"
-- make
 
+os: linux
+
+addons:
+  apt:
+    packages: [ debhelper ]
+
+language: c
+
+compiler: [ gcc, clang ]
+
+script:
+  - ./configure
+  - make
+  - dh build-arch

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: softether-vpn
 Section: net
 Priority: optional
 Maintainer: Dmitry Orlov <me@mosquito.su>
-Build-Depends: debhelper (>= 7.0.50~), libncurses-dev, linux-libc-dev, libssl-dev, libreadline-dev, build-essential, dh-exec
+Build-Depends: debhelper (>= 7.0.50~), libncurses5-dev, linux-libc-dev, libssl-dev, zlib1g-dev, libreadline-dev, build-essential, dh-exec
 Standards-Version: 3.9.1
 Homepage: http://www.softether.org/
 


### PR DESCRIPTION
debian: fix dependencies

Changes proposed in this pull request:
 - it should fix armh build failures reported by @paskal


Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- 1
