### PR TITLE
configure: stop on any error

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo '---------------------------------------------------------------------'
 echo 'SoftEther VPN for Unix'
 echo


### PR DESCRIPTION
Changes proposed in this pull request:
 - add "set -e" to configure in order to stop build on any error
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

