### PR TITLE
Add Missing Debian build-dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: softether-vpn
 Section: net
 Priority: optional
 Maintainer: Dmitry Orlov <me@mosquito.su>
-Build-Depends: debhelper (>= 7.0.50~), libncurses5-dev, linux-libc-dev, libssl-dev, zlib1g-dev, libreadline-dev, build-essential, dh-exec
+Build-Depends: debhelper (>= 7.0.50~), libncurses5-dev, linux-libc-dev, libssl-dev, zlib1g-dev, libreadline-dev, zlib1g-dev, build-essential, dh-exec
 Standards-Version: 3.9.1
 Homepage: http://www.softether.org/
 


### PR DESCRIPTION
The Debian control file is missing one of the build dependencies (zlib dev libraries), adding the package zlib1g-dev satisfies that

Changes proposed in this pull request:
 - Add zlib1g-dev as  a build-dep in the debian control file
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- Option 1

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

