### PR TITLE
Encrypt: set default RSA key size to 1024 everywhere, using the RSA_KEY_SIZE macro

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -2194,7 +2194,7 @@ bool RsaVerifyEx(void *data, UINT data_size, void *sign, K *k, UINT bits)
 	}
 	if (bits == 0)
 	{
-		bits = 1024;
+		bits = RSA_KEY_SIZE;
 	}
 
 	// Hash the data
@@ -2233,7 +2233,7 @@ bool RsaSignEx(void *dst, void *src, UINT size, K *k, UINT bits)
 	}
 	if (bits == 0)
 	{
-		bits = 1024;
+		bits = RSA_KEY_SIZE;
 	}
 
 	Zero(dst, bits / 8);
@@ -2302,7 +2302,7 @@ bool RsaCheck()
 	BIO *bio;
 	char errbuf[MAX_SIZE];
 	UINT size = 0;
-	UINT bit = 32;
+	UINT bit = RSA_KEY_SIZE;
 	// Validate arguments
 
 	// Key generation
@@ -2372,7 +2372,7 @@ bool RsaGen(K **priv, K **pub, UINT bit)
 	}
 	if (bit == 0)
 	{
-		bit = 1024;
+		bit = RSA_KEY_SIZE;
 	}
 
 	// Key generation

--- a/src/Mayaqua/Encrypt.h
+++ b/src/Mayaqua/Encrypt.h
@@ -128,7 +128,7 @@ void RAND_Free_For_SoftEther();
 #define	DES_IV_SIZE					8			// DES IV size
 #define DES_BLOCK_SIZE				8			// DES block size
 #define DES3_KEY_SIZE				(8 * 3)		// 3DES key size
-#define RSA_KEY_SIZE				128			// RSA key size
+#define RSA_KEY_SIZE				1024		// RSA key size
 #define DH_KEY_SIZE					128			// DH key size
 #define	RSA_MIN_SIGN_HASH_SIZE		(15 + SHA1_HASH_SIZE)	// Minimum RSA hash size
 #define	RSA_SIGN_HASH_SIZE			(RSA_MIN_SIGN_HASH_SIZE)	// RSA hash size


### PR DESCRIPTION
This pull request also fixes the problem described in #31, which was caused by the test key generated in RsaCheck() being too small for newer OpenSSL versions.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.