### PR TITLE
Cedar: replace "Interop_" and "IPsec_" with "Proto_" in the protocol-specific source/header files' names

### DIFF
--- a/src/Cedar/Cedar.h
+++ b/src/Cedar/Cedar.h
@@ -1108,7 +1108,7 @@ typedef struct CEDAR
 #include <Cedar/Sam.h>
 // Radius authentication module
 #include <Cedar/Radius.h>
-// Protocol
+// Native protocol
 #include <Cedar/Protocol.h>
 // Inter-HUB link
 #include <Cedar/Link.h>
@@ -1126,19 +1126,18 @@ typedef struct CEDAR
 #include <Cedar/Command.h>
 // RPC over HTTP
 #include <Cedar/Wpc.h>
-// IPsec
-#include <Cedar/IPsec.h>
-#include <Cedar/IPsec_L2TP.h>
-#include <Cedar/IPsec_PPP.h>
-#include <Cedar/IPsec_IPC.h>
-#include <Cedar/IPsec_IkePacket.h>
-#include <Cedar/IPsec_IKE.h>
-#include <Cedar/IPsec_Win7.h>
-#include <Cedar/IPsec_EtherIP.h>
-// SSTP
-#include <Cedar/Interop_SSTP.h>
-// OpenVPN
-#include <Cedar/Interop_OpenVPN.h>
+// Layer-2/Layer-3 converter
+#include <Cedar/IPC.h>
+// Third party protocols
+#include <Cedar/Proto_IPsec.h>
+#include <Cedar/Proto_EtherIP.h>
+#include <Cedar/Proto_IkePacket.h>
+#include <Cedar/Proto_IKE.h>
+#include <Cedar/Proto_L2TP.h>
+#include <Cedar/Proto_OpenVPN.h>
+#include <Cedar/Proto_PPP.h>
+#include <Cedar/Proto_SSTP.h>
+#include <Cedar/Proto_Win7.h>
 // UDP Acceleration
 #include <Cedar/UdpAccel.h>
 // DDNS Client

--- a/src/Cedar/Cedar.vcproj
+++ b/src/Cedar/Cedar.vcproj
@@ -583,76 +583,8 @@
 				>
 			</File>
 			<File
-				RelativePath=".\Interop_OpenVPN.c"
+				RelativePath=".\IPC.c"
 				>
-			</File>
-			<File
-				RelativePath=".\Interop_SSTP.c"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec.c"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_EtherIP.c"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_IKE.c"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_IkePacket.c"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_IPC.c"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_L2TP.c"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_PPP.c"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_Win7.c"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						UsePrecompiledHeader="0"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						UsePrecompiledHeader="0"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						UsePrecompiledHeader="0"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						UsePrecompiledHeader="0"
-					/>
-				</FileConfiguration>
 			</File>
 			<File
 				RelativePath=".\Layer3.c"
@@ -717,6 +649,74 @@
 			<File
 				RelativePath=".\NullLan.c"
 				>
+			</File>
+			<File
+				RelativePath=".\Proto_EtherIP.c"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_IKE.c"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_IkePacket.c"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_IPsec.c"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_L2TP.c"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_OpenVPN.c"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_PPP.c"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_SSTP.c"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_Win7.c"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						UsePrecompiledHeader="0"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						UsePrecompiledHeader="0"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						UsePrecompiledHeader="0"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						UsePrecompiledHeader="0"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath=".\Protocol.c"
@@ -1241,47 +1241,7 @@
 				>
 			</File>
 			<File
-				RelativePath=".\Interop_OpenVPN.h"
-				>
-			</File>
-			<File
-				RelativePath=".\Interop_SSTP.h"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec.h"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_EtherIP.h"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_IKE.h"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_IkePacket.h"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_IPC.h"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_L2TP.h"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_PPP.h"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_Win7.h"
-				>
-			</File>
-			<File
-				RelativePath=".\IPsec_Win7Inner.h"
+				RelativePath=".\IPC.h"
 				>
 			</File>
 			<File
@@ -1318,6 +1278,46 @@
 			</File>
 			<File
 				RelativePath=".\NullLan.h"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_EtherIP.h"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_IKE.h"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_IkePacket.h"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_IPsec.h"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_L2TP.h"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_OpenVPN.h"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_PPP.h"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_SSTP.h"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_Win7.h"
+				>
+			</File>
+			<File
+				RelativePath=".\Proto_Win7Inner.h"
 				>
 			</File>
 			<File

--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -108,7 +108,7 @@
 // test has been passed before release this source code.
 
 
-// IPsec_IPC.c
+// IPC.c
 // In-process VPN client module
 
 #include "CedarPch.h"

--- a/src/Cedar/IPC.h
+++ b/src/Cedar/IPC.h
@@ -108,11 +108,11 @@
 // test has been passed before release this source code.
 
 
-// IPsec_IPC.h
-// Header of IPsec_IPC.c
+// IPC.h
+// Header of IPC.c
 
-#ifndef	IPSEC_IPC
-#define	IPSEC_IPC
+#ifndef	IPC_H
+#define	IPC_H
 
 // Constants
 #define	IPC_ARP_LIFETIME				(3 * 60 * 1000)
@@ -263,7 +263,4 @@ void FreeIPCAsync(IPC_ASYNC *a);
 
 bool ParseAndExtractMsChapV2InfoFromPassword(IPC_MSCHAP_V2_AUTHINFO *d, char *password);
 
-#endif	// IPSEC_IPC
-
-
-
+#endif	// IPC_H

--- a/src/Cedar/Proto_EtherIP.c
+++ b/src/Cedar/Proto_EtherIP.c
@@ -108,7 +108,7 @@
 // test has been passed before release this source code.
 
 
-// IPsec_EtherIP.c
+// Proto_EtherIP.c
 // EtherIP protocol stack
 
 #include "CedarPch.h"

--- a/src/Cedar/Proto_EtherIP.h
+++ b/src/Cedar/Proto_EtherIP.h
@@ -108,11 +108,11 @@
 // test has been passed before release this source code.
 
 
-// IPsec_EtherIP.h
-// Header of IPsec_EtherIP.c
+// Proto_EtherIP.h
+// Header of Proto_EtherIP.c
 
-#ifndef	IPSEC_ETHERIP_H
-#define	IPSEC_ETHERIP_H
+#ifndef	PROTO_ETHERIP_H
+#define	PROTO_ETHERIP_H
 
 //// Macro
 
@@ -171,6 +171,4 @@ void EtherIPIpcConnectThread(THREAD *t, void *p);
 UINT CalcEtherIPTcpMss(ETHERIP_SERVER *s);
 
 
-#endif	// IPSEC_ETHERIP_H
-
-
+#endif	// PROTO_ETHERIP_H

--- a/src/Cedar/Proto_IKE.c
+++ b/src/Cedar/Proto_IKE.c
@@ -108,7 +108,7 @@
 // test has been passed before release this source code.
 
 
-// IPsec_IKE.c
+// Proto_IKE.c
 // IKE (ISAKMP) and ESP protocol stack
 
 #include "CedarPch.h"

--- a/src/Cedar/Proto_IKE.h
+++ b/src/Cedar/Proto_IKE.h
@@ -108,11 +108,11 @@
 // test has been passed before release this source code.
 
 
-// IPsec_IKE.h
-// Header of IPsec_IKE.c
+// Proto_IKE.h
+// Header of Proto_IKE.c
 
-#ifndef	IPSEC_IKE_H
-#define	IPSEC_IKE_H
+#ifndef	PROTO_IKE_H
+#define	PROTO_IKE_H
 
 //// Macro
 
@@ -472,5 +472,5 @@ void ProcL2TPv3PacketRecv(IKE_SERVER *ike, IKE_CLIENT *c, UCHAR *data, UINT data
 
 IKE_SA *SearchIkeSaByCookie(IKE_SERVER *ike, UINT64 init_cookie, UINT64 resp_cookie);
 
-#endif	// IPSEC_IKE_H
+#endif	// PROTO_IKE_H
 

--- a/src/Cedar/Proto_IPsec.c
+++ b/src/Cedar/Proto_IPsec.c
@@ -108,7 +108,7 @@
 // test has been passed before release this source code.
 
 
-// IPsec.c
+// Proto_IPsec.c
 // IPsec module
 
 #include "CedarPch.h"

--- a/src/Cedar/Proto_IPsec.h
+++ b/src/Cedar/Proto_IPsec.h
@@ -108,79 +108,98 @@
 // test has been passed before release this source code.
 
 
-// IPsec_Win7.h
-// Internal header of IPsec_Win7.c
+// Proto_IPsec.h
+// Header of Proto_IPsec.c
 
-#ifndef	IPSEC_WIN7_INNER_H
-#define	IPSEC_WIN7_INNER_H
+#ifndef	PROTO_IPSEC_H
+#define	PROTO_IPSEC_H
 
-// API function
-typedef struct IPSEC_WIN7_FUNCTIONS
+//// Constants
+
+// UDP port number
+#define	IPSEC_PORT_L2TP					1701		// L2TP
+#define	IPSEC_PORT_IPSEC_ISAKMP			500			// ISAKMP
+#define	IPSEC_PORT_IPSEC_ESP_UDP		4500		// IPsec ESP over UDP
+#define	IPSEC_PORT_IPSEC_ESP_RAW		MAKE_SPECIAL_PORT(50)	// Raw mode ESP Protocol No: 50
+#define	IPSEC_PORT_IPSEC_ESP_RAW_WPF	MAKE_SPECIAL_PORT(52)	// Raw mode ESP Protocol No: 52 (WPF)
+#define	IPSEC_PORT_L2TPV3_VIRTUAL		1000001		// L2TPv3 virtual port
+
+// IP protocol number
+#define	IPSEC_IP_PROTO_ETHERIP			IP_PROTO_ETHERIP	// EtherIP
+#define	IPSEC_IP_PROTO_L2TPV3			IP_PROTO_L2TPV3		// L2TPv3
+
+// WFP tag
+#define	WFP_ESP_PACKET_TAG_1		0x19841117
+#define	WFP_ESP_PACKET_TAG_2		0x1accafe1
+
+// Monitoring interval of OS service
+#define	IPSEC_CHECK_OS_SERVICE_INTERVAL_INITIAL	1024
+#define	IPSEC_CHECK_OS_SERVICE_INTERVAL_MAX		(5 * 60 * 1000)
+
+// Default IPsec pre-shared key
+#define	IPSEC_DEFAULT_SECRET			"vpn"
+
+
+//// Type
+
+// List of services provided by IPsec server
+struct IPSEC_SERVICES
 {
-	DWORD (WINAPI *FwpmEngineOpen0)(
-		IN OPTIONAL const wchar_t* serverName,
-		IN UINT32 authnService,
-		IN OPTIONAL SEC_WINNT_AUTH_IDENTITY_W* authIdentity,
-		IN OPTIONAL const FWPM_SESSION0* session,
-		OUT HANDLE* engineHandle
-		);
+	bool L2TP_Raw;								// Raw L2TP
+	bool L2TP_IPsec;							// L2TP over IPsec
+	bool EtherIP_IPsec;							// EtherIP over IPsec
 
-	DWORD (WINAPI *FwpmEngineClose0)(IN HANDLE engineHandle);
+	char IPsec_Secret[MAX_SIZE];				// IPsec pre-shared key
+	char L2TP_DefaultHub[MAX_SIZE];				// Default Virtual HUB name for L2TP connection
+};
 
-	void (WINAPI *FwpmFreeMemory0)(IN OUT void** p);
-
-	DWORD (WINAPI *FwpmFilterAdd0)(
-		IN HANDLE engineHandle,
-		IN const FWPM_FILTER0* filter,
-		IN OPTIONAL PSECURITY_DESCRIPTOR sd,
-		OUT OPTIONAL UINT64* id
-		);
-
-	DWORD (WINAPI *IPsecSaContextCreate0)(
-		IN HANDLE engineHandle,
-		IN const IPSEC_TRAFFIC0* outboundTraffic,
-		OUT OPTIONAL UINT64* inboundFilterId,
-		OUT UINT64* id
-		);
-
-	DWORD (WINAPI *IPsecSaContextGetSpi0)(
-		IN HANDLE engineHandle,
-		IN UINT64 id,
-		IN const IPSEC_GETSPI0* getSpi,
-		OUT IPSEC_SA_SPI* inboundSpi
-		);
-
-	DWORD (WINAPI *IPsecSaContextAddInbound0)(
-		IN HANDLE engineHandle,
-		IN UINT64 id,
-		IN const IPSEC_SA_BUNDLE0* inboundBundle
-		);
-
-	DWORD (WINAPI *IPsecSaContextAddOutbound0)(
-		IN HANDLE engineHandle,
-		IN UINT64 id,
-		IN const IPSEC_SA_BUNDLE0* outboundBundle
-		);
-
-	DWORD (WINAPI *FwpmCalloutAdd0)(
-		IN HANDLE engineHandle,
-		IN const FWPM_CALLOUT0* callout,
-		IN OPTIONAL PSECURITY_DESCRIPTOR sd,
-		OUT OPTIONAL UINT32* id
-		);
-
-} IPSEC_WIN7_FUNCTIONS;
-
-// Instance
-struct IPSEC_WIN7
+// EtherIP key list entry
+struct ETHERIP_ID
 {
-	HANDLE hEngine;
-	HANDLE hDriverFile;
-	UINT64 FilterIPv4Id, FilterIPv6Id;
+	char Id[MAX_SIZE];							// ID
+	char HubName[MAX_HUBNAME_LEN + 1];			// Virtual HUB name
+	char UserName[MAX_USERNAME_LEN + 1];		// User name
+	char Password[MAX_USERNAME_LEN + 1];		// Password
+};
+
+// IPsec server
+struct IPSEC_SERVER
+{
+	CEDAR *Cedar;
+	UDPLISTENER *UdpListener;
+	bool Halt;
+	bool NoMoreChangeSettings;
+	LOCK *LockSettings;
+	IPSEC_SERVICES Services;
+	L2TP_SERVER *L2TP;							// L2TP server
+	IKE_SERVER *Ike;							// IKE server
+	LIST *EtherIPIdList;						// EtherIP setting list
+	UINT EtherIPIdListSettingVerNo;				// EtherIP setting list version number
+	THREAD *OsServiceCheckThread;				// OS Service monitoring thread
+	EVENT *OsServiceCheckThreadEvent;			// Event for OS Service monitoring thread
+	IPSEC_WIN7 *Win7;							// Helper module for Windows Vista / 7
+	bool Check_LastEnabledStatus;
+	bool HostIPAddressListChanged;
+	bool OsServiceStoped;
 };
 
 
-#endif	// IPSEC_WIN7_INNER_H
+//// Function prototype
+IPSEC_SERVER *NewIPsecServer(CEDAR *cedar);
+void FreeIPsecServer(IPSEC_SERVER *s);
+void IPsecServerUdpPacketRecvProc(UDPLISTENER *u, LIST *packet_list);
+void IPsecServerSetServices(IPSEC_SERVER *s, IPSEC_SERVICES *sl);
+void IPsecNormalizeServiceSetting(IPSEC_SERVER *s);
+void IPsecServerGetServices(IPSEC_SERVER *s, IPSEC_SERVICES *sl);
+void IPsecProcPacket(IPSEC_SERVER *s, UDPPACKET *p);
+int CmpEtherIPId(void *p1, void *p2);
+bool SearchEtherIPId(IPSEC_SERVER *s, ETHERIP_ID *id, char *id_str);
+void AddEtherIPId(IPSEC_SERVER *s, ETHERIP_ID *id);
+bool DeleteEtherIPId(IPSEC_SERVER *s, char *id_str);
+void IPsecOsServiceCheckThread(THREAD *t, void *p);
+bool IPsecCheckOsService(IPSEC_SERVER *s);
+void IPSecSetDisable(bool b);
 
 
+#endif	// PROTO_IPSEC_H
 

--- a/src/Cedar/Proto_IkePacket.c
+++ b/src/Cedar/Proto_IkePacket.c
@@ -108,7 +108,7 @@
 // test has been passed before release this source code.
 
 
-// IPsec_IkePacket.c
+// Proto_IkePacket.c
 // IKE (ISAKMP) packet processing
 
 #include "CedarPch.h"

--- a/src/Cedar/Proto_IkePacket.h
+++ b/src/Cedar/Proto_IkePacket.h
@@ -108,11 +108,11 @@
 // test has been passed before release this source code.
 
 
-// IPsec_IkePacket.h
-// Header of IPsec_IkePacket.c
+// Proto_IkePacket.h
+// Header of Proto_IkePacket.c
 
-#ifndef	IPSEC_PACKET_H
-#define	IPSEC_PACKET_H
+#ifndef	PROTO_IKEPACKET_H
+#define	PROTO_IKEPACKET_H
 
 // Constants
 #ifdef	OS_WIN32
@@ -768,6 +768,4 @@ DH_CTX *IkeDhNewCtx(IKE_DH *d);
 void IkeDhFreeCtx(DH_CTX *dh);
 
 
-#endif	// IPSEC_PACKET_H
-
-
+#endif	// PROTO_IKEPACKET_H

--- a/src/Cedar/Proto_L2TP.c
+++ b/src/Cedar/Proto_L2TP.c
@@ -108,7 +108,7 @@
 // test has been passed before release this source code.
 
 
-// IPsec_L2TP.c
+// Proto_L2TP.c
 // L2TP protocol stack
 
 #include "CedarPch.h"

--- a/src/Cedar/Proto_L2TP.h
+++ b/src/Cedar/Proto_L2TP.h
@@ -108,11 +108,11 @@
 // test has been passed before release this source code.
 
 
-// IPsec_L2TP.h
-// Header of IPsec_L2TP.c
+// Proto_L2TP.h
+// Header of Proto_L2TP.c
 
-#ifndef	IPSEC_L2TP_H
-#define	IPSEC_L2TP_H
+#ifndef	PROTO_L2TP_H
+#define	PROTO_L2TP_H
 
 //// Macro
 
@@ -378,6 +378,4 @@ UINT GenerateNewSessionIdForL2TPv3(L2TP_SERVER *l2tp);
 L2TP_SESSION *SearchL2TPSessionById(L2TP_SERVER *l2tp, bool is_v3, UINT id);
 void L2TPSessionManageEtherIPServer(L2TP_SERVER *l2tp, L2TP_SESSION *s);
 
-#endif	// IPSEC_L2TP_H
-
-
+#endif	// PROTO_L2TP_H

--- a/src/Cedar/Proto_OpenVPN.c
+++ b/src/Cedar/Proto_OpenVPN.c
@@ -108,7 +108,7 @@
 // test has been passed before release this source code.
 
 
-// Interop_OpenVPN.c
+// Proto_OpenVPN.c
 // OpenVPN protocol stack
 
 #include "CedarPch.h"

--- a/src/Cedar/Proto_OpenVPN.h
+++ b/src/Cedar/Proto_OpenVPN.h
@@ -108,11 +108,11 @@
 // test has been passed before release this source code.
 
 
-// Interop_OpenVPN.h
-// Header of Interop_OpenVPN.c
+// Proto_OpenVPN.h
+// Header of Proto_OpenVPN.c
 
-#ifndef	INTEROP_OPENVPN_H
-#define	INTEROP_OPENVPN_H
+#ifndef	PROTO_OPENVPN_H
+#define	PROTO_OPENVPN_H
 
 
 //// Constants
@@ -380,6 +380,4 @@ void OpenVpnServerUdpSetDhParam(OPENVPN_SERVER_UDP *u, DH_CTX *dh);
 
 
 
-#endif	// INTEROP_OPENVPN_H
-
-
+#endif	// PROTO_OPENVPN_H

--- a/src/Cedar/Proto_PPP.c
+++ b/src/Cedar/Proto_PPP.c
@@ -108,7 +108,7 @@
 // test has been passed before release this source code.
 
 
-// IPsec_PPP.c
+// Proto_PPP.c
 // PPP protocol stack
 
 #include "CedarPch.h"

--- a/src/Cedar/Proto_PPP.h
+++ b/src/Cedar/Proto_PPP.h
@@ -108,11 +108,11 @@
 // test has been passed before release this source code.
 
 
-// IPsec_PPP.h
-// Header of IPsec_PPP.c
+// Proto_PPP.h
+// Header of Proto_PPP.c
 
-#ifndef	IPSEC_PPP_H
-#define	IPSEC_PPP_H
+#ifndef	PROTO_PPP_H
+#define	PROTO_PPP_H
 
 
 //// Macro
@@ -336,6 +336,4 @@ bool MsChapV2VerityPassword(IPC_MSCHAP_V2_AUTHINFO *d, char *password);
 char *MsChapV2DoBruteForce(IPC_MSCHAP_V2_AUTHINFO *d, LIST *password_list);
 void PPPFreeEapClient(PPP_SESSION *p);
 
-#endif	// IPSEC_PPP_H
-
-
+#endif	// PROTO_PPP_H

--- a/src/Cedar/Proto_SSTP.c
+++ b/src/Cedar/Proto_SSTP.c
@@ -108,7 +108,7 @@
 // test has been passed before release this source code.
 
 
-// Interop_SSTP.c
+// Proto_SSTP.c
 // SSTP (Microsoft Secure Socket Tunneling Protocol) protocol stack
 
 #include "CedarPch.h"

--- a/src/Cedar/Proto_SSTP.h
+++ b/src/Cedar/Proto_SSTP.h
@@ -108,11 +108,11 @@
 // test has been passed before release this source code.
 
 
-// Interop_SSTP.h
-// Header of Interop_SSTP.c
+// Proto_SSTP.h
+// Header of Proto_SSTP.c
 
-#ifndef	INTEROP_SSTP_H
-#define	INTEROP_SSTP_H
+#ifndef	PROTO_SSTP_H
+#define	PROTO_SSTP_H
 
 //// Constants
 #define	SSTP_URI				"/sra_{BA195980-CD49-458b-9E23-C84EE0ADCD75}/"		// SSTP HTTPS URI
@@ -259,6 +259,4 @@ void SstpSendPacket(SSTP_SERVER *s, SSTP_PACKET *p);
 bool GetNoSstp();
 void SetNoSstp(bool b);
 
-#endif	// INTEROP_SSTP_H
-
-
+#endif	// PROTO_SSTP_H

--- a/src/Cedar/Proto_Win7.c
+++ b/src/Cedar/Proto_Win7.c
@@ -108,7 +108,7 @@
 // test has been passed before release this source code.
 
 
-// IPsec_Win7.c
+// Proto_Win7.c
 // Initialize the helper module for Windows 7 / Windows 8 / Windows Vista / Windows Server 2008 / Windows Server 2008 R2 / Windows Server 2012 / Windows 10
 
 #include <GlobalConst.h>
@@ -137,7 +137,7 @@
 #include <errno.h>
 #include <Mayaqua/Mayaqua.h>
 #include <Cedar/Cedar.h>
-#include "IPsec_Win7Inner.h"
+#include "Proto_Win7Inner.h"
 #include <Wfp/Wfp.h>
 
 static IPSEC_WIN7_FUNCTIONS *api = NULL;

--- a/src/Cedar/Proto_Win7.h
+++ b/src/Cedar/Proto_Win7.h
@@ -108,11 +108,11 @@
 // test has been passed before release this source code.
 
 
-// IPsec_Win7.h
-// Header of IPsec_Win7.c
+// Proto_Win7.h
+// Header of Proto_Win7.c
 
-#ifndef	IPSEC_WIN7_H
-#define	IPSEC_WIN7_H
+#ifndef	PROTO_WIN7_H
+#define	PROTO_WIN7_H
 
 // Constants
 #define	IPSEC_WIN7_SRC_SYS_X86	"|pxwfp_x86.sys"
@@ -142,7 +142,4 @@ void SetCurrentIPsecWin7DriverBuild();
 bool IPsecWin7InitApi();
 
 
-#endif	// IPSEC_WIN7_H
-
-
-
+#endif	// PROTO_WIN7_H

--- a/src/Cedar/Proto_Win7Inner.h
+++ b/src/Cedar/Proto_Win7Inner.h
@@ -108,98 +108,76 @@
 // test has been passed before release this source code.
 
 
-// IPsec.h
-// Header of IPsec.c
+// Proto_Win7Inner.h
+// Internal header of Proto_Win7.c
 
-#ifndef	IPSEC_H
-#define	IPSEC_H
+#ifndef	PROTO_WIN7_INNER_H
+#define	PROTO_WIN7_INNER_H
 
-//// Constants
-
-// UDP port number
-#define	IPSEC_PORT_L2TP					1701		// L2TP
-#define	IPSEC_PORT_IPSEC_ISAKMP			500			// ISAKMP
-#define	IPSEC_PORT_IPSEC_ESP_UDP		4500		// IPsec ESP over UDP
-#define	IPSEC_PORT_IPSEC_ESP_RAW		MAKE_SPECIAL_PORT(50)	// Raw mode ESP Protocol No: 50
-#define	IPSEC_PORT_IPSEC_ESP_RAW_WPF	MAKE_SPECIAL_PORT(52)	// Raw mode ESP Protocol No: 52 (WPF)
-#define	IPSEC_PORT_L2TPV3_VIRTUAL		1000001		// L2TPv3 virtual port
-
-// IP protocol number
-#define	IPSEC_IP_PROTO_ETHERIP			IP_PROTO_ETHERIP	// EtherIP
-#define	IPSEC_IP_PROTO_L2TPV3			IP_PROTO_L2TPV3		// L2TPv3
-
-// WFP tag
-#define	WFP_ESP_PACKET_TAG_1		0x19841117
-#define	WFP_ESP_PACKET_TAG_2		0x1accafe1
-
-// Monitoring interval of OS service
-#define	IPSEC_CHECK_OS_SERVICE_INTERVAL_INITIAL	1024
-#define	IPSEC_CHECK_OS_SERVICE_INTERVAL_MAX		(5 * 60 * 1000)
-
-// Default IPsec pre-shared key
-#define	IPSEC_DEFAULT_SECRET			"vpn"
-
-
-//// Type
-
-// List of services provided by IPsec server
-struct IPSEC_SERVICES
+// API function
+typedef struct IPSEC_WIN7_FUNCTIONS
 {
-	bool L2TP_Raw;								// Raw L2TP
-	bool L2TP_IPsec;							// L2TP over IPsec
-	bool EtherIP_IPsec;							// EtherIP over IPsec
+	DWORD (WINAPI *FwpmEngineOpen0)(
+		IN OPTIONAL const wchar_t* serverName,
+		IN UINT32 authnService,
+		IN OPTIONAL SEC_WINNT_AUTH_IDENTITY_W* authIdentity,
+		IN OPTIONAL const FWPM_SESSION0* session,
+		OUT HANDLE* engineHandle
+		);
 
-	char IPsec_Secret[MAX_SIZE];				// IPsec pre-shared key
-	char L2TP_DefaultHub[MAX_SIZE];				// Default Virtual HUB name for L2TP connection
-};
+	DWORD (WINAPI *FwpmEngineClose0)(IN HANDLE engineHandle);
 
-// EtherIP key list entry
-struct ETHERIP_ID
+	void (WINAPI *FwpmFreeMemory0)(IN OUT void** p);
+
+	DWORD (WINAPI *FwpmFilterAdd0)(
+		IN HANDLE engineHandle,
+		IN const FWPM_FILTER0* filter,
+		IN OPTIONAL PSECURITY_DESCRIPTOR sd,
+		OUT OPTIONAL UINT64* id
+		);
+
+	DWORD (WINAPI *IPsecSaContextCreate0)(
+		IN HANDLE engineHandle,
+		IN const IPSEC_TRAFFIC0* outboundTraffic,
+		OUT OPTIONAL UINT64* inboundFilterId,
+		OUT UINT64* id
+		);
+
+	DWORD (WINAPI *IPsecSaContextGetSpi0)(
+		IN HANDLE engineHandle,
+		IN UINT64 id,
+		IN const IPSEC_GETSPI0* getSpi,
+		OUT IPSEC_SA_SPI* inboundSpi
+		);
+
+	DWORD (WINAPI *IPsecSaContextAddInbound0)(
+		IN HANDLE engineHandle,
+		IN UINT64 id,
+		IN const IPSEC_SA_BUNDLE0* inboundBundle
+		);
+
+	DWORD (WINAPI *IPsecSaContextAddOutbound0)(
+		IN HANDLE engineHandle,
+		IN UINT64 id,
+		IN const IPSEC_SA_BUNDLE0* outboundBundle
+		);
+
+	DWORD (WINAPI *FwpmCalloutAdd0)(
+		IN HANDLE engineHandle,
+		IN const FWPM_CALLOUT0* callout,
+		IN OPTIONAL PSECURITY_DESCRIPTOR sd,
+		OUT OPTIONAL UINT32* id
+		);
+
+} IPSEC_WIN7_FUNCTIONS;
+
+// Instance
+struct IPSEC_WIN7
 {
-	char Id[MAX_SIZE];							// ID
-	char HubName[MAX_HUBNAME_LEN + 1];			// Virtual HUB name
-	char UserName[MAX_USERNAME_LEN + 1];		// User name
-	char Password[MAX_USERNAME_LEN + 1];		// Password
-};
-
-// IPsec server
-struct IPSEC_SERVER
-{
-	CEDAR *Cedar;
-	UDPLISTENER *UdpListener;
-	bool Halt;
-	bool NoMoreChangeSettings;
-	LOCK *LockSettings;
-	IPSEC_SERVICES Services;
-	L2TP_SERVER *L2TP;							// L2TP server
-	IKE_SERVER *Ike;							// IKE server
-	LIST *EtherIPIdList;						// EtherIP setting list
-	UINT EtherIPIdListSettingVerNo;				// EtherIP setting list version number
-	THREAD *OsServiceCheckThread;				// OS Service monitoring thread
-	EVENT *OsServiceCheckThreadEvent;			// Event for OS Service monitoring thread
-	IPSEC_WIN7 *Win7;							// Helper module for Windows Vista / 7
-	bool Check_LastEnabledStatus;
-	bool HostIPAddressListChanged;
-	bool OsServiceStoped;
+	HANDLE hEngine;
+	HANDLE hDriverFile;
+	UINT64 FilterIPv4Id, FilterIPv6Id;
 };
 
 
-//// Function prototype
-IPSEC_SERVER *NewIPsecServer(CEDAR *cedar);
-void FreeIPsecServer(IPSEC_SERVER *s);
-void IPsecServerUdpPacketRecvProc(UDPLISTENER *u, LIST *packet_list);
-void IPsecServerSetServices(IPSEC_SERVER *s, IPSEC_SERVICES *sl);
-void IPsecNormalizeServiceSetting(IPSEC_SERVER *s);
-void IPsecServerGetServices(IPSEC_SERVER *s, IPSEC_SERVICES *sl);
-void IPsecProcPacket(IPSEC_SERVER *s, UDPPACKET *p);
-int CmpEtherIPId(void *p1, void *p2);
-bool SearchEtherIPId(IPSEC_SERVER *s, ETHERIP_ID *id, char *id_str);
-void AddEtherIPId(IPSEC_SERVER *s, ETHERIP_ID *id);
-bool DeleteEtherIPId(IPSEC_SERVER *s, char *id_str);
-void IPsecOsServiceCheckThread(THREAD *t, void *p);
-bool IPsecCheckOsService(IPSEC_SERVER *s);
-void IPSecSetDisable(bool b);
-
-
-#endif	// IPSEC_H
-
+#endif	// PROTO_WIN7_INNER_H


### PR DESCRIPTION
Changes proposed in this pull request:

 - Rename `IPsec_IPC` to `IPC`, as it's not related to third-party protocols.
 - Replace `Interop_` and `IPsec_` with `Proto_` in the protocol-specific source/header files' names so that it's clear that they are all third-party protocols.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.