### PR TITLE
Preventing the Win32 API LoadLibrary() current directory DLL injection issue.

### DIFF
--- a/src/Mayaqua/Mayaqua.c
+++ b/src/Mayaqua/Mayaqua.c
@@ -154,7 +154,19 @@ static UINT64 probe_start = 0;
 static UINT64 probe_last = 0;
 static bool probe_enabled = false;
 
+// The function which should be called once as soon as possible after the process is started
+static bool init_proc_once_flag = false;
+void InitProcessCallOnce()
+{
+	if (init_proc_once_flag == false)
+	{
+		init_proc_once_flag = true;
 
+#ifdef	OS_WIN32
+		MsInitProcessCallOnce();
+#endif	// OS_WIN32
+	}
+}
 
 // Calculate the checksum
 USHORT CalcChecksum16(void *buf, UINT size)
@@ -489,6 +501,8 @@ void InitMayaqua(bool memcheck, bool debug, int argc, char **argv)
 	{
 		return;
 	}
+
+	InitProcessCallOnce();
 
 	g_memcheck = memcheck;
 	g_debug = debug;

--- a/src/Mayaqua/Mayaqua.h
+++ b/src/Mayaqua/Mayaqua.h
@@ -133,6 +133,8 @@
 
 #endif	// VPN_SPEED
 
+void InitProcessCallOnce();
+
 #ifdef	VPN_EXE
 // To build the executable file
 #ifdef	WIN32
@@ -142,6 +144,7 @@ int main(int argc, char *argv[]);
 int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	char *argv[] = { CmdLine, };
+	InitProcessCallOnce();
 	return main(1, argv);
 }
 #endif	// WIN32

--- a/src/Mayaqua/Microsoft.h
+++ b/src/Mayaqua/Microsoft.h
@@ -1160,6 +1160,7 @@ void MsTest();
 
 bool MsSaveSystemInfo(wchar_t *dst_filename);
 bool MsCollectVpnInfo(BUF *bat, char *tmpdir, char *svc_name, wchar_t *config_name, wchar_t *logdir_name);
+void MsInitProcessCallOnce();
 
 MS_SUSPEND_HANDLER *MsNewSuspendHandler();
 void MsFreeSuspendHandler(MS_SUSPEND_HANDLER *h);

--- a/src/vpnbridge/vpnbridge.c
+++ b/src/vpnbridge/vpnbridge.c
@@ -155,6 +155,8 @@ void StopProcess()
 // WinMain function
 int main(int argc, char *argv[])
 {
+	InitProcessCallOnce();
+
 	VgUseStaticLink();
 
 #ifdef	OS_WIN32

--- a/src/vpnclient/vpncsvc.c
+++ b/src/vpnclient/vpncsvc.c
@@ -143,6 +143,8 @@ void StopProcess()
 // WinMain function
 int main(int argc, char *argv[])
 {
+	InitProcessCallOnce();
+
 #ifdef	OS_WIN32
 
 	return MsService(GC_SVC_NAME_VPNCLIENT, StartProcess, StopProcess, ICO_MACHINE, argv[0]);

--- a/src/vpncmd/vpncmd.c
+++ b/src/vpncmd/vpncmd.c
@@ -137,6 +137,8 @@ int main(int argc, char *argv[])
 	wchar_t *s;
 	UINT ret = 0;
 
+	InitProcessCallOnce();
+
 #ifdef	OS_WIN32
 	SetConsoleTitleA(CEDAR_PRODUCT_STR " VPN Command Line Utility");
 #endif	// OS_WIN32

--- a/src/vpncmgr/vpncmgr.c
+++ b/src/vpncmgr/vpncmgr.c
@@ -134,6 +134,8 @@
 // WinMain function
 int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
+	InitProcessCallOnce();
+
 	InitMayaqua(false, false, 0, NULL);
 	InitCedar();
 

--- a/src/vpndrvinst/vpndrvinst.c
+++ b/src/vpndrvinst/vpndrvinst.c
@@ -353,6 +353,8 @@ void MainFunction(char *cmd)
 // winmain function
 int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
+	InitProcessCallOnce();
+
 	InitMayaqua(false, false, 0, NULL);
 	EnableProbe(false);
 	InitCedar();

--- a/src/vpninstall/vpninstall.c
+++ b/src/vpninstall/vpninstall.c
@@ -1634,6 +1634,7 @@ void ViFreeStringTables()
 int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	INSTANCE *instance;
+	InitProcessCallOnce();
 	is_debug = false;
 	MayaquaMinimalMode();
 	InitMayaqua(false, is_debug, 0, NULL);

--- a/src/vpnserver/vpnserver.c
+++ b/src/vpnserver/vpnserver.c
@@ -155,6 +155,8 @@ void StopProcess()
 // WinMain function
 int main(int argc, char *argv[])
 {
+	InitProcessCallOnce();
+
 	VgUseStaticLink();
 
 #ifdef	OS_WIN32

--- a/src/vpnsetup/vpnsetup.c
+++ b/src/vpnsetup/vpnsetup.c
@@ -134,6 +134,8 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	UINT ret;
 
+	InitProcessCallOnce();
+
 	VgUseStaticLink();
 
 	ret = SWExec();

--- a/src/vpnsmgr/vpnsmgr.c
+++ b/src/vpnsmgr/vpnsmgr.c
@@ -132,6 +132,8 @@
 // WinMain function
 int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
+	InitProcessCallOnce();
+
 	InitMayaqua(false, false, 0, NULL);
 	InitCedar();
 	SMExec();


### PR DESCRIPTION
- Preventing the Win32 API LoadLibrary() current directory DLL injection issue.

- When loading the DLL file by the LoadLibrary() function in Windows VPN programs, we changed the behavior not to search the current directory. Based on this improvement, even if there are untrusted DLL files in the current directory, it is now safe to avoid the problem of unexpected security problem caused by the default loading behavior of Windows. Acknowledgments: This is based on a report by Herman Groeneveld, aka Sh4d0wman.

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- 1
