### PR TITLE
ignore temp cmake files, check whether cloned recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ cmake-build-debug/
 src/bin/BuiltHamcoreFiles/
 tmp/
 .gitconfig
-
-
+CMakeCache.txt
+CMakeFiles/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,9 @@ project(SoftEtherVPN LANGUAGES C)
 
 set(default_build_type "Release")
 
+# Check that submodules are present only if source was downloaded with git
+if(EXISTS "${SoftEtherVPN_SOURCE_DIR}/.git" AND NOT EXISTS "${SoftEtherVPN_SOURCE_DIR}/src/Mayaqua/cpu_features/CMakeLists.txt")
+    message (FATAL_ERROR "Submodules are not initialized. Run\n\tgit submodule update --init --recursive")
+endif()
+
 add_subdirectory(src)


### PR DESCRIPTION
check whether cloned recursively during cmake build

Changes proposed in this pull request:
 - additional error message if cloned without submodules
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

