### PR TITLE
recursive git checkout for launchpad

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,7 @@ export export CMAKE_INSTALL_PREFIX=../debian/usr
 	dh $@ 
 
 override_dh_auto_configure:
+	git submodule update --init --recursive
 	cmake .
 
 override_dh_auto_install:


### PR DESCRIPTION
Changes proposed in this pull request:
 - launchpad does not support git submodules by itself, so we need to add git modules checkout by ourselves
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

