### PR TITLE
support staged installs

### DIFF
--- a/src/makefiles/freebsd_32bit.mak
+++ b/src/makefiles/freebsd_32bit.mak
@@ -393,6 +393,7 @@ install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbrid
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
 	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
@@ -402,6 +403,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
 	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
@@ -411,6 +413,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
 	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
@@ -420,6 +423,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
 	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd

--- a/src/makefiles/freebsd_32bit.mak
+++ b/src/makefiles/freebsd_32bit.mak
@@ -379,7 +379,7 @@ tmp/objs/vpncmd.o: src/vpncmd/vpncmd.c $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJ
 	$(CC) $(OPTIONS_COMPILE) -c src/vpncmd/vpncmd.c -o tmp/objs/vpncmd.o
 
 # Install
-install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)vpnclient $(INSTALL_BINDIR)vpncmd
+install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbridge $(DESTDIR)$(INSTALL_BINDIR)vpnclient $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 	@echo
 	@echo "--------------------------------------------------------------------"
 	@echo "Installation completed successfully."
@@ -391,41 +391,41 @@ install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)
 	@echo "--------------------------------------------------------------------"
 	@echo
 
-$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
-	@mkdir -p $(INSTALL_VPNSERVER_DIR)
-	cp bin/vpnserver/hamcore.se2 $(INSTALL_VPNSERVER_DIR)hamcore.se2
-	cp bin/vpnserver/vpnserver $(INSTALL_VPNSERVER_DIR)vpnserver
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnserver
-	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(INSTALL_BINDIR)vpnserver
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnserver
-	chmod 755 $(INSTALL_BINDIR)vpnserver
+$(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
+	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnserver
 
-$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
-	@mkdir -p $(INSTALL_VPNBRIDGE_DIR)
-	cp bin/vpnbridge/hamcore.se2 $(INSTALL_VPNBRIDGE_DIR)hamcore.se2
-	cp bin/vpnbridge/vpnbridge $(INSTALL_VPNBRIDGE_DIR)vpnbridge
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnbridge
-	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(INSTALL_BINDIR)vpnbridge
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnbridge
-	chmod 755 $(INSTALL_BINDIR)vpnbridge
+$(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
+	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
 
-$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
-	@mkdir -p $(INSTALL_VPNCLIENT_DIR)
-	cp bin/vpnclient/hamcore.se2 $(INSTALL_VPNCLIENT_DIR)hamcore.se2
-	cp bin/vpnclient/vpnclient $(INSTALL_VPNCLIENT_DIR)vpnclient
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnclient
-	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(INSTALL_BINDIR)vpnclient
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnclient
-	chmod 755 $(INSTALL_BINDIR)vpnclient
+$(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
+	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnclient
 
-$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
-	@mkdir -p $(INSTALL_VPNCMD_DIR)
-	cp bin/vpncmd/hamcore.se2 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	cp bin/vpncmd/vpncmd $(INSTALL_VPNCMD_DIR)vpncmd
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpncmd
-	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(INSTALL_BINDIR)vpncmd
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpncmd
-	chmod 755 $(INSTALL_BINDIR)vpncmd
+$(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 
 # Clean
 clean:

--- a/src/makefiles/freebsd_64bit.mak
+++ b/src/makefiles/freebsd_64bit.mak
@@ -393,6 +393,7 @@ install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbrid
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
 	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
@@ -402,6 +403,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
 	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
@@ -411,6 +413,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
 	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
@@ -420,6 +423,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
 	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd

--- a/src/makefiles/freebsd_64bit.mak
+++ b/src/makefiles/freebsd_64bit.mak
@@ -379,7 +379,7 @@ tmp/objs/vpncmd.o: src/vpncmd/vpncmd.c $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJ
 	$(CC) $(OPTIONS_COMPILE) -c src/vpncmd/vpncmd.c -o tmp/objs/vpncmd.o
 
 # Install
-install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)vpnclient $(INSTALL_BINDIR)vpncmd
+install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbridge $(DESTDIR)$(INSTALL_BINDIR)vpnclient $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 	@echo
 	@echo "--------------------------------------------------------------------"
 	@echo "Installation completed successfully."
@@ -391,41 +391,41 @@ install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)
 	@echo "--------------------------------------------------------------------"
 	@echo
 
-$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
-	@mkdir -p $(INSTALL_VPNSERVER_DIR)
-	cp bin/vpnserver/hamcore.se2 $(INSTALL_VPNSERVER_DIR)hamcore.se2
-	cp bin/vpnserver/vpnserver $(INSTALL_VPNSERVER_DIR)vpnserver
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnserver
-	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(INSTALL_BINDIR)vpnserver
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnserver
-	chmod 755 $(INSTALL_BINDIR)vpnserver
+$(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
+	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnserver
 
-$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
-	@mkdir -p $(INSTALL_VPNBRIDGE_DIR)
-	cp bin/vpnbridge/hamcore.se2 $(INSTALL_VPNBRIDGE_DIR)hamcore.se2
-	cp bin/vpnbridge/vpnbridge $(INSTALL_VPNBRIDGE_DIR)vpnbridge
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnbridge
-	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(INSTALL_BINDIR)vpnbridge
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnbridge
-	chmod 755 $(INSTALL_BINDIR)vpnbridge
+$(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
+	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
 
-$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
-	@mkdir -p $(INSTALL_VPNCLIENT_DIR)
-	cp bin/vpnclient/hamcore.se2 $(INSTALL_VPNCLIENT_DIR)hamcore.se2
-	cp bin/vpnclient/vpnclient $(INSTALL_VPNCLIENT_DIR)vpnclient
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnclient
-	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(INSTALL_BINDIR)vpnclient
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnclient
-	chmod 755 $(INSTALL_BINDIR)vpnclient
+$(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
+	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnclient
 
-$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
-	@mkdir -p $(INSTALL_VPNCMD_DIR)
-	cp bin/vpncmd/hamcore.se2 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	cp bin/vpncmd/vpncmd $(INSTALL_VPNCMD_DIR)vpncmd
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpncmd
-	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(INSTALL_BINDIR)vpncmd
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpncmd
-	chmod 755 $(INSTALL_BINDIR)vpncmd
+$(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 
 # Clean
 clean:

--- a/src/makefiles/linux_32bit.mak
+++ b/src/makefiles/linux_32bit.mak
@@ -379,7 +379,7 @@ tmp/objs/vpncmd.o: src/vpncmd/vpncmd.c $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJ
 	$(CC) $(OPTIONS_COMPILE) -c src/vpncmd/vpncmd.c -o tmp/objs/vpncmd.o
 
 # Install
-install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)vpnclient $(INSTALL_BINDIR)vpncmd
+install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbridge $(DESTDIR)$(INSTALL_BINDIR)vpnclient $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 	@echo
 	@echo "--------------------------------------------------------------------"
 	@echo "Installation completed successfully."
@@ -391,42 +391,42 @@ install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)
 	@echo "--------------------------------------------------------------------"
 	@echo
 
-$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
-	@mkdir -p $(INSTALL_VPNSERVER_DIR)
-	cp bin/vpnserver/hamcore.se2 $(INSTALL_VPNSERVER_DIR)hamcore.se2
-	cp bin/vpnserver/vpnserver $(INSTALL_VPNSERVER_DIR)vpnserver
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnserver
-	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(INSTALL_BINDIR)vpnserver
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnserver
-	chmod 755 $(INSTALL_BINDIR)vpnserver
+$(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
+	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnserver
 
-$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
-	@mkdir -p $(INSTALL_VPNBRIDGE_DIR)
-	cp bin/vpnbridge/hamcore.se2 $(INSTALL_VPNBRIDGE_DIR)hamcore.se2
-	cp bin/vpnbridge/vpnbridge $(INSTALL_VPNBRIDGE_DIR)vpnbridge
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnbridge
-	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(INSTALL_BINDIR)vpnbridge
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnbridge
-	chmod 755 $(INSTALL_BINDIR)vpnbridge
+$(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
+	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
 
-$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
-	@mkdir -p $(INSTALL_VPNCLIENT_DIR)
-	cp bin/vpnclient/hamcore.se2 $(INSTALL_VPNCLIENT_DIR)hamcore.se2
-	cp bin/vpnclient/vpnclient $(INSTALL_VPNCLIENT_DIR)vpnclient
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnclient
-	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(INSTALL_BINDIR)vpnclient
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnclient
-	chmod 755 $(INSTALL_BINDIR)vpnclient
+$(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
+	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnclient
 
-$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
-	@mkdir -p $(INSTALL_VPNCMD_DIR)
-	cp bin/vpncmd/hamcore.se2 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	cp bin/vpncmd/vpncmd $(INSTALL_VPNCMD_DIR)vpncmd
-	chmod 644 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpncmd
-	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(INSTALL_BINDIR)vpncmd
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpncmd
-	chmod 755 $(INSTALL_BINDIR)vpncmd
+$(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
+	chmod 644 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 
 # Clean
 clean:

--- a/src/makefiles/linux_32bit.mak
+++ b/src/makefiles/linux_32bit.mak
@@ -393,6 +393,7 @@ install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbrid
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
 	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
@@ -402,6 +403,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
 	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
@@ -411,6 +413,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
 	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
@@ -420,6 +423,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
 	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
 	chmod 644 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2

--- a/src/makefiles/linux_64bit.mak
+++ b/src/makefiles/linux_64bit.mak
@@ -399,6 +399,7 @@ install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbrid
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
 	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
@@ -408,6 +409,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
 	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
@@ -417,6 +419,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
 	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
@@ -426,6 +429,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
 	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
 	chmod 644 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2

--- a/src/makefiles/linux_64bit.mak
+++ b/src/makefiles/linux_64bit.mak
@@ -385,7 +385,7 @@ tmp/objs/vpncmd.o: src/vpncmd/vpncmd.c $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJ
 	$(CC) $(OPTIONS_COMPILE) -c src/vpncmd/vpncmd.c -o tmp/objs/vpncmd.o
 
 # Install
-install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)vpnclient $(INSTALL_BINDIR)vpncmd
+install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbridge $(DESTDIR)$(INSTALL_BINDIR)vpnclient $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 	@echo
 	@echo "--------------------------------------------------------------------"
 	@echo "Installation completed successfully."
@@ -397,42 +397,42 @@ install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)
 	@echo "--------------------------------------------------------------------"
 	@echo
 
-$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
-	@mkdir -p $(INSTALL_VPNSERVER_DIR)
-	cp bin/vpnserver/hamcore.se2 $(INSTALL_VPNSERVER_DIR)hamcore.se2
-	cp bin/vpnserver/vpnserver $(INSTALL_VPNSERVER_DIR)vpnserver
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnserver
-	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(INSTALL_BINDIR)vpnserver
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnserver
-	chmod 755 $(INSTALL_BINDIR)vpnserver
+$(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
+	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnserver
 
-$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
-	@mkdir -p $(INSTALL_VPNBRIDGE_DIR)
-	cp bin/vpnbridge/hamcore.se2 $(INSTALL_VPNBRIDGE_DIR)hamcore.se2
-	cp bin/vpnbridge/vpnbridge $(INSTALL_VPNBRIDGE_DIR)vpnbridge
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnbridge
-	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(INSTALL_BINDIR)vpnbridge
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnbridge
-	chmod 755 $(INSTALL_BINDIR)vpnbridge
+$(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
+	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
 
-$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
-	@mkdir -p $(INSTALL_VPNCLIENT_DIR)
-	cp bin/vpnclient/hamcore.se2 $(INSTALL_VPNCLIENT_DIR)hamcore.se2
-	cp bin/vpnclient/vpnclient $(INSTALL_VPNCLIENT_DIR)vpnclient
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnclient
-	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(INSTALL_BINDIR)vpnclient
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnclient
-	chmod 755 $(INSTALL_BINDIR)vpnclient
+$(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
+	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnclient
 
-$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
-	@mkdir -p $(INSTALL_VPNCMD_DIR)
-	cp bin/vpncmd/hamcore.se2 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	cp bin/vpncmd/vpncmd $(INSTALL_VPNCMD_DIR)vpncmd
-	chmod 644 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpncmd
-	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(INSTALL_BINDIR)vpncmd
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpncmd
-	chmod 755 $(INSTALL_BINDIR)vpncmd
+$(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
+	chmod 644 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 
 # Clean
 clean:

--- a/src/makefiles/macos_32bit.mak
+++ b/src/makefiles/macos_32bit.mak
@@ -393,6 +393,7 @@ install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbrid
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
 	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
@@ -402,6 +403,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
 	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
@@ -411,6 +413,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
 	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
@@ -420,6 +423,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
 	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd

--- a/src/makefiles/macos_32bit.mak
+++ b/src/makefiles/macos_32bit.mak
@@ -379,7 +379,7 @@ tmp/objs/vpncmd.o: src/vpncmd/vpncmd.c $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJ
 	$(CC) $(OPTIONS_COMPILE) -c src/vpncmd/vpncmd.c -o tmp/objs/vpncmd.o
 
 # Install
-install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)vpnclient $(INSTALL_BINDIR)vpncmd
+install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbridge $(DESTDIR)$(INSTALL_BINDIR)vpnclient $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 	@echo
 	@echo "--------------------------------------------------------------------"
 	@echo "Installation completed successfully."
@@ -391,41 +391,41 @@ install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)
 	@echo "--------------------------------------------------------------------"
 	@echo
 
-$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
-	@mkdir -p $(INSTALL_VPNSERVER_DIR)
-	cp bin/vpnserver/hamcore.se2 $(INSTALL_VPNSERVER_DIR)hamcore.se2
-	cp bin/vpnserver/vpnserver $(INSTALL_VPNSERVER_DIR)vpnserver
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnserver
-	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(INSTALL_BINDIR)vpnserver
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnserver
-	chmod 755 $(INSTALL_BINDIR)vpnserver
+$(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
+	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnserver
 
-$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
-	@mkdir -p $(INSTALL_VPNBRIDGE_DIR)
-	cp bin/vpnbridge/hamcore.se2 $(INSTALL_VPNBRIDGE_DIR)hamcore.se2
-	cp bin/vpnbridge/vpnbridge $(INSTALL_VPNBRIDGE_DIR)vpnbridge
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnbridge
-	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(INSTALL_BINDIR)vpnbridge
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnbridge
-	chmod 755 $(INSTALL_BINDIR)vpnbridge
+$(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
+	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
 
-$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
-	@mkdir -p $(INSTALL_VPNCLIENT_DIR)
-	cp bin/vpnclient/hamcore.se2 $(INSTALL_VPNCLIENT_DIR)hamcore.se2
-	cp bin/vpnclient/vpnclient $(INSTALL_VPNCLIENT_DIR)vpnclient
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnclient
-	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(INSTALL_BINDIR)vpnclient
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnclient
-	chmod 755 $(INSTALL_BINDIR)vpnclient
+$(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
+	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnclient
 
-$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
-	@mkdir -p $(INSTALL_VPNCMD_DIR)
-	cp bin/vpncmd/hamcore.se2 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	cp bin/vpncmd/vpncmd $(INSTALL_VPNCMD_DIR)vpncmd
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpncmd
-	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(INSTALL_BINDIR)vpncmd
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpncmd
-	chmod 755 $(INSTALL_BINDIR)vpncmd
+$(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 
 # Clean
 clean:

--- a/src/makefiles/macos_64bit.mak
+++ b/src/makefiles/macos_64bit.mak
@@ -393,6 +393,7 @@ install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbrid
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
 	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
@@ -402,6 +403,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
 	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
@@ -411,6 +413,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
 	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
@@ -420,6 +423,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
 	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd

--- a/src/makefiles/macos_64bit.mak
+++ b/src/makefiles/macos_64bit.mak
@@ -379,7 +379,7 @@ tmp/objs/vpncmd.o: src/vpncmd/vpncmd.c $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJ
 	$(CC) $(OPTIONS_COMPILE) -c src/vpncmd/vpncmd.c -o tmp/objs/vpncmd.o
 
 # Install
-install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)vpnclient $(INSTALL_BINDIR)vpncmd
+install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbridge $(DESTDIR)$(INSTALL_BINDIR)vpnclient $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 	@echo
 	@echo "--------------------------------------------------------------------"
 	@echo "Installation completed successfully."
@@ -391,41 +391,41 @@ install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)
 	@echo "--------------------------------------------------------------------"
 	@echo
 
-$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
-	@mkdir -p $(INSTALL_VPNSERVER_DIR)
-	cp bin/vpnserver/hamcore.se2 $(INSTALL_VPNSERVER_DIR)hamcore.se2
-	cp bin/vpnserver/vpnserver $(INSTALL_VPNSERVER_DIR)vpnserver
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnserver
-	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(INSTALL_BINDIR)vpnserver
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnserver
-	chmod 755 $(INSTALL_BINDIR)vpnserver
+$(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
+	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnserver
 
-$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
-	@mkdir -p $(INSTALL_VPNBRIDGE_DIR)
-	cp bin/vpnbridge/hamcore.se2 $(INSTALL_VPNBRIDGE_DIR)hamcore.se2
-	cp bin/vpnbridge/vpnbridge $(INSTALL_VPNBRIDGE_DIR)vpnbridge
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnbridge
-	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(INSTALL_BINDIR)vpnbridge
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnbridge
-	chmod 755 $(INSTALL_BINDIR)vpnbridge
+$(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
+	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
 
-$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
-	@mkdir -p $(INSTALL_VPNCLIENT_DIR)
-	cp bin/vpnclient/hamcore.se2 $(INSTALL_VPNCLIENT_DIR)hamcore.se2
-	cp bin/vpnclient/vpnclient $(INSTALL_VPNCLIENT_DIR)vpnclient
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnclient
-	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(INSTALL_BINDIR)vpnclient
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnclient
-	chmod 755 $(INSTALL_BINDIR)vpnclient
+$(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
+	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnclient
 
-$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
-	@mkdir -p $(INSTALL_VPNCMD_DIR)
-	cp bin/vpncmd/hamcore.se2 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	cp bin/vpncmd/vpncmd $(INSTALL_VPNCMD_DIR)vpncmd
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpncmd
-	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(INSTALL_BINDIR)vpncmd
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpncmd
-	chmod 755 $(INSTALL_BINDIR)vpncmd
+$(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 
 # Clean
 clean:

--- a/src/makefiles/openbsd_32bit.mak
+++ b/src/makefiles/openbsd_32bit.mak
@@ -393,6 +393,7 @@ install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbrid
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
 	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
@@ -402,6 +403,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
 	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
@@ -411,6 +413,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
 	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
@@ -420,6 +423,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
 	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd

--- a/src/makefiles/openbsd_32bit.mak
+++ b/src/makefiles/openbsd_32bit.mak
@@ -379,7 +379,7 @@ tmp/objs/vpncmd.o: src/vpncmd/vpncmd.c $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJ
 	$(CC) $(OPTIONS_COMPILE) -c src/vpncmd/vpncmd.c -o tmp/objs/vpncmd.o
 
 # Install
-install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)vpnclient $(INSTALL_BINDIR)vpncmd
+install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbridge $(DESTDIR)$(INSTALL_BINDIR)vpnclient $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 	@echo
 	@echo "--------------------------------------------------------------------"
 	@echo "Installation completed successfully."
@@ -391,41 +391,41 @@ install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)
 	@echo "--------------------------------------------------------------------"
 	@echo
 
-$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
-	@mkdir -p $(INSTALL_VPNSERVER_DIR)
-	cp bin/vpnserver/hamcore.se2 $(INSTALL_VPNSERVER_DIR)hamcore.se2
-	cp bin/vpnserver/vpnserver $(INSTALL_VPNSERVER_DIR)vpnserver
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnserver
-	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(INSTALL_BINDIR)vpnserver
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnserver
-	chmod 755 $(INSTALL_BINDIR)vpnserver
+$(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
+	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnserver
 
-$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
-	@mkdir -p $(INSTALL_VPNBRIDGE_DIR)
-	cp bin/vpnbridge/hamcore.se2 $(INSTALL_VPNBRIDGE_DIR)hamcore.se2
-	cp bin/vpnbridge/vpnbridge $(INSTALL_VPNBRIDGE_DIR)vpnbridge
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnbridge
-	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(INSTALL_BINDIR)vpnbridge
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnbridge
-	chmod 755 $(INSTALL_BINDIR)vpnbridge
+$(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
+	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
 
-$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
-	@mkdir -p $(INSTALL_VPNCLIENT_DIR)
-	cp bin/vpnclient/hamcore.se2 $(INSTALL_VPNCLIENT_DIR)hamcore.se2
-	cp bin/vpnclient/vpnclient $(INSTALL_VPNCLIENT_DIR)vpnclient
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnclient
-	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(INSTALL_BINDIR)vpnclient
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnclient
-	chmod 755 $(INSTALL_BINDIR)vpnclient
+$(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
+	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnclient
 
-$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
-	@mkdir -p $(INSTALL_VPNCMD_DIR)
-	cp bin/vpncmd/hamcore.se2 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	cp bin/vpncmd/vpncmd $(INSTALL_VPNCMD_DIR)vpncmd
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpncmd
-	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(INSTALL_BINDIR)vpncmd
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpncmd
-	chmod 755 $(INSTALL_BINDIR)vpncmd
+$(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 
 # Clean
 clean:

--- a/src/makefiles/openbsd_64bit.mak
+++ b/src/makefiles/openbsd_64bit.mak
@@ -393,6 +393,7 @@ install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbrid
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
 	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
@@ -402,6 +403,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
 	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
@@ -411,6 +413,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
 	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
@@ -420,6 +423,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
 	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd

--- a/src/makefiles/openbsd_64bit.mak
+++ b/src/makefiles/openbsd_64bit.mak
@@ -379,7 +379,7 @@ tmp/objs/vpncmd.o: src/vpncmd/vpncmd.c $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJ
 	$(CC) $(OPTIONS_COMPILE) -c src/vpncmd/vpncmd.c -o tmp/objs/vpncmd.o
 
 # Install
-install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)vpnclient $(INSTALL_BINDIR)vpncmd
+install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbridge $(DESTDIR)$(INSTALL_BINDIR)vpnclient $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 	@echo
 	@echo "--------------------------------------------------------------------"
 	@echo "Installation completed successfully."
@@ -391,41 +391,41 @@ install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)
 	@echo "--------------------------------------------------------------------"
 	@echo
 
-$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
-	@mkdir -p $(INSTALL_VPNSERVER_DIR)
-	cp bin/vpnserver/hamcore.se2 $(INSTALL_VPNSERVER_DIR)hamcore.se2
-	cp bin/vpnserver/vpnserver $(INSTALL_VPNSERVER_DIR)vpnserver
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnserver
-	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(INSTALL_BINDIR)vpnserver
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnserver
-	chmod 755 $(INSTALL_BINDIR)vpnserver
+$(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
+	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnserver
 
-$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
-	@mkdir -p $(INSTALL_VPNBRIDGE_DIR)
-	cp bin/vpnbridge/hamcore.se2 $(INSTALL_VPNBRIDGE_DIR)hamcore.se2
-	cp bin/vpnbridge/vpnbridge $(INSTALL_VPNBRIDGE_DIR)vpnbridge
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnbridge
-	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(INSTALL_BINDIR)vpnbridge
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnbridge
-	chmod 755 $(INSTALL_BINDIR)vpnbridge
+$(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
+	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
 
-$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
-	@mkdir -p $(INSTALL_VPNCLIENT_DIR)
-	cp bin/vpnclient/hamcore.se2 $(INSTALL_VPNCLIENT_DIR)hamcore.se2
-	cp bin/vpnclient/vpnclient $(INSTALL_VPNCLIENT_DIR)vpnclient
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnclient
-	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(INSTALL_BINDIR)vpnclient
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnclient
-	chmod 755 $(INSTALL_BINDIR)vpnclient
+$(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
+	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnclient
 
-$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
-	@mkdir -p $(INSTALL_VPNCMD_DIR)
-	cp bin/vpncmd/hamcore.se2 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	cp bin/vpncmd/vpncmd $(INSTALL_VPNCMD_DIR)vpncmd
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpncmd
-	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(INSTALL_BINDIR)vpncmd
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpncmd
-	chmod 755 $(INSTALL_BINDIR)vpncmd
+$(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 
 # Clean
 clean:

--- a/src/makefiles/solaris_32bit.mak
+++ b/src/makefiles/solaris_32bit.mak
@@ -393,6 +393,7 @@ install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbrid
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
 	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
@@ -402,6 +403,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
 	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
@@ -411,6 +413,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
 	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
@@ -420,6 +423,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
 	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd

--- a/src/makefiles/solaris_32bit.mak
+++ b/src/makefiles/solaris_32bit.mak
@@ -379,7 +379,7 @@ tmp/objs/vpncmd.o: src/vpncmd/vpncmd.c $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJ
 	$(CC) $(OPTIONS_COMPILE) -c src/vpncmd/vpncmd.c -o tmp/objs/vpncmd.o
 
 # Install
-install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)vpnclient $(INSTALL_BINDIR)vpncmd
+install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbridge $(DESTDIR)$(INSTALL_BINDIR)vpnclient $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 	@echo
 	@echo "--------------------------------------------------------------------"
 	@echo "Installation completed successfully."
@@ -391,41 +391,41 @@ install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)
 	@echo "--------------------------------------------------------------------"
 	@echo
 
-$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
-	@mkdir -p $(INSTALL_VPNSERVER_DIR)
-	cp bin/vpnserver/hamcore.se2 $(INSTALL_VPNSERVER_DIR)hamcore.se2
-	cp bin/vpnserver/vpnserver $(INSTALL_VPNSERVER_DIR)vpnserver
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnserver
-	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(INSTALL_BINDIR)vpnserver
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnserver
-	chmod 755 $(INSTALL_BINDIR)vpnserver
+$(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
+	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnserver
 
-$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
-	@mkdir -p $(INSTALL_VPNBRIDGE_DIR)
-	cp bin/vpnbridge/hamcore.se2 $(INSTALL_VPNBRIDGE_DIR)hamcore.se2
-	cp bin/vpnbridge/vpnbridge $(INSTALL_VPNBRIDGE_DIR)vpnbridge
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnbridge
-	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(INSTALL_BINDIR)vpnbridge
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnbridge
-	chmod 755 $(INSTALL_BINDIR)vpnbridge
+$(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
+	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
 
-$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
-	@mkdir -p $(INSTALL_VPNCLIENT_DIR)
-	cp bin/vpnclient/hamcore.se2 $(INSTALL_VPNCLIENT_DIR)hamcore.se2
-	cp bin/vpnclient/vpnclient $(INSTALL_VPNCLIENT_DIR)vpnclient
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnclient
-	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(INSTALL_BINDIR)vpnclient
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnclient
-	chmod 755 $(INSTALL_BINDIR)vpnclient
+$(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
+	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnclient
 
-$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
-	@mkdir -p $(INSTALL_VPNCMD_DIR)
-	cp bin/vpncmd/hamcore.se2 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	cp bin/vpncmd/vpncmd $(INSTALL_VPNCMD_DIR)vpncmd
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpncmd
-	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(INSTALL_BINDIR)vpncmd
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpncmd
-	chmod 755 $(INSTALL_BINDIR)vpncmd
+$(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 
 # Clean
 clean:

--- a/src/makefiles/solaris_64bit.mak
+++ b/src/makefiles/solaris_64bit.mak
@@ -393,6 +393,7 @@ install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbrid
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
 	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
@@ -402,6 +403,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
 	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
@@ -411,6 +413,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
 	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
@@ -420,6 +423,7 @@ $(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vp
 
 $(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
 	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	@mkdir -p $(DESTDIR)$(INSTALL_BINDIR)
 	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
 	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
 	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd

--- a/src/makefiles/solaris_64bit.mak
+++ b/src/makefiles/solaris_64bit.mak
@@ -379,7 +379,7 @@ tmp/objs/vpncmd.o: src/vpncmd/vpncmd.c $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJ
 	$(CC) $(OPTIONS_COMPILE) -c src/vpncmd/vpncmd.c -o tmp/objs/vpncmd.o
 
 # Install
-install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)vpnclient $(INSTALL_BINDIR)vpncmd
+install: $(DESTDIR)$(INSTALL_BINDIR)vpnserver $(DESTDIR)$(INSTALL_BINDIR)vpnbridge $(DESTDIR)$(INSTALL_BINDIR)vpnclient $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 	@echo
 	@echo "--------------------------------------------------------------------"
 	@echo "Installation completed successfully."
@@ -391,41 +391,41 @@ install: $(INSTALL_BINDIR)vpnserver $(INSTALL_BINDIR)vpnbridge $(INSTALL_BINDIR)
 	@echo "--------------------------------------------------------------------"
 	@echo
 
-$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
-	@mkdir -p $(INSTALL_VPNSERVER_DIR)
-	cp bin/vpnserver/hamcore.se2 $(INSTALL_VPNSERVER_DIR)hamcore.se2
-	cp bin/vpnserver/vpnserver $(INSTALL_VPNSERVER_DIR)vpnserver
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnserver
-	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(INSTALL_BINDIR)vpnserver
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnserver
-	chmod 755 $(INSTALL_BINDIR)vpnserver
+$(DESTDIR)$(INSTALL_BINDIR)vpnserver: bin/vpnserver/hamcore.se2 bin/vpnserver/vpnserver
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNSERVER_DIR)
+	cp bin/vpnserver/hamcore.se2 $(DESTDIR)$(INSTALL_VPNSERVER_DIR)hamcore.se2
+	cp bin/vpnserver/vpnserver $(DESTDIR)$(INSTALL_VPNSERVER_DIR)vpnserver
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo $(INSTALL_VPNSERVER_DIR)vpnserver '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnserver
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnserver
 
-$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
-	@mkdir -p $(INSTALL_VPNBRIDGE_DIR)
-	cp bin/vpnbridge/hamcore.se2 $(INSTALL_VPNBRIDGE_DIR)hamcore.se2
-	cp bin/vpnbridge/vpnbridge $(INSTALL_VPNBRIDGE_DIR)vpnbridge
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnbridge
-	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(INSTALL_BINDIR)vpnbridge
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnbridge
-	chmod 755 $(INSTALL_BINDIR)vpnbridge
+$(DESTDIR)$(INSTALL_BINDIR)vpnbridge: bin/vpnbridge/hamcore.se2 bin/vpnbridge/vpnbridge
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)
+	cp bin/vpnbridge/hamcore.se2 $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)hamcore.se2
+	cp bin/vpnbridge/vpnbridge $(DESTDIR)$(INSTALL_VPNBRIDGE_DIR)vpnbridge
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo $(INSTALL_VPNBRIDGE_DIR)vpnbridge '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnbridge
 
-$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
-	@mkdir -p $(INSTALL_VPNCLIENT_DIR)
-	cp bin/vpnclient/hamcore.se2 $(INSTALL_VPNCLIENT_DIR)hamcore.se2
-	cp bin/vpnclient/vpnclient $(INSTALL_VPNCLIENT_DIR)vpnclient
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpnclient
-	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(INSTALL_BINDIR)vpnclient
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpnclient
-	chmod 755 $(INSTALL_BINDIR)vpnclient
+$(DESTDIR)$(INSTALL_BINDIR)vpnclient: bin/vpnclient/hamcore.se2 bin/vpnclient/vpnclient
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)
+	cp bin/vpnclient/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)hamcore.se2
+	cp bin/vpnclient/vpnclient $(DESTDIR)$(INSTALL_VPNCLIENT_DIR)vpnclient
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo $(INSTALL_VPNCLIENT_DIR)vpnclient '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpnclient
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpnclient
 
-$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
-	@mkdir -p $(INSTALL_VPNCMD_DIR)
-	cp bin/vpncmd/hamcore.se2 $(INSTALL_VPNCMD_DIR)hamcore.se2
-	cp bin/vpncmd/vpncmd $(INSTALL_VPNCMD_DIR)vpncmd
-	echo "#!/bin/sh" > $(INSTALL_BINDIR)vpncmd
-	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(INSTALL_BINDIR)vpncmd
-	echo 'exit $$?' >> $(INSTALL_BINDIR)vpncmd
-	chmod 755 $(INSTALL_BINDIR)vpncmd
+$(DESTDIR)$(INSTALL_BINDIR)vpncmd: bin/vpncmd/hamcore.se2 bin/vpncmd/vpncmd
+	@mkdir -p $(DESTDIR)$(INSTALL_VPNCMD_DIR)
+	cp bin/vpncmd/hamcore.se2 $(DESTDIR)$(INSTALL_VPNCMD_DIR)hamcore.se2
+	cp bin/vpncmd/vpncmd $(DESTDIR)$(INSTALL_VPNCMD_DIR)vpncmd
+	echo "#!/bin/sh" > $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo $(INSTALL_VPNCMD_DIR)vpncmd '"$$@"' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	echo 'exit $$?' >> $(DESTDIR)$(INSTALL_BINDIR)vpncmd
+	chmod 755 $(DESTDIR)$(INSTALL_BINDIR)vpncmd
 
 # Clean
 clean:


### PR DESCRIPTION
Dear SoftEther Team,

I would like to propose the following adaptions to the makefiles to allow for staged install:
 - add `$(DESTDIR)` in front of every file being installed / dir being created
 - add necessary `mkdir` calls to create all parent directories, too

The above changes allow do to

```
$ ./configure
$ make
$ DESTDIR=/some/staged/install/area make install
$ package up the files for distribution
```

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?


- option 1

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

