### PR TITLE
Encrypt: support NULL message digest

### DIFF
--- a/src/Mayaqua/Encrypt.h
+++ b/src/Mayaqua/Encrypt.h
@@ -359,6 +359,7 @@ struct CIPHER
 struct MD
 {
 	char Name[MAX_PATH];
+	bool isNullMd;
 	const struct evp_md_st *Md;
 	struct hmac_ctx_st *Ctx;
 	UINT Size;


### PR DESCRIPTION
This is in preparation for the GCM ciphers support (OpenVPN).

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.