### PR TITLE
Encrypt.c: check whether OpenSSL compression and FIPS features are available

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -3679,7 +3679,9 @@ void FreeCryptLibrary()
 //	RAND_Free_For_SoftEther();
 	OpenSSL_FreeLock();
 
+#ifdef OPENSSL_FIPS
 	FIPS_mode_set(0);
+#endif
 	ENGINE_cleanup();
 	CONF_modules_unload(1);
 	EVP_cleanup();

--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -3690,7 +3690,9 @@ void FreeCryptLibrary()
 
 	ERR_free_strings();
 
+#ifndef OPENSSL_NO_COMP
 	SSL_COMP_free_compression_methods();
+#endif
 }
 
 // Initialize the Crypt library


### PR DESCRIPTION
Changes proposed in this pull request:
 -  FIPS mode and openssl compression could have been compiled out on target platform and results in undefined refs
 - added defines to check for `OPENSSL_FIPS` and `OPENSSL_NO_COMP`
 
Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- option 1

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.
