### PR TITLE
Foreground logging

### DIFF
--- a/src/Cedar/Logging.c
+++ b/src/Cedar/Logging.c
@@ -2625,7 +2625,6 @@ void LogThread(THREAD *thread, void *param)
 	bool flag = false;
 	char current_file_name[MAX_SIZE];
 	char current_logfile_datename[MAX_SIZE];
-	bool last_priority_flag = false;
 	bool log_date_changed = false;
 	// Validate arguments
 	if (thread == NULL || param == NULL)
@@ -2729,23 +2728,15 @@ static bool LogThreadWriteGeneral(LOG *log_object, BUF *buffer, IO **io, bool *l
 	if (num >= LOG_ENGINE_SAVE_START_CACHE_COUNT)
 	{
 		// Raise the priority
-		if (last_priority_flag == false)
-		{
-			Debug("LOG_THREAD: MsSetThreadPriorityRealtime\n");
-			MsSetThreadPriorityRealtime();
-			last_priority_flag = true;
-		}
+		Debug("LOG_THREAD: MsSetThreadPriorityRealtime\n");
+		MsSetThreadPriorityRealtime();
 	}
 
 	if (num < (LOG_ENGINE_SAVE_START_CACHE_COUNT / 2))
 	{
 		// Restore the priority
-		if (last_priority_flag)
-		{
-			Debug("LOG_THREAD: MsSetThreadPriorityIdle\n");
-			MsSetThreadPriorityIdle();
-			last_priority_flag = false;
-		}
+		Debug("LOG_THREAD: MsSetThreadPriorityIdle\n");
+		MsSetThreadPriorityIdle();
 	}
 #endif	// OS_WIN32
 

--- a/src/Mayaqua/Mayaqua.c
+++ b/src/Mayaqua/Mayaqua.c
@@ -513,7 +513,12 @@ void InitMayaqua(bool memcheck, bool debug, int argc, char **argv)
 		// Fail this for some reason when this is called this in .NET mode
 		setbuf(stdout, NULL);
 	}
+
+#ifdef OS_UNIX
 	g_foreground = (argc >= 3 && StrCmpi(argv[2], UNIX_SVC_ARG_FOREGROUND) == 0);
+#else
+	g_foreground = false;
+#endif // OS_UNIX
 
 	// Acquisition whether NT
 #ifdef	OS_WIN32

--- a/src/Mayaqua/Mayaqua.c
+++ b/src/Mayaqua/Mayaqua.c
@@ -133,6 +133,7 @@ BOOL kernel_status_inited = false;				// Kernel state initialization flag
 bool g_little_endian = true;
 char *cmdline = NULL;							// Command line
 wchar_t *uni_cmdline = NULL;					// Unicode command line
+bool g_foreground = false;					// Execute service in foreground mode
 
 // Static variable
 static char *exename = NULL;						// EXE file name (ANSI)
@@ -512,6 +513,7 @@ void InitMayaqua(bool memcheck, bool debug, int argc, char **argv)
 		// Fail this for some reason when this is called this in .NET mode
 		setbuf(stdout, NULL);
 	}
+	g_foreground = (argc >= 3 && StrCmpi(argv[2], UNIX_SVC_ARG_FOREGROUND) == 0);
 
 	// Acquisition whether NT
 #ifdef	OS_WIN32

--- a/src/Mayaqua/Mayaqua.h
+++ b/src/Mayaqua/Mayaqua.h
@@ -395,6 +395,7 @@ extern char *cmdline;
 extern wchar_t *uni_cmdline;
 extern bool g_little_endian;
 extern LOCK *tick_manual_lock;
+extern bool g_foreground;
 
 // Kernel state
 #define	NUM_KERNEL_STATUS	128

--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -2849,6 +2849,12 @@ RESTART_PROCESS:
 			}
 		}
 	}
+	else if (argc >= 3 && StrCmpi(argv[1], UNIX_SVC_ARG_START) == 0 && StrCmpi(argv[2], UNIX_SVC_ARG_FOREGROUND) == 0)
+	{
+		InitMayaqua(false, false, argc, argv);
+		UnixExecService(name, start, stop);
+		FreeMayaqua();
+	}
 	else
 	{
 		// Start normally

--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -1703,6 +1703,23 @@ void *UnixFileOpen(char *name, bool write_mode, bool read_lock)
 	return (void *)p;
 }
 
+// Get UNIXIO object for stdout
+void* GetUnixio4Stdout()
+{
+	static UNIXIO unixio =
+	{
+		.fd = -1,
+		.write_mode = true
+	};
+
+	if (g_foreground)
+	{
+		unixio.fd = STDOUT_FILENO;
+		return &unixio;
+	}
+	return NULL;
+}
+
 // Return the current thread ID
 UINT UnixThreadId()
 {

--- a/src/Mayaqua/Unix.h
+++ b/src/Mayaqua/Unix.h
@@ -179,6 +179,7 @@ void *UnixFileOpen(char *name, bool write_mode, bool read_lock);
 void *UnixFileOpenW(wchar_t *name, bool write_mode, bool read_lock);
 void *UnixFileCreate(char *name);
 void *UnixFileCreateW(wchar_t *name);
+void *GetUnixio4Stdout();
 bool UnixFileWrite(void *pData, void *buf, UINT size);
 bool UnixFileRead(void *pData, void *buf, UINT size);
 void UnixFileClose(void *pData, bool no_flush);

--- a/src/Mayaqua/Unix.h
+++ b/src/Mayaqua/Unix.h
@@ -141,6 +141,7 @@ typedef void (SERVICE_FUNCTION)();
 #define	UNIX_SVC_ARG_STOP				"stop"
 #define	UNIX_SVC_ARG_EXEC_SVC			"execsvc"
 #define	UNIX_ARG_EXIT					"exit"
+#define UNIX_SVC_ARG_FOREGROUND				"--foreground"
 
 #define	UNIX_SVC_MODE_START				1
 #define	UNIX_SVC_MODE_STOP				2

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -1072,7 +1072,7 @@ SVC_HIDE_TRAY_MSG		This will hide the tasktray icons when starting %S in user mo
 
 
 # Concerning services (UNIX)
-UNIX_SVC_HELP			%S service program\nCopyright (c) SoftEther VPN Project. All Rights Reserved.\n\n%S command usage:\n %S start  - Start the %S service.\n %S stop   - Stop the %S service if the service has been already started.\n\n
+UNIX_SVC_HELP			%S service program\nCopyright (c) SoftEther VPN Project. All Rights Reserved.\n\n%S command usage:\n %S start [--foreground] - Start the %S service. '--foreground' parameter prevents switching to daemon mode.\n %S stop   - Stop the %S service if the service has been already started.\n\n
 UNIX_SVC_STARTED		The %S service has been started.\n
 UNIX_SVC_STOPPING		Stopping the %S service ...\n
 UNIX_SVC_STOPPED		%S service has been stopped.\n


### PR DESCRIPTION
This is the first in couple of patches to make softether compatible with running inside an immutable, stateless, container. We currently run softether on top of kubernetes as a docker container and have run into a number of design decisions that make it very difficult.

In a containerized infrastructure, it is almost a rule that processes do not daemonize and direct their logging output to stdout. This is because the container process runs as PID 0 inside the container, and the process's stdout is collected by the infrastructure logging facility.

Changes proposed in this pull request:
 - Create a `--foreground` command line option so that the service does not daemonize
 - In foreground mode the service will log only to stdout and not to log files

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- We are fine with our code being used in proprietary products under the terms of a BSD/MIT-like OSS license.

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

