### PR TITLE
travis-ci: split openssl into 1.0.2, 1.1.0 matrix

### DIFF
--- a/.ci/build-openssl.sh
+++ b/.ci/build-openssl.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eux
+
+download_openssl () {
+    if [ ! -f "download-cache/openssl-${OPENSSL_VERSION}.tar.gz" ]; then
+        wget -P download-cache/ \
+            "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
+    fi
+}
+
+build_openssl () {
+    if [ "$(cat ${PREFIX}/.openssl-version)" != "${OPENSSL_VERSION}" ]; then
+        tar zxf "download-cache/openssl-${OPENSSL_VERSION}.tar.gz"
+        cd "openssl-${OPENSSL_VERSION}/"
+        ./config shared --prefix="${PREFIX}" --openssldir="${PREFIX}" -DPURIFY
+        make all install_sw
+        echo "${OPENSSL_VERSION}" > "${PREFIX}/.openssl-version"
+    fi
+}
+
+
+download_openssl
+build_openssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,36 @@ addons:
 
 language: c
 
-compiler: [ gcc, clang ]
+env:
+  global:
+    - PREFIX="${HOME}/opt"
+    - CFLAGS="-I${PREFIX}/include"
+    - LDFLAGS="-L${PREFIX}/lib"
+
+matrix:
+  include:
+    - env: OPENSSL_VERSION="1.0.2o"
+      os: linux
+      compiler: gcc
+    - env: OPENSSL_VERSION="1.1.0f"
+      os: linux
+      compiler: gcc
+    - env: OPENSSL_VERSION="1.0.2o"
+      os: linux
+      compiler: clang
+    - env: OPENSSL_VERSION="1.1.0f"
+      os: linux
+      compiler: clang
+
+cache:
+  directories:
+  - download-cache
+  - ${HOME}/opt
 
 script:
+  - .ci/build-openssl.sh > build-deps.log 2>&1 || (cat build-deps.log && exit 1)
+  - export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH:-}"
   - ./configure
   - make
+  - ldd bin/vpnserver/vpnserver
   - dh build-arch

--- a/src/makefiles/linux_32bit.mak
+++ b/src/makefiles/linux_32bit.mak
@@ -25,13 +25,13 @@
 
 #CC=gcc
 
-OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_LINUX -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
+OPTIONS_COMPILE_DEBUG=$(CFLAGS) -D_DEBUG -DDEBUG -DUNIX -DUNIX_LINUX -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
 
-OPTIONS_LINK_DEBUG=-g -fsigned-char -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
+OPTIONS_LINK_DEBUG=$(LDFLAGS) -g -fsigned-char -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
 
-OPTIONS_COMPILE_RELEASE=-DNDEBUG -DVPN_SPEED -DUNIX -DUNIX_LINUX -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -O2 -fsigned-char
+OPTIONS_COMPILE_RELEASE=$(CFLAGS) -DNDEBUG -DVPN_SPEED -DUNIX -DUNIX_LINUX -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -O2 -fsigned-char
 
-OPTIONS_LINK_RELEASE=-O2 -fsigned-char -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
+OPTIONS_LINK_RELEASE=$(LDFLAGS) -O2 -fsigned-char -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
 
 INSTALL_BINDIR=/usr/bin/
 INSTALL_VPNSERVER_DIR=/usr/vpnserver/

--- a/src/makefiles/linux_64bit.mak
+++ b/src/makefiles/linux_64bit.mak
@@ -31,13 +31,13 @@ else
 	M64:=-m64
 endif
 
-OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_LINUX -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char $(M64)
+OPTIONS_COMPILE_DEBUG=$(CFLAGS) -D_DEBUG -DDEBUG -DUNIX -DUNIX_LINUX -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char $(M64)
 
-OPTIONS_LINK_DEBUG=-g -fsigned-char $(M64) -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
+OPTIONS_LINK_DEBUG=$(LDFLAGS) -g -fsigned-char $(M64) -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
 
-OPTIONS_COMPILE_RELEASE=-DNDEBUG -DVPN_SPEED -DUNIX -DUNIX_LINUX -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -O2 -fsigned-char $(M64)
+OPTIONS_COMPILE_RELEASE=$(CFLAGS) -DNDEBUG -DVPN_SPEED -DUNIX -DUNIX_LINUX -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -O2 -fsigned-char $(M64)
 
-OPTIONS_LINK_RELEASE=-O2 -fsigned-char $(M64) -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
+OPTIONS_LINK_RELEASE=$(LDFLAGS) -O2 -fsigned-char $(M64) -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
 
 INSTALL_BINDIR=/usr/bin/
 INSTALL_VPNSERVER_DIR=/usr/vpnserver/


### PR DESCRIPTION
Changes proposed in this pull request:
 - introducing openssl-1.1.0 in travis-ci builds

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one
