### PR TITLE
src/Cedar/Client.c: remove redundant "if" statement, unused variable

### DIFF
--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -497,13 +497,11 @@ bool CnIsCnServiceReady()
 // Check whether the notification service is already running
 bool CnCheckAlreadyExists(bool lock)
 {
-	bool ret = false;
-
 #ifdef	OS_WIN32
-	ret = Win32CnCheckAlreadyExists(lock);
+	return Win32CnCheckAlreadyExists(lock);
+#else
+	return false;
 #endif
-
-	return ret;
 }
 
 typedef struct CNC_STATUS_PRINTER_WINDOW_PARAM
@@ -9091,7 +9089,6 @@ void CiSetVLanToDefault(CLIENT *c)
 	}
 #else	// OS_WIN32
 	{
-		UINT i;
 		UNIX_VLAN *v;
 
 		LockList(c->UnixVLanList);
@@ -9163,16 +9160,8 @@ void CiInitConfiguration(CLIENT *c)
 		// Clear the password
 		Hash(c->EncryptedPassword, "", 0, true);
 		// Initialize the client configuration
-		if (OS_IS_WINDOWS(GetOsInfo()->OsType))
-		{
-			// Disable remote management in Windows
-			c->Config.AllowRemoteConfig = false;
-		}
-		else
-		{
-			// Disable the remote management also in case of UNIX
-			c->Config.AllowRemoteConfig = false;
-		}
+		// Disable remote management
+		c->Config.AllowRemoteConfig = false;
 		StrCpy(c->Config.KeepConnectHost, sizeof(c->Config.KeepConnectHost), CLIENT_DEFAULT_KEEPALIVE_HOST);
 		c->Config.KeepConnectPort = CLIENT_DEFAULT_KEEPALIVE_PORT;
 		c->Config.KeepConnectProtocol = CONNECTION_UDP;


### PR DESCRIPTION


[src/Cedar/Client.c:9094]: (style) Unused variable: i
[src/Cedar/Client.c:500] -> [src/Cedar/Client.c:503]: (style) Variabl
Changes proposed in this pull request:
 - remove redundant "if"
 - remove unused variable
 - one

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

-

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

