### PR TITLE
Certificate date fixes

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -2134,6 +2134,9 @@ bool Asn1TimeToSystem(SYSTEMTIME *s, void *asn1_time)
 // Convert the string to the system time
 bool StrToSystem(SYSTEMTIME *s, char *str)
 {
+	char century[3] = {0, 0, 0};
+	bool fourdigityear = false;
+
 	// Validate arguments
 	if (s == NULL || str == NULL)
 	{
@@ -2141,7 +2144,14 @@ bool StrToSystem(SYSTEMTIME *s, char *str)
 	}
 	if (StrLen(str) != 13)
 	{
-		return false;
+		if (StrLen(str) != 15) return false;
+
+		//Year has 4 digits - save first two and use the rest
+		//as if it had two digits
+		fourdigityear = true;
+		century[0] = str[0];
+		century[1] = str[1];
+		str += 2;
 	}
 	if (str[12] != 'Z')
 	{
@@ -2158,7 +2168,10 @@ bool StrToSystem(SYSTEMTIME *s, char *str)
 			second[3] = {str[10], str[11], 0};
 		Zero(s, sizeof(SYSTEMTIME));
 		s->wYear = ToInt(year);
-		if (s->wYear >= 60)
+		if( fourdigityear ) {
+			s->wYear += ToInt(century) * 100;
+		}
+		else if (s->wYear >= 60)
 		{
 			s->wYear += 1900;
 		}

--- a/src/Mayaqua/Kernel.c
+++ b/src/Mayaqua/Kernel.c
@@ -2137,6 +2137,15 @@ UINT64 SystemToUINT64(SYSTEMTIME *st)
 	}
 
 	time = SystemToTime(st);
+
+	//For times before 1970-01-01, clamp to the minimum
+	//because we have to return an unsigned integer.
+	//This is less wrong than casting it to UINT64
+	//and returning a time far in the future.
+	//For some reason we subtract 9 hours below, so
+	//account for that here.
+	if( time < 32400000LL ) return 0;
+
 	sec64 = (UINT64)time * (UINT64)1000;
 	sec64 += st->wMilliseconds;
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - Two fixes regarding time usage on X509 certificates

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.