### PR TITLE
Windows: suppress detailed build output

### DIFF
--- a/src/BuildAll.cmd
+++ b/src/BuildAll.cmd
@@ -24,9 +24,7 @@ if exist "%BATCH_DIR_NAME%\bin\BuildUtil.exe" (
 	del "%BATCH_DIR_NAME%\bin\BuildUtil.exe"
 )
 
-C:\windows\Microsoft.NET\Framework\v3.5\MSBuild.exe /toolsversion:3.5 /verbosity:detailed /target:Clean /property:Configuration=Debug "%BATCH_DIR_NAME%\BuildUtil\BuildUtil.csproj"
-
-C:\windows\Microsoft.NET\Framework\v3.5\MSBuild.exe /toolsversion:3.5 /verbosity:detailed /target:Rebuild /property:Configuration=Debug "%BATCH_DIR_NAME%\BuildUtil\BuildUtil.csproj"
+C:\windows\Microsoft.NET\Framework\v3.5\MSBuild.exe /toolsversion:3.5 /target:Clean;Rebuild /property:Configuration=Debug "%BATCH_DIR_NAME%\BuildUtil\BuildUtil.csproj"
 
 cd %BATCH_DIR_NAME%\bin
 

--- a/src/BuildUtil/Win32BuildUtil.cs
+++ b/src/BuildUtil/Win32BuildUtil.cs
@@ -627,19 +627,19 @@ namespace BuildUtil
 				StreamWriter bat = new StreamWriter(batFileName, false, Str.ShiftJisEncoding);
 				bat.WriteLine("call \"{0}\"", Paths.VisualStudioVCBatchFileName);
 				bat.WriteLine("echo on");
-				bat.WriteLine("\"{0}\" /toolsversion:3.5 /verbosity:detailed /target:Clean /property:Configuration=Release /property:Platform=Win32 \"{1}\"",
+				bat.WriteLine("\"{0}\" /toolsversion:3.5 /target:Clean /property:Configuration=Release /property:Platform=Win32 \"{1}\"",
 					Paths.MSBuildFileName, Paths.VPN4SolutionFileName);
 				bat.WriteLine("IF ERRORLEVEL 1 GOTO LABEL_ERROR");
 
-				bat.WriteLine("\"{0}\" /toolsversion:3.5 /verbosity:detailed /target:Clean /property:Configuration=Release /property:Platform=x64 \"{1}\"",
+				bat.WriteLine("\"{0}\" /toolsversion:3.5 /target:Clean /property:Configuration=Release /property:Platform=x64 \"{1}\"",
 					Paths.MSBuildFileName, Paths.VPN4SolutionFileName);
 				bat.WriteLine("IF ERRORLEVEL 1 GOTO LABEL_ERROR");
 
-				bat.WriteLine("\"{0}\" /toolsversion:3.5 /verbosity:detailed /target:Rebuild /property:Configuration=Release /property:Platform=Win32 \"{1}\"",
+				bat.WriteLine("\"{0}\" /toolsversion:3.5 /target:Rebuild /property:Configuration=Release /property:Platform=Win32 \"{1}\"",
 					Paths.MSBuildFileName, Paths.VPN4SolutionFileName);
 				bat.WriteLine("IF ERRORLEVEL 1 GOTO LABEL_ERROR");
 
-				bat.WriteLine("\"{0}\" /toolsversion:3.5 /verbosity:detailed /target:Rebuild /property:Configuration=Release /property:Platform=x64 \"{1}\"",
+				bat.WriteLine("\"{0}\" /toolsversion:3.5 /target:Rebuild /property:Configuration=Release /property:Platform=x64 \"{1}\"",
 					Paths.MSBuildFileName, Paths.VPN4SolutionFileName);
 				bat.WriteLine("IF ERRORLEVEL 1 GOTO LABEL_ERROR");
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - reduce app veyor build log from 29771 to 29009 lines
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

