### PR TITLE
CMake: use find_package() and link Cedar to Ncurses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ before_install:
   - bash .ci/build-openssl.sh > build-deps.log 2>&1 || (cat build-deps.log && exit 1)
 
 script:
+  - export OPENSSL_ROOT_DIR=${OPENSSL_INSTALL_DIR}
   - export LD_LIBRARY_PATH="${HOME}/opt/lib:${LD_LIBRARY_PATH:-}"
   - export CFLAGS="-I${HOME}/opt/include"
   - export LDFLAGS="-L${HOME}/opt/lib"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.4.3)
 
 project(SoftEtherVPN LANGUAGES C)
 

--- a/configure
+++ b/configure
@@ -25,6 +25,14 @@ if [ ! -z ${CMAKE_INSTALL_PREFIX+x} ]; then
 	CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
 fi
 
+if [ -z ${OPENSSL_ROOT_DIR} ]; then
+	unameOut="$(uname -s)"
+	if [ "$unameOut" = "Darwin" ]; then
+		echo "Environment variable OPENSSL_ROOT_DIR not set, using default Homebrew path: /usr/local/opt/openssl/"
+		export OPENSSL_ROOT_DIR="/usr/local/opt/openssl/"
+	fi
+fi
+
 (cd tmp && cmake ${CMAKE_FLAGS} .. || exit 1)
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,8 +63,6 @@ if(UNIX)
 
   if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     add_definitions(-DUNIX_MACOS -DBRIDGE_PCAP)
-    include_directories(SYSTEM /usr/local/opt/openssl/include)
-    link_directories(SYSTEM /usr/local/opt/openssl/lib)
   endif()
 endif()
 

--- a/src/Cedar/CMakeLists.txt
+++ b/src/Cedar/CMakeLists.txt
@@ -10,6 +10,11 @@ set_target_properties(cedar
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp/Cedar"
 )
 
+find_library(LIB_READLINE readline)
+find_package(Curses REQUIRED)
+
+target_link_libraries(cedar ${LIB_READLINE} ${CURSES_LIBRARIES})
+
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
   target_link_libraries(cedar pcap)
 endif()

--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -12,26 +12,14 @@ set_target_properties(mayaqua
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp/Mayaqua"
 )
 
-find_package(Threads)
-find_library(LIB_READLINE readline)
-find_library(LIB_NCURSES ncurses)
-find_library(LIB_Z z)
+find_package(OpenSSL REQUIRED)
+find_package(Threads REQUIRED)
+find_package(ZLIB REQUIRED)
 
 # In some cases libiconv is not included in libc
 find_library(LIB_ICONV iconv)
 
-# This is required in order to link to the correct OpenSSL library
-find_library(LIB_SSL
-  NAMES ssl
-  HINTS "/usr/local/opt/openssl/lib"
-)
-
-find_library(LIB_CRYPTO
-  NAMES crypto
-  HINTS "/usr/local/opt/openssl/lib"
-)
-
-target_link_libraries(mayaqua ${CMAKE_THREAD_LIBS_INIT} ${LIB_SSL} ${LIB_CRYPTO} ${LIB_READLINE} ${LIB_NCURSES} ${LIB_Z})
+target_link_libraries(mayaqua OpenSSL::SSL OpenSSL::Crypto Threads::Threads ZLIB::ZLIB)
 
 if(LIB_ICONV)
   target_link_libraries(mayaqua ${LIB_ICONV})


### PR DESCRIPTION
Changes proposed in this pull request:
 - use "modern" cmake 3.4.3 _(released in 2015)_ lib features for better cross-platform lib detection
 - moved (readline, curses) libs to cedar

cmake docu:
https://cmake.org/cmake/help/v3.4/module/FindThreads.html
https://cmake.org/cmake/help/v3.4/module/FindOpenSSL.html
https://cmake.org/cmake/help/v3.4/module/FindCurses.html
https://cmake.org/cmake/help/v3.4/module/FindZLIB.html

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- Option 1

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

