### PR TITLE
Unix.c: don't use hardcoded path to call "ethtool"

### DIFF
--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -364,7 +364,7 @@ void UnixDisableInterfaceOffload(char *name)
 		{
 			char *a = t->Token[i];
 
-			Format(tmp, sizeof(tmp), "/sbin/ethtool -K %s %s off 2>/dev/null", name, a);
+			Format(tmp, sizeof(tmp), "ethtool -K %s %s off 2>/dev/null", name, a);
 			FreeToken(UnixExec(tmp));
 		}
 	}


### PR DESCRIPTION
Fixes #300.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.