### PR TITLE
add debian package builds to gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,35 @@
+.ubuntu: &ubuntu_def
+  before_script:
+    - apt-get update && apt-get install -y debhelper devscripts fakeroot ${CMAKE} dh-exec gcc libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev git
+  script:
+    - debuild -i -us -uc -b
+
+bionic: 
+  <<: *ubuntu_def
+  image: ubuntu:bionic
+  variables:     
+    CMAKE: cmake
+
+xenial:     
+  <<: *ubuntu_def
+  image: ubuntu:xenial
+  variables:     
+    CMAKE: cmake
+
+trusty:      
+  <<: *ubuntu_def
+  image: ubuntu:trusty
+  variables:     
+    CMAKE: cmake3
+
+
+#
+# there's no cmake3 for 12.04
+# maybe, there's ppa ?
+#
+#precise:
+#  <<: *ubuntu_def
+#  image: ubuntu:precise
+#  variables:
+#    CMAKE: cmake3
+


### PR DESCRIPTION
Changes proposed in this pull request:
 - ubuntu package builds for 14.04, 16.04, 18.04 on gitlab.com
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

