### PR TITLE
IPC: use hostname as client identifier, if available

### DIFF
--- a/src/Cedar/IPsec_IPC.c
+++ b/src/Cedar/IPsec_IPC.c
@@ -1235,7 +1235,6 @@ BUF *IPCBuildDhcpRequestOptions(IPC *ipc, DHCP_OPTION_LIST *opt)
 {
 	LIST *o;
 	UCHAR opcode;
-	UCHAR client_id[7];
 	BUF *ret;
 	// Validate arguments
 	if (ipc == NULL || opt == NULL)
@@ -1255,11 +1254,6 @@ BUF *IPCBuildDhcpRequestOptions(IPC *ipc, DHCP_OPTION_LIST *opt)
 		Add(o, NewDhcpOption(DHCP_ID_SERVER_ADDRESS, &opt->ServerAddress, 4));
 	}
 
-	// Client MAC Address
-	client_id[0] = ARP_HARDWARE_TYPE_ETHERNET;
-	Copy(client_id + 1, ipc->MacAddress, 6);
-	Add(o, NewDhcpOption(DHCP_ID_CLIENT_ID, client_id, sizeof(client_id)));
-
 	// Requested IP Address
 	if (opt->RequestedIp != 0)
 	{
@@ -1270,6 +1264,14 @@ BUF *IPCBuildDhcpRequestOptions(IPC *ipc, DHCP_OPTION_LIST *opt)
 	if (IsEmptyStr(opt->Hostname) == false)
 	{
 		Add(o, NewDhcpOption(DHCP_ID_HOST_NAME, opt->Hostname, StrLen(opt->Hostname)));
+		Add(o, NewDhcpOption(DHCP_ID_CLIENT_ID, opt->Hostname, StrLen(opt->Hostname)));
+	}
+	else // Client MAC Address
+	{
+		UCHAR client_id[7];
+		client_id[0] = ARP_HARDWARE_TYPE_ETHERNET;
+		Copy(client_id + 1, ipc->MacAddress, 6);
+		Add(o, NewDhcpOption(DHCP_ID_CLIENT_ID, client_id, sizeof(client_id)));
 	}
 
 	// User Class


### PR DESCRIPTION
This allows a DHCP server to use the client ID as unique identifier, in order to correctly assign a static lease.

Previously this wasn't possible, as the client identifier was set to its MAC address, which is randomly generated.

Related issue: #449.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.