### PR TITLE
changelog was not correct from Launchpad point of view

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,4 +2,4 @@ softether-vpn (0:5.01.9657) unstable; urgency=low
 
   * Updated release version
 
- -- Ilya Shipitsin <chipitsine@gmail.com>  Mon, 11 Jun 2018 22:50:39 +05
+ -- Ilya Shipitsin <chipitsine@gmail.com>  Mon, 11 Jun 2018 17:50:39 +0000


### PR DESCRIPTION
Changes proposed in this pull request:
 - fix of Launchpad build (see https://launchpadlibrarian.net/376355504/buildlog.txt.gz)
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

