### PR TITLE
OpenVPN: hostname support

### DIFF
--- a/src/Cedar/Interop_OpenVPN.c
+++ b/src/Cedar/Interop_OpenVPN.c
@@ -710,7 +710,7 @@ void OvsBeginIPCAsyncConnectionIfEmpty(OPENVPN_SERVER *s, OPENVPN_SESSION *se, O
 		pi = OvsParsePeerInfo(c->ClientKey.PeerInfo);
 
 		// Check presence of custom hostname
-		if (OvsHasOption(pi, "UV_HOSTNAME"))
+		if (OvsHasEntry(pi, "UV_HOSTNAME"))
 		{
 			StrCpy(p.ClientHostname, sizeof(p.ClientHostname), IniStrValue(pi, "UV_HOSTNAME"));
 		}
@@ -719,7 +719,7 @@ void OvsBeginIPCAsyncConnectionIfEmpty(OPENVPN_SERVER *s, OPENVPN_SESSION *se, O
 			StrCpy(p.ClientHostname, sizeof(p.ClientHostname), IniStrValue(pi, "IV_HWADDR"));
 		}
 
-		OvsFreeOptions(pi);
+		OvsFreeList(pi);
 
 		if (se->Mode == OPENVPN_MODE_L3)
 		{
@@ -932,7 +932,7 @@ void OvsSetupSessionParameters(OPENVPN_SERVER *s, OPENVPN_SESSION *se, OPENVPN_C
 	SetMdKey(c->MdRecv, c->ExpansionKey + 64, c->MdRecv->Size);
 	SetMdKey(c->MdSend, c->ExpansionKey + 192, c->MdSend->Size);
 
-	OvsFreeOptions(o);
+	OvsFreeList(o);
 
 	// Generate the response option string
 	Format(c->ServerKey.OptionString, sizeof(c->ServerKey.OptionString),
@@ -1055,7 +1055,7 @@ LIST *OvsParsePeerInfo(char *str)
 }
 
 // Release the option list
-void OvsFreeOptions(LIST *o)
+void OvsFreeList(LIST *o)
 {
 	// Validate arguments
 	if (o == NULL)
@@ -1067,13 +1067,13 @@ void OvsFreeOptions(LIST *o)
 }
 
 // Create an Option List
-LIST *OvsNewOptions()
+LIST *OvsNewList()
 {
 	return NewListFast(NULL);
 }
 
 // Add a value to the option list
-void OvsAddOption(LIST *o, char *key, char *value)
+void OvsAddEntry(LIST *o, char *key, char *value)
 {
 	INI_ENTRY *e;
 	// Validate arguments
@@ -1105,7 +1105,7 @@ void OvsAddOption(LIST *o, char *key, char *value)
 }
 
 // Confirm whether there is specified option key string
-bool OvsHasOption(LIST *o, char *key)
+bool OvsHasEntry(LIST *o, char *key)
 {
 	// Validate arguments
 	if (o == NULL || key == NULL)

--- a/src/Cedar/Interop_OpenVPN.h
+++ b/src/Cedar/Interop_OpenVPN.h
@@ -363,10 +363,10 @@ void OvsWriteStringToBuf(BUF *b, char *str, UINT max_size);
 
 LIST *OvsParseOptions(char *str);
 LIST *OvsParsePeerInfo(char *str);
-void OvsFreeOptions(LIST *o);
-LIST *OvsNewOptions();
-void OvsAddOption(LIST *o, char *key, char *value);
-bool OvsHasOption(LIST *o, char *key);
+void OvsFreeList(LIST *o);
+LIST *OvsNewList();
+void OvsAddEntry(LIST *o, char *key, char *value);
+bool OvsHasEntry(LIST *o, char *key);
 UINT OvsPeekStringFromFifo(FIFO *f, char *str, UINT str_size);
 void OvsBeginIPCAsyncConnectionIfEmpty(OPENVPN_SERVER *s, OPENVPN_SESSION *se, OPENVPN_CHANNEL *c);
 bool OvsIsCompatibleL3IP(UINT ip);

--- a/src/Cedar/Interop_OpenVPN.h
+++ b/src/Cedar/Interop_OpenVPN.h
@@ -190,6 +190,10 @@
 #define	OPENVPN_MODE_L2							1		// TAP (Ethernet)
 #define	OPENVPN_MODE_L3							2		// TUN (IP)
 
+// Data
+#define OPENVPN_DATA_OPTIONS	0
+#define OPENVPN_DATA_PEERINFO	1
+
 
 //// Type
 
@@ -361,8 +365,7 @@ void OvsSetupSessionParameters(OPENVPN_SERVER *s, OPENVPN_SESSION *se, OPENVPN_C
 BUF *OvsBuildKeyMethod2(OPENVPN_KEY_METHOD_2 *d);
 void OvsWriteStringToBuf(BUF *b, char *str, UINT max_size);
 
-LIST *OvsParseOptions(char *str);
-LIST *OvsParsePeerInfo(char *str);
+LIST *OvsParseData(char *str, int type);
 void OvsFreeList(LIST *o);
 LIST *OvsNewList();
 void OvsAddEntry(LIST *o, char *key, char *value);

--- a/src/Cedar/Interop_OpenVPN.h
+++ b/src/Cedar/Interop_OpenVPN.h
@@ -362,6 +362,7 @@ BUF *OvsBuildKeyMethod2(OPENVPN_KEY_METHOD_2 *d);
 void OvsWriteStringToBuf(BUF *b, char *str, UINT max_size);
 
 LIST *OvsParseOptions(char *str);
+LIST *OvsParsePeerInfo(char *str);
 void OvsFreeOptions(LIST *o);
 LIST *OvsNewOptions();
 void OvsAddOption(LIST *o, char *key, char *value);

--- a/src/bin/hamcore/openvpn_sample.ovpn
+++ b/src/bin/hamcore/openvpn_sample.ovpn
@@ -20,6 +20,28 @@
 
 
 ###############################################################################
+# Custom hostname setting.
+#
+# Uncomment the line and replace "Hostname" with your desired string, if you
+# want the server to use a specific hostname instead of the default gateway's
+# hardware address.
+
+;setenv UV_HOSTNAME Hostname
+
+
+###############################################################################
+# Push extra info about the client to the server.
+#
+# The server currently uses:
+#  IV_HWADDR = Default gateway's MAC Address
+#  UV_HOSTNAME = Custom hostname
+#
+# They are required in order to set an hostname for the client.
+
+push-peer-info
+
+
+###############################################################################
 # Specify the type of the layer of the VPN connection.
 # 
 # To connect to the VPN Server as a "Remote-Access VPN Client PC",


### PR DESCRIPTION
OpenVPN sends the default gateway's MAC address, if the option **--push-peer-info** is enabled.
It also sends the client's environment variables whose names start with `UV_`.

From OpenVPN's [documentation](https://community.openvpn.net/openvpn/wiki/Openvpn23ManPage):

```
Push additional information about the client to server. The following data is always pushed to the server:
IV_VER=<version> -- the client OpenVPN version

IV_PLAT=[linux|solaris|openbsd|mac|netbsd|freebsd|win] -- the client OS platform

IV_LZO_STUB=1 -- if client was built with LZO stub capability

IV_LZ4=1 -- if the client supports LZ4 compressions.

IV_RGI6=1 -- if the client supports --redirect-gateway for ipv6

IV_PROTO=2 -- if the client supports peer-id floating mechansim

IV_NCP=2 -- negotiable ciphers, client supports --cipher pushed by the server, a value of 2 or greater indicates client supports AES-GCM-128 and AES-GCM-256.

IV_UI_VER=<gui_id> <version> -- the UI version of a UI if one is running, for example "de.blinkt.openvpn 0.5.47" for the Android app.

When --push-peer-info is enabled the additional information consists of the following data:

IV_HWADDR=<mac address> -- the MAC address of clients default gateway

IV_SSL=<version string> -- the ssl version used by the client, e.g. "OpenSSL 1.0.2f 28 Jan 2016".

IV_PLAT_VER=x.y - the version of the operating system, e.g. 6.1 for Windows 7.

UV_<name>=<value> -- client environment variables whose names start with "UV_"
```

This first commit adds some lines of code in `OvsBeginIPCAsyncConnectionIfEmpty()`, in order to set the hostname to `UV_HOSTNAME`'s value, which is defined by the user on their device.
In case `UV_HOSTNAME` is not available, `IV_HWADDR`'s value (the default gateway's MAC address) is used instead.

`OvsParseOptions()` has been adapted into a new function called `OvsParsePeerInfo()`, in order to parse the peer info string.

The second commit renames the functions `OvsFreeOptions()`, `OvsNewOptions()`, `OvsAddOption()` and `OvsHasOption()`, as their functionality is not related to OpenVPN's options.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.