### PR TITLE
Mayaqua: use "cpu_features" to check whether AES-NI is supported

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/Mayaqua/cpu_features"]
+	path = src/Mayaqua/cpu_features
+	url = https://github.com/google/cpu_features.git

--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -19,7 +19,11 @@ find_package(ZLIB REQUIRED)
 # In some cases libiconv is not included in libc
 find_library(LIB_ICONV iconv)
 
-target_link_libraries(mayaqua OpenSSL::SSL OpenSSL::Crypto Threads::Threads ZLIB::ZLIB)
+add_subdirectory(cpu_features)
+
+target_include_directories(mayaqua PRIVATE cpu_features/include)
+
+target_link_libraries(mayaqua cpu_features OpenSSL::SSL OpenSSL::Crypto Threads::Threads ZLIB::ZLIB)
 
 if(LIB_ICONV)
   target_link_libraries(mayaqua ${LIB_ICONV})


### PR DESCRIPTION
Fixes #573.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.