### PR TITLE
Unix.c: remove macOS-specific UnixGetTick64() implementation

### DIFF
--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -128,8 +128,6 @@
 #include <Mayaqua/Mayaqua.h>
 
 #ifdef	UNIX_MACOS
-#include <mach/clock.h>
-#include <mach/mach.h>
 #ifdef	NO_VLAN
 // Struct statfs for MacOS X
 typedef struct fsid { int32_t val[2]; } fsid_t;
@@ -2092,22 +2090,8 @@ UINT64 UnixGetTick64()
 	}
 
 	return ret;
-
-#else
-#ifdef	UNIX_MACOS
-	static clock_serv_t clock_serv = 0;
-	mach_timespec_t t;
-	UINT64 ret;
-	if (clock_serv == 0) {
-		host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &clock_serv);
-	}
-	clock_get_time(clock_serv, &t);
-	ret = ((UINT64)((UINT32)t.tv_sec)) * 1000LL + (UINT64)t.tv_nsec / 1000000LL;
-	return ret;
 #else
 	return TickRealtimeManual();
-#endif
-
 #endif
 }
 


### PR DESCRIPTION
`clock_gettime()` was implemented in macOS 10.12.

This may also fix #47, as @Schouwenburg mentioned that the server started crashing after updating to version `4.06.9433`, which contains 4c48388b1235faa91cf377a8d238871cb5184e3b:
https://github.com/SoftEtherVPN/SoftEtherVPN/blob/e530932df61d2e6a1c5b07374c9817d5cdc4295b/src/Mayaqua/Unix.c#L2097-L2109

Resources are not freed, as `mach_port_deallocate()` is never called.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.