### PR TITLE
Cedar: fix implicit function declaration warnings

### DIFF
--- a/src/Cedar/Console.c
+++ b/src/Cedar/Console.c
@@ -2048,7 +2048,11 @@ bool PasswordPrompt(char *password, UINT size)
 		else if (c == 0xE0)
 		{
 			// Read one more character
+#ifdef	OS_WIN32
 			c = getch();
+#else	// OS_WIN32
+			c = getc(stdin);
+#endif	// OS_WIN32
 			if (c == 0x4B || c == 0x53)
 			{
 				// Backspace

--- a/src/Cedar/VLanUnix.h
+++ b/src/Cedar/VLanUnix.h
@@ -131,6 +131,7 @@ struct VLAN
 VLAN *NewVLan(char *instance_name, VLAN_PARAM *param);
 VLAN *NewTap(char *name, char *mac_address, bool create_up);
 void FreeVLan(VLAN *v);
+void FreeTap(VLAN *v);
 CANCEL *VLanGetCancel(VLAN *v);
 bool VLanGetNextPacket(VLAN *v, void **buf, UINT *size);
 bool VLanPutPacket(VLAN *v, void *buf, UINT size);


### PR DESCRIPTION
```c
In file included from /builds/SoftEther/SoftEtherVPN/src/Cedar/Bridge.c:130:0:
/builds/SoftEther/SoftEtherVPN/src/Cedar/BridgeUnix.c: In function 'CloseEth':
/builds/SoftEther/SoftEtherVPN/src/Cedar/BridgeUnix.c:1568:3: warning: implicit declaration of function 'FreeTap'; did you mean 'FreeCaps'? [-Wimplicit-function-declaration]
   FreeTap(e->Tap);
   ^~~~~~~
   FreeCaps
```
```c
/builds/SoftEther/SoftEtherVPN/src/Cedar/Console.c: In function 'PasswordPrompt':
/builds/SoftEther/SoftEtherVPN/src/Cedar/Console.c:2051:8: warning: implicit declaration of function 'getch'; did you mean 'getc'? [-Wimplicit-function-declaration]
    c = getch();
        ^~~~~
        getc
```

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.