### PR TITLE
src/Mayaqua/Unix: remove unused code, improve readability of "ifdef"

### DIFF
--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -2060,12 +2060,6 @@ UINT64 UnixGetTick64()
 
 	struct timespec t;
 	UINT64 ret;
-	static bool akirame = false;
-
-	if (akirame)
-	{
-		return TickRealtimeManual();
-	}
 
 	Zero(&t, sizeof(t));
 
@@ -2073,20 +2067,17 @@ UINT64 UnixGetTick64()
 	// Be careful. The Implementation is depend on the system.
 #ifdef	CLOCK_HIGHRES
 	clock_gettime(CLOCK_HIGHRES, &t);
-#else	// CLOCK_HIGHRES
-#ifdef	CLOCK_MONOTONIC
+#elif	CLOCK_MONOTONIC
 	clock_gettime(CLOCK_MONOTONIC, &t);
-#else	// CLOCK_MONOTONIC
+#else
 	clock_gettime(CLOCK_REALTIME, &t);
-#endif	// CLOCK_MONOTONIC
-#endif	// CLOCK_HIGHRES
+#endif
 
 	ret = ((UINT64)((UINT32)t.tv_sec)) * 1000LL + (UINT64)t.tv_nsec / 1000000LL;
 
-	if (akirame == false && ret == 0)
+	if (ret == 0)
 	{
 		ret = TickRealtimeManual();
-		akirame = true;
 	}
 
 	return ret;


### PR DESCRIPTION
refactoring was discussed in PR#672

Changes proposed in this pull request:
 - unused variable removed
 - readability of ifdef improved
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

