### PR TITLE
Cedar: fix segmentation fault during local bridge creation on FreeBSD

### DIFF
--- a/src/Cedar/BridgeUnix.c
+++ b/src/Cedar/BridgeUnix.c
@@ -1492,7 +1492,7 @@ ETH *OpenEthBpf(char *name, bool local, bool tapmode, char *tapaddr)
 #endif // BRIDGE_BPF
 
 #ifdef UNIX_BSD
-ETH *OpenEthBSD(name, local, tapmode, tapaddr)
+ETH *OpenEthBSD(char *name, bool local, bool tapmode, char *tapaddr)
 {
 	if (tapmode)
 	{


### PR DESCRIPTION
Fixes #674.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.