### PR TITLE
Cedar/Proto_PPP.c: push 192.0.0.8 instead of 1.0.0.1 as gateway IP address

### DIFF
--- a/src/Cedar/Proto_PPP.c
+++ b/src/Cedar/Proto_PPP.c
@@ -390,7 +390,9 @@ void PPPThread(THREAD *thread, void *param)
 
 	// Notify the IP address of the PPP server
 	c = NewPPPLCP(PPP_LCP_CODE_REQ, 0);
-	ui = Endian32(0x01000001);	// 1.0.0.1
+	// SoftEther VPN is L2-based VPN, so there is no concept of gateway IP address.
+	// We always push 192.0.0.8, which is defined in RFC7600 as dummy IPv4 address.
+	ui = Endian32(0xc0000008);
 	Add(c->OptionList, NewPPPOption(PPP_IPCP_OPTION_IP, &ui, sizeof(UINT)));
 	ret = PPPSendRequest(p, PPP_PROTOCOL_IPCP, c);
 	FreePPPLCP(c);


### PR DESCRIPTION
Fixes #114.

`1.0.0.1` is a real IP address, owned by CloudFlare and used for their DNS service.

This commit changes the IP address we push to `192.0.0.8`, which is defined in RFC7600 as dummy IPv4 address.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.