### PR TITLE
Added Try+Except block for ProbeForRead

### DIFF
--- a/src/Neo6/NDIS6.c
+++ b/src/Neo6/NDIS6.c
@@ -634,18 +634,25 @@ NTSTATUS NeoNdisDispatch(DEVICE_OBJECT *DeviceObject, IRP *Irp)
 						{
 							MmProbeAndLockPages(mdl, KernelMode, IoReadAccess);
 						}
-
-						ProbeForRead(buf, NEO_EXCHANGE_BUFFER_SIZE, 1);
-
-						// Write
-						NeoWrite(buf);
-						Irp->IoStatus.Information = stack->Parameters.Write.Length;
-						ok = true;
-
-						if (mdl != NULL)
+						__try
 						{
+							ProbeForRead(buf, NEO_EXCHANGE_BUFFER_SIZE, 1);	
+						}
+						__except (EXCEPTION_EXECUTE_HANDLER)
+						{
+							check_ok = false;	
+						}
+						if (check_ok) {
+							// Write
+							NeoWrite(buf);
+							Irp->IoStatus.Information = stack->Parameters.Write.Length;
+							ok = true;
+
+							if (mdl != NULL)
+							{
 							MmUnlockPages(mdl);
 							IoFreeMdl(mdl);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Possible security problem under double-fetch conditions. Microsoft says all ProbeForRead calls should be treated as if they could throw exceptions.  SRC: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-probeforread
I choose Contribution option (1) 