### PR TITLE
Encrypt: improve FreeOpenSSLThreadState() and FreeCryptLibrary(), in order to clean up the library correctly

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -3643,8 +3643,13 @@ void Rand(void *buf, UINT size)
 // Delete a thread-specific information that OpenSSL has holded
 void FreeOpenSSLThreadState()
 {
+	CRYPTO_cleanup_all_ex_data();
 	ERR_remove_state(0);
 }
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define SSL_COMP_free_compression_methods() (sk_free(SSL_COMP_get_compression_methods()))
+#endif
 
 // Release the Crypt library
 void FreeCryptLibrary()
@@ -3655,6 +3660,17 @@ void FreeCryptLibrary()
 	openssl_lock = NULL;
 //	RAND_Free_For_SoftEther();
 	OpenSSL_FreeLock();
+
+	FIPS_mode_set(0);
+	ENGINE_cleanup();
+	CONF_modules_unload(1);
+	EVP_cleanup();
+
+	FreeOpenSSLThreadState();
+
+	ERR_free_strings();
+
+	SSL_COMP_free_compression_methods();
 }
 
 // Initialize the Crypt library


### PR DESCRIPTION
This pull request improves `FreeOpenSSLThreadState()` and `FreeCryptLibrary()`, in order to clean up the library correctly.

https://wiki.openssl.org/index.php/Library_Initialization#Cleanup

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.