### PR TITLE
src/BUILD_UNIX.md: Reorder commands of SE manual build with musl

### DIFF
--- a/src/BUILD_UNIX.md
+++ b/src/BUILD_UNIX.md
@@ -64,8 +64,8 @@ To build the programs from the source code when using musl as libc, run the foll
 ```bash
 export USE_MUSL=YES
 git clone https://github.com/SoftEtherVPN/SoftEtherVPN.git
-git submodule init && git submodule update
 cd SoftEtherVPN
+git submodule init && git submodule update
 ./configure
 make -C tmp
 make -C tmp install


### PR DESCRIPTION
Changes proposed in this pull request:
 - reorder "cd ..." and "git submodule" commands
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

