### PR TITLE
Change 'Don't use TLS' to 'Use SSL 3.0' to clarify the danger.

### DIFF
--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -2332,7 +2332,7 @@ S_RETRY_NUM_2				次
 S_RETRY_SPAN_1				重连间隔(&K):
 S_RETRY_SPAN_2				秒
 R_INFINITE					无限重连(总是保持 VPN 在线) (&I)
-R_NOTLS1					不要使用 TLS &1.0
+R_NOTLS1					使用 SSL 3.0 (&1)
 B_DETAIL					高级设置(&D)...
 IDOK						确定(&O)
 IDCANCEL					取消

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -2312,7 +2312,7 @@ S_RETRY_NUM_2			times
 S_RETRY_SPAN_1			Reconnect Interval:
 S_RETRY_SPAN_2			seconds
 R_INFINITE				&Infinite Reconnects (Keep VPN Always Online)
-R_NOTLS1				Do not use TLS &1.0
+R_NOTLS1				Use SSL 3.0 (&1)
 B_DETAIL				A&dvanced Settings...
 IDOK					&OK
 IDCANCEL				Cancel

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -2317,7 +2317,7 @@ S_RETRY_NUM_2			回
 S_RETRY_SPAN_1			再接続間隔(&K):
 S_RETRY_SPAN_2			秒
 R_INFINITE				無限に再接続を試行する (常時接続) (&I)
-R_NOTLS1				TLS &1.0 を使用しない
+R_NOTLS1				SSL 3.0 を使用する(&1)
 B_DETAIL				高度な通信設定(&N)...
 IDOK					&OK
 IDCANCEL				キャンセル

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -2312,7 +2312,7 @@ S_RETRY_NUM_2 회
 S_RETRY_SPAN_1 다시 연결 간격 (&K):
 S_RETRY_SPAN_2 초
 R_INFINITE 무한 재 연결을 시도하는 (상시 접속) (&I)
-R_NOTLS1 TLS 및 1.0을 사용하지
+R_NOTLS1 사용 SSL 3.0(&1)
 B_DETAIL 고급 통신 설정 (&N)...
 IDOK & OK
 IDCANCEL 취소

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -2333,7 +2333,7 @@ S_RETRY_NUM_2			次
 S_RETRY_SPAN_1			重連間隔(&K):
 S_RETRY_SPAN_2			秒
 R_INFINITE				無限重連(總是保持 VPN 線上) (&I)
-R_NOTLS1				不要使用 TLS &1.0
+R_NOTLS1				使用 SSL 3.0 (&1)
 B_DETAIL				進階設置(&D)...
 IDOK					確定(&O)
 IDCANCEL				取消


### PR DESCRIPTION
Committer: MtCedarNet <mtcedar@hotmail.com>

Changes proposed in this pull request:
- The notation 'Do not use TLS 1.0' on the UI is currently misleading as it supports TLS 1.1 or later, so modify it to the notation 'Use SSL 3.0'.

Could you please choose either option 1 or 2, and specify it clearly on the reply?

- choose 1

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

