### PR TITLE
Mayaqua/Encrypt.c: fix invalid features.aes for mips, ppc

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -4289,11 +4289,9 @@ bool IsAesNiSupported()
 		const Aarch64Features features = GetAarch64Info().features;
 		supported = features.aes;
 	#elif defined(CPU_FEATURES_ARCH_MIPS)
-		const MipsFeatures features = GetMipsInfo().features;
-		supported = features.aes;
+		//const MipsFeatures features = GetMipsInfo().features;  // no features.aes
 	#elif defined(CPU_FEATURES_ARCH_PPC)
-		const PPCFeatures features = GetPPCInfo().features;
-		supported = features.aes;
+		//const PPCFeatures features = GetPPCInfo().features;  // no features.aes
 	#endif
 #endif // _MSC_VER
 


### PR DESCRIPTION
Changes proposed in this pull request:

* fix invalid features.aes for mips, ppc (fixes #651)

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

option 1

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

