### PR TITLE
Network: fix compile error occurring with MSVC 2008 (C89 standard)

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -5828,11 +5828,10 @@ int SslCertVerifyCallback(int preverify_ok, X509_STORE_CTX *ctx)
 
 	if (clientcert != NULL)
 	{
-		clientcert->PreverifyErr = 0;
+		clientcert->PreverifyErr = X509_STORE_CTX_get_error(ctx);
 		clientcert->PreverifyErrMessage[0] = '\0';
 		if (!preverify_ok)
 		{
-			clientcert->PreverifyErr = X509_STORE_CTX_get_error(ctx);
 			const char *msg = X509_verify_cert_error_string(clientcert->PreverifyErr);
 			StrCpy(clientcert->PreverifyErrMessage, PREVERIFY_ERR_MESSAGE_SIZE, msg);
 			Debug("SslCertVerifyCallback preverify error: '%s'\n", msg);


### PR DESCRIPTION
All of the variables have to be declared at the top of the function, as MSVC 2008 doesn't support the C99 standard.

Fixes #488.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.