### PR TITLE
launchpad builds: add "git" as a build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: softether-vpn
 Section: net
 Priority: optional
 Maintainer: Dmitry Orlov <me@mosquito.su>
-Build-Depends: debhelper (>= 7.0.50~), libncurses5-dev, linux-libc-dev, libssl-dev, zlib1g-dev, libreadline-dev, build-essential, cmake3 | cmake, dh-exec
+Build-Depends: debhelper (>= 7.0.50~), libncurses5-dev, linux-libc-dev, libssl-dev, zlib1g-dev, libreadline-dev, build-essential, cmake3 | cmake, dh-exec, git
 Standards-Version: 3.9.1
 Homepage: http://www.softether.org/
 


### PR DESCRIPTION
(we need it to checkout submodules)

Changes proposed in this pull request:
 - specify "git" as build dependency for debian packages (required for submodules checkout)
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

