### PR TITLE
src/Cedar/EtherLog: remove null dereference introduced in #650

### DIFF
--- a/src/Cedar/EtherLog.c
+++ b/src/Cedar/EtherLog.c
@@ -281,7 +281,7 @@ PACK *ElRpcServer(RPC *r, char *name, PACK *p)
 	UINT err;
 	bool ok;
 	// Validate arguments
-	if (r == NULL || name == NULL || p == NULL || e == NULL)
+	if (r == NULL || name == NULL || p == NULL || r->Param == NULL)
 	{
 		return NULL;
 	}
@@ -1364,20 +1364,5 @@ void ElStop()
 		el = NULL;
 	}
 	Unlock(el_lock);
-}
-
-// EL initialization
-void ElInit()
-{
-	// Lock initialization
-	el_lock = NewLock();
-}
-
-// EL release
-void ElFree()
-{
-	// Lock release
-	DeleteLock(el_lock);
-	el_lock = NULL;
 }
 

--- a/src/Cedar/EtherLog.h
+++ b/src/Cedar/EtherLog.h
@@ -205,8 +205,6 @@ struct EL
 };
 
 // Function prototype
-void ElInit();
-void ElFree();
 void ElStart();
 void ElStop();
 EL *NewEl();


### PR DESCRIPTION
Changes proposed in this pull request:
 - it is wrong to use "e == NULL" in https://github.com/SoftEtherVPN/SoftEtherVPN/blob/master/src/Cedar/EtherLog.c#L284, it should be "r->Param == NULL"
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

