### PR TITLE
Fixed typo in docs

### DIFF
--- a/src/BUILD_UNIX.md
+++ b/src/BUILD_UNIX.md
@@ -3,7 +3,7 @@ This document describes how to build SoftEtherVPN for Unix based Operating syste
 - [Requirements](#requirements)
   * [Install requirements on Centos/RedHat](#install-requirements-on-centosredhat)
   * [Install Requirements on Debian/Ubuntu](#install-requirements-on-debianubuntu)
-- [Build from source code and instal](#build-from-source-code-and-instal)
+- [Build from source code and install](#build-from-source-code-and-install)
 - [How to Run SoftEther](#how-to-run-softether)
   * [Start/Stop SoftEther VPN Server](#startstop-softether-vpn-server)
   * [Start/Stop SoftEther VPN Bridge](#startstop-softether-vpn-bridge)
@@ -40,7 +40,7 @@ sudo apt -y install cmake gcc libncurses5-dev libreadline-dev libssl-dev make zl
 ```
 
 
-# Build from source code and instal
+# Build from source code and install
 
 To build the programs from the source code, run the following commands:
 


### PR DESCRIPTION
Just a quick typo fix that was driving me mad :laughing: 


Changes proposed in this pull request:
 - 
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

-

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

