### PR TITLE
GitLab: install "wget"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 .ubuntu: &ubuntu_def
   before_script:
     - REPOSITORY="$PWD" && cd ..
-    - apt-get update && apt-get install -y g++ gcc libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev git file
+    - apt-get update && apt-get install -y wget g++ gcc libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev git file
     - wget https://cmake.org/files/v3.12/cmake-3.12.1.tar.gz && tar -xzvf cmake-3.12.1.tar.gz
     - cd cmake-3.12.1 && ./bootstrap && make install
     - cd "$REPOSITORY" && git submodule update --init --recursive


### PR DESCRIPTION
It's used to download the CMake source code archive from its website.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.