### PR TITLE
resolve cosmetic coverity issues

### DIFF
--- a/src/Cedar/EtherLog.c
+++ b/src/Cedar/EtherLog.c
@@ -240,7 +240,7 @@ UINT EcConnect(char *host, UINT port, char *password, RPC **rpc)
 
 	// Receive the random number
 	Zero(rand, sizeof(rand));
-	RecvAll(s, rand, sizeof(rand), false);
+	(void)RecvAll(s, rand, sizeof(rand), false);
 	SecurePassword(response, password_hash, rand);
 
 	// Send a response
@@ -324,7 +324,6 @@ DECLARE_SC("GetDevice", RPC_ADD_DEVICE, EcGetDevice, InRpcAddDevice, OutRpcAddDe
 DECLARE_SC_EX("EnumDevice", RPC_ENUM_DEVICE, EcEnumDevice, InRpcEnumDevice, OutRpcEnumDevice, FreeRpcEnumDevice)
 DECLARE_SC("SetPassword", RPC_SET_PASSWORD, EcSetPassword, InRpcSetPassword, OutRpcSetPassword)
 DECLARE_SC_EX("EnumAllDevice", RPC_ENUM_DEVICE, EcEnumAllDevice, InRpcEnumDevice, OutRpcEnumDevice, FreeRpcEnumDevice)
-DECLARE_SC("AddLicenseKey", RPC_TEST, EcAddLicenseKey, InRpcTest, OutRpcTest)
 DECLARE_SC("DelLicenseKey", RPC_TEST, EcDelLicenseKey, InRpcTest, OutRpcTest)
 DECLARE_SC_EX("EnumLicenseKey", RPC_ENUM_LICENSE_KEY, EcEnumLicenseKey, InRpcEnumLicenseKey, OutRpcEnumLicenseKey, FreeRpcEnumLicenseKey)
 DECLARE_SC("GetLicenseStatus", RPC_EL_LICENSE_STATUS, EcGetLicenseStatus, InRpcElLicenseStatus, OutRpcElLicenseStatus)
@@ -379,11 +378,6 @@ UINT EtGetBridgeSupport(EL *a, RPC_BRIDGE_SUPPORT *t)
 	t->IsWinPcapNeeded = IsNeedWinPcap();
 
 	return ERR_NO_ERROR;
-}
-
-// Update the status by checking the all licenses
-void ElCheckLicense(EL_LICENSE_STATUS *st, LICENSE *e)
-{
 }
 
 // Save by analyzing the status of the current license
@@ -755,7 +749,7 @@ void ElListenerProc(THREAD *thread, void *param)
 	// Receive a response
 	SecurePassword(pass1, e->HashedPassword, rand);
 	Zero(pass2, sizeof(pass2));
-	RecvAll(s, pass2, sizeof(pass2), false);
+	(void)RecvAll(s, pass2, sizeof(pass2), false);
 
 	if (Cmp(pass1, pass2, SHA1_SIZE) != 0)
 	{

--- a/src/Cedar/EtherLog.h
+++ b/src/Cedar/EtherLog.h
@@ -225,7 +225,6 @@ void ElStartListener(EL *e);
 void ElStopListener(EL *e);
 void ElListenerProc(THREAD *thread, void *param);
 PACK *ElRpcServer(RPC *r, char *name, PACK *p);
-void ElCheckLicense(EL_LICENSE_STATUS *st, LICENSE *e);
 void ElParseCurrentLicenseStatus(LICENSE_SYSTEM *s, EL_LICENSE_STATUS *st);
 bool ElIsBetaExpired();
 
@@ -251,7 +250,6 @@ UINT EcGetDevice(RPC *r, RPC_ADD_DEVICE *t);
 UINT EcEnumDevice(RPC *r, RPC_ENUM_DEVICE *t);
 UINT EcEnumAllDevice(RPC *r, RPC_ENUM_DEVICE *t);
 UINT EcSetPassword(RPC *r, RPC_SET_PASSWORD *t);
-UINT EcAddLicenseKey(RPC *r, RPC_TEST *t);
 UINT EcDelLicenseKey(RPC *r, RPC_TEST *t);
 UINT EcEnumLicenseKey(RPC *r, RPC_ENUM_LICENSE_KEY *t);
 UINT EcGetLicenseStatus(RPC *r, RPC_EL_LICENSE_STATUS *t);


### PR DESCRIPTION
Changes proposed in this pull request:
 - coverity warns to "check" return value of function
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

