### PR TITLE
TUN/TAP support under FreeBSD

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -4040,22 +4040,6 @@ void FreeOpenSSLThreadState()
 	ERR_remove_state(0);
 }
 
-void FreeSsl()
-{
-	/* thread-safe cleanup */ 
-	ERR_remove_state(0);
-	ENGINE_cleanup(); 
-	CONF_modules_unload(1); 
-
-	sk_free(SSL_COMP_get_compression_methods());
-
-	/* global application exit cleanup (after all SSL activity is shutdown) */ 
-	ERR_free_strings(); 
-	EVP_cleanup(); 
-	CRYPTO_cleanup_all_ex_data();
-
-}
-
 // Release the Crypt library
 void FreeCryptLibrary()
 {
@@ -4065,8 +4049,6 @@ void FreeCryptLibrary()
 	openssl_lock = NULL;
 //	RAND_Free_For_SoftEther();
 	OpenSSL_FreeLock();
-
-	FreeSsl();
 }
 
 // Initialize the Crypt library


### PR DESCRIPTION
FreeBSD have built-in TAP/TUN support. It would be great SoftEtherVPN feature to support TAP/TUN under FreeBSD, not only Linux. 

Softether users requested it already: http://www.vpnusers.com/viewtopic.php?t=4336

Thank you!