### PR TITLE
Improving the compliance of Virtual Network Adapters with the local address bit of the MAC address rule.

### DIFF
--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -431,7 +431,7 @@ void CiChangeAllVLanMacAddress(CLIENT *c)
 			RPC_CLIENT_ENUM_VLAN_ITEM *e = t.Items[i];
 			UCHAR mac[6];
 
-			if (StrToMac(mac, e->MacAddress) && ((mac[0] == 0x00 && mac[1] == 0xAC) || (mac[0] = 0x5E)))
+			if (StrToMac(mac, e->MacAddress) && ((mac[0] == 0x00 && mac[1] == 0xAC) || (mac[0] == 0x5E)))
 			{
 				char *name = e->DeviceName;
 				RPC_CLIENT_SET_VLAN s;

--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -431,7 +431,7 @@ void CiChangeAllVLanMacAddress(CLIENT *c)
 			RPC_CLIENT_ENUM_VLAN_ITEM *e = t.Items[i];
 			UCHAR mac[6];
 
-			if (StrToMac(mac, e->MacAddress) && mac[1] == 0xAC)
+			if (StrToMac(mac, e->MacAddress) && ((mac[0] == 0x00 && mac[1] == 0xAC) || (mac[0] = 0x5E)))
 			{
 				char *name = e->DeviceName;
 				RPC_CLIENT_SET_VLAN s;

--- a/src/Cedar/Virtual.c
+++ b/src/Cedar/Virtual.c
@@ -10306,12 +10306,12 @@ void GenMacAddress(UCHAR *mac)
 	Hash(hash, b->Buf, b->Size, true);
 
 	// Generate a MAC address
-	mac[0] = 0x00;
-	mac[1] = 0xAC;		// AC hurray
-	mac[2] = hash[0];
-	mac[3] = hash[1];
-	mac[4] = hash[2];
-	mac[5] = hash[3];
+	mac[0] = 0x5E;
+	mac[1] = hash[0];
+	mac[2] = hash[1];
+	mac[3] = hash[2];
+	mac[4] = hash[3];
+	mac[5] = hash[4];
 
 	FreeBuf(b);
 }

--- a/src/Mayaqua/Microsoft.c
+++ b/src/Mayaqua/Microsoft.c
@@ -10509,12 +10509,12 @@ void MsGenMacAddress(UCHAR *mac)
 
 	Hash(hash, hash_src, sizeof(hash_src), true);
 
-	mac[0] = 0x00;
-	mac[1] = 0xAC;
-	mac[2] = hash[0];
-	mac[3] = hash[1];
-	mac[4] = hash[2];
-	mac[5] = hash[3];
+	mac[0] = 0x5E;
+	mac[1] = hash[0];
+	mac[2] = hash[1];
+	mac[3] = hash[2];
+	mac[4] = hash[3];
+	mac[5] = hash[4];
 }
 
 // Finish the driver installation


### PR DESCRIPTION
- Improving the compliance of Virtual Network Adapters with the local address bit of the MAC address rule.

- When installing a new device driver of the Virtual Network Driver card, we changed the initial random MAC address from 00-AC-xx-xx-xx-xx to 5E-xx-xx-xx-xx-xx. This realizes the compliance with the local address bit of the MAC address rule.

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- 1
