### PR TITLE
Cedar: custom TAP interface name support for FreeBSD, function refactor

### DIFF
--- a/src/Cedar/Cedar.h
+++ b/src/Cedar/Cedar.h
@@ -744,20 +744,14 @@
 // 
 //////////////////////////////////////////////////////////////////////
 
+#ifndef	UNIX_BSD
 #define	TAP_FILENAME_1				"/dev/net/tun"
 #define	TAP_FILENAME_2				"/dev/tun"
-#ifdef	UNIX_BSD
-#ifdef	NO_VLAN
-#define	TAP_BSD_FILENAME			"/dev/tap0"
-#else	// NO_VLAN
-#define	TAP_BSD_FILENAME			"tap"
-#endif	// NO_VLAN
-#define	TAP_BSD_DIR				"/dev/"
-#define	TAP_BSD_NUMBER			(16)
-#endif	// UNIX_MACOS
-
-
-
+#else	// UNIX_BSD
+#define	TAP_NAME					"tap"
+#define	TAP_DIR						"/dev/"
+#define	TAP_MAX						(512)
+#endif	// UNIX_BSD
 
 
 #define	LICENSE_EDITION_VPN3_NO_LICENSE					0		// Without license


### PR DESCRIPTION
Changes proposed in this pull request:
 - Add custom TAP interface name support for FreeBSD.
 - Increase the maximum number of TAP devices to iterate through from 16 to 512.
 - Refactor `UnixCreateTapDeviceEx()`.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.