### PR TITLE
Interop_OpenVPN.c: convert the cipher name to lowercase prior to calling EVP_get_cipherbyname()

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -513,6 +513,7 @@ CIPHER *NewCipher(char *name)
 	c->Cipher = EVP_get_cipherbyname(c->Name);
 	if (c->Cipher == NULL)
 	{
+		Debug("NewCipher(): Cipher %s not found by EVP_get_cipherbyname().\n", c->Name);
 		FreeCipher(c);
 		return NULL;
 	}


### PR DESCRIPTION
OpenVPN sends the cipher name in uppercase, even if it's not standard, thus we have to convert it to lowercase for `EVP_get_cipherbyname()`.

We also have to send the cipher name as it was received from the OpenVPN client, unless it's a different cipher, to prevent a message such as:
```
WARNING: 'cipher' is used inconsistently, local='cipher AES-128-GCM', remote='cipher aes-128-gcm'
```
It happens because OpenVPN uses `strcmp()` to compare the local and remote parameters: https://github.com/OpenVPN/openvpn/blob/a6fd48ba36ede465b0905a95568c3ec0d425ca71/src/openvpn/options.c#L3819-L3831

See openssl/openssl#6921 for `EVP_get_cipherbyname()`.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.