### PR TITLE
AppVeyor: increment build number with pull requests, in order to avoid conflicts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,12 +7,12 @@ skip_branch_with_pr: true
 clone_depth: 1
 
 init:
-- ps: Update-AppveyorBuild -Version "build-$env:appveyor_build_number-$($env:appveyor_repo_commit.substring(0,7))"
+  - ps: Update-AppveyorBuild -Version "build-$env:appveyor_build_number-$($env:appveyor_repo_commit.substring(0,7))"
 
 build_script:
-- cmd: >-
-    src\BuildAll.cmd
-    exit %errorlevel%
+  - cmd: >-
+      src\BuildAll.cmd
+      exit %errorlevel%
 
 artifacts:
   - path: output\pkg\*\*

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,9 +2,6 @@ version: '{build}'
 
 image: Visual Studio 2015
 
-pull_requests:
-  do_not_increment_build_number: true
-
 skip_branch_with_pr: true
 
 clone_depth: 1


### PR DESCRIPTION
This is required because we are currently using `build-{build}-{commit-sha1}` as build name pattern.

There may be multiple builds for the same commit.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.