### PR TITLE
GitLab: compile and install latest version of CMake

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,10 @@
 .ubuntu: &ubuntu_def
   before_script:
-    - apt-get update && apt-get install -y ${CMAKE} g++ gcc libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev git file
-    - git submodule update --init --recursive
+    - REPOSITORY="$PWD" && cd ..
+    - apt-get update && apt-get install -y g++ gcc libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev git file
+    - wget https://cmake.org/files/v3.12/cmake-3.12.1.tar.gz && tar -xzvf cmake-3.12.1.tar.gz
+    - cd cmake-3.12.1 && ./bootstrap && make install
+    - cd "$REPOSITORY" && git submodule update --init --recursive
   script:
     - ./configure
     - make package -C tmp


### PR DESCRIPTION
`CMakeLists.txt` requires at least CMake 3.6, but Ubuntu Trusty and Xenial have 3.5.1.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.