### PR TITLE
CMake: fix pthread detection

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,7 +128,7 @@ if(UNIX)
 
   add_definitions(-DUNIX)
 
-  find_library(LIB_PTHREAD pthread)
+  find_package(Threads)
   find_library(LIB_READLINE readline)
   find_library(LIB_NCURSES ncurses)
   find_library(LIB_Z z)
@@ -176,7 +176,7 @@ if(UNIX)
   endif()
 endif()
 
-target_link_libraries(mayaqua ${LIB_PTHREAD} ${LIB_SSL} ${LIB_CRYPTO} ${LIB_READLINE} ${LIB_NCURSES} ${LIB_Z})
+target_link_libraries(mayaqua ${CMAKE_THREAD_LIBS_INIT} ${LIB_SSL} ${LIB_CRYPTO} ${LIB_READLINE} ${LIB_NCURSES} ${LIB_Z})
 
 if(LIB_ICONV)
   target_link_libraries(mayaqua ${LIB_ICONV})


### PR DESCRIPTION
Changes proposed in this pull request:
 - don't treat pthreads like a normal lib
 - compile will fail on systems with musl or none stubed pthread

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- Option 1

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

