### PR TITLE
Add recursive checkout to gitlab-ci, also specify g++ as build dependency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 .ubuntu: &ubuntu_def
   before_script:
-    - apt-get update && apt-get install -y debhelper devscripts fakeroot ${CMAKE} dh-exec gcc libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev git
+    - apt-get update && apt-get install -y ${CMAKE} g++ gcc libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev git file
+    - git submodule update --init --recursive
   script:
     - ./configure
     - make package -C tmp

--- a/src/BUILD_UNIX.md
+++ b/src/BUILD_UNIX.md
@@ -36,7 +36,7 @@ sudo yum -y install cmake ncurses-devel openssl-devel readline-devel zlib-devel
 
 ## Install Requirements on Debian/Ubuntu
 ```bash
-sudo apt -y install cmake gcc libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev
+sudo apt -y install cmake gcc g++ libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev
 ```
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - Add recursive checkout to gitlab-ci, also specify g++ as build dependency
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

