### PR TITLE
HubName has to be set after Copy

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -7392,8 +7392,8 @@ UINT StGetSecureNATOption(ADMIN *a, VH_OPTION *t)
 	}
 
 	Zero(t, sizeof(VH_OPTION));
-	StrCpy(t->HubName, sizeof(t->HubName), hubname);
 	Copy(t, h->SecureNATOption, sizeof(VH_OPTION));
+	StrCpy(t->HubName, sizeof(t->HubName), h->Name);
 	t->ApplyDhcpPushRoutes = true;
 
 	ReleaseHub(h);


### PR DESCRIPTION
Hubname has to be set after copy or it will be an empty string. To get the real hubname (correct casing) we use it directly from the hub instead of the given parameter

Changes proposed in this pull request:
 - Set hubName after copy from hub because otherwhise its an empty string

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- Option 1

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

