### PR TITLE
musl support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ if(UNIX)
 
   if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     add_definitions(-DUNIX_LINUX)
-    if($ENV{USE_MUSL} STREQUAL "YES")
+    if("$ENV{USE_MUSL}" STREQUAL "YES")
       add_definitions(-DUNIX_LINUX_MUSL)
     endif()
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,9 @@ if(UNIX)
 
   if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     add_definitions(-DUNIX_LINUX)
+    if($ENV{USE_MUSL} STREQUAL "YES")
+      add_definitions(-DUNIX_LINUX_MUSL)
+    endif()
   endif()
 
   if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")

--- a/src/Mayaqua/Internat.c
+++ b/src/Mayaqua/Internat.c
@@ -789,11 +789,11 @@ void InitInternational()
 	d = IconvWideToStrInternal();
 	if (d == (void *)-1)
 	{
-#ifdef	UNIX_MACOS
+#if defined (UNIX_MACOS) || defined (UNIX_LINUX_MUSL)
 		StrCpy(charset, sizeof(charset), "utf-8");
-#else	// UNIX_MACOS
+#else // defined (UNIX_MACOS) || defined (UNIX_LINUX_MUSL) 
 		StrCpy(charset, sizeof(charset), "EUCJP");
-#endif	// UNIX_MACOS
+#endif // defined (UNIX_MACOS) || defined (UNIX_LINUX_MUSL) 
 		d = IconvWideToStrInternal();
 		if (d == (void *)-1)
 		{


### PR DESCRIPTION
As previous discussion on my previous pull request, I implemented musl support (which is a small change in Internat.c file) using conditional compilation, so that default behaviour is unchanged, and using a new environment variable allows musl compilation to work.

Summary of previous discussion:
- musl has a bug in iconv() function, which cause softether to compile correctly, but exhibit a bad runtime behaviour: any string conversion fails because iconv initialization fails early;
- to correct this bug, I used the same workaround that was already used to compile on macOS, see Internat.c diff and this is self-evident;
- workaround is triggered compile-time by the UNIX_LINUX_MUSL #define flag;
- cmake has been modified to add the -DUNIX_LINUX_MUSL command line flag to gcc when the environment variable USE_MUSL is set to YES

So, build on musl with that commands:

export USE_MUSL=YES
./configure
make -C tmp

I have tested this patch on alpine linux and produces working executables.

About vpn patch acceptance, for me option 1 is ok.

Is this PR ok for anybody?
Thanks!

Davide




Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

-

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

