### PR TITLE
resolve several issues found by cppcheck

### DIFF
--- a/src/Cedar/Connection.c
+++ b/src/Cedar/Connection.c
@@ -1082,12 +1082,12 @@ void ConnectionSend(CONNECTION *c, UINT64 now)
 			for (i = 0;i < num;i++)
 			{
 				TCPSOCK *tcpsock = tcpsocks[i];
-				if (tcpsock->Sock->Connected && tcpsock->Sock->AsyncMode &&
+				if (s != NULL && tcpsock->Sock->Connected && tcpsock->Sock->AsyncMode &&
 					IS_SEND_TCP_SOCK(tcpsock))
 				{
 					// Processing of KeepAlive
 					if (now >= tcpsock->NextKeepAliveTime || tcpsock->NextKeepAliveTime == 0 ||
-						(s != NULL && s->UseUdpAcceleration && s->UdpAccel != NULL && s->UdpAccel->MyPortByNatTServerChanged))
+						(s->UseUdpAcceleration && s->UdpAccel != NULL && s->UdpAccel->MyPortByNatTServerChanged))
 					{
 						// Send the KeepAlive
 						SendKeepAlive(c, tcpsock);

--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -2948,12 +2948,9 @@ bool ServerAccept(CONNECTION *c)
 			// VLAN ID
 			if (assigned_vlan_id != 0)
 			{
-				if (policy != NULL)
+				if (policy->VLanId == 0)
 				{
-					if (policy->VLanId == 0)
-					{
-						policy->VLanId = assigned_vlan_id;
-					}
+					policy->VLanId = assigned_vlan_id;
 				}
 			}
 
@@ -3146,12 +3143,7 @@ bool ServerAccept(CONNECTION *c)
 			s->Timeout = timeout;
 			s->QoS = qos;
 			s->NoReconnectToSession = no_reconnect_to_session;
-
-
-			if (policy != NULL)
-			{
-				s->VLanId = policy->VLanId;
-			}
+			s->VLanId = policy->VLanId;
 
 			// User name
 			s->Username = CopyStr(username);


### PR DESCRIPTION
[src/Cedar/Connection.c:1090] -> [src/Cedar/Connection.c:1086]:
(warning) Either the condition 's!=NULL' is redundant or there is possible null pointer dereference: s.

macros IS_SEND_TCP_SOCK expands into "s" dereferencing, so check for NULL should go before that macros

[src/Cedar/Protocol.c:2951] -> [src/Cedar/Protocol.c:2892]:
(warning) Either the condition 'policy!=NULL' is redundant or there is possible null pointer dereference: policy.
[src/Cedar/Protocol.c:2951] -> [src/Cedar/Protocol.c:2901]:
(warning) Either the condition 'policy!=NULL' is redundant or there is possible null pointer dereference: policy.
[src/Cedar/Protocol.c:3151] -> [src/Cedar/Protocol.c:3082]:
(warning) Either the condition 'policy!=NULL' is redundant or there is possible null pointer dereference: policy.
[src/Cedar/Protocol.c:3151] -> [src/Cedar/Protocol.c:3083]:
(warning) Either the condition 'policy!=NULL' is redundant or there is possible null pointer dereference: policy.

as we already have a check

			if (policy == NULL)
			{
				// Use the default policy
				policy = ClonePolicy(GetDefaultPolicy());
                        }

no need to compare policy with NULL anymore

Changes proposed in this pull request:
 - remove one possible null pointer dereference
 - remove not needed checks
 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one
