### PR TITLE
Revamp digest functions

### DIFF
--- a/src/Cedar/Account.c
+++ b/src/Cedar/Account.c
@@ -701,7 +701,7 @@ void HashPassword(void *dst, char *username, char *password)
 	StrUpper(username_upper);
 	WriteBuf(b, password, StrLen(password));
 	WriteBuf(b, username_upper, StrLen(username_upper));
-	Hash(dst, b->Buf, b->Size, true);
+	Sha0(dst, b->Buf, b->Size);
 
 	FreeBuf(b);
 	Free(username_upper);

--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -8018,7 +8018,7 @@ UINT StSetHub(ADMIN *a, RPC_CREATE_HUB *t)
 	{
 		UCHAR hash1[SHA1_SIZE], hash2[SHA1_SIZE];
 		HashPassword(hash1, ADMINISTRATOR_USERNAME, "");
-		Hash(hash2, "", 0, true);
+		Sha0(hash2, "", 0);
 
 		if (Cmp(t->HashedPassword, hash2, SHA1_SIZE) == 0 || Cmp(t->SecurePassword, hash1, SHA1_SIZE) == 0)
 		{
@@ -13602,7 +13602,7 @@ void HashAdminPassword(void *hash, char *password)
 		return;
 	}
 
-	Hash(hash, password, StrLen(password), true);
+	Sha0(hash, password, StrLen(password));
 }
 
 // Disconnect admin connection
@@ -13823,7 +13823,7 @@ bool SiIsEmptyPassword(void *hash_password)
 		return false;
 	}
 
-	Hash(hash, "", 0, true);
+	Sha0(hash, "", 0);
 
 	if (Cmp(hash_password, hash, SHA1_SIZE) == 0)
 	{

--- a/src/Cedar/Bridge.c
+++ b/src/Cedar/Bridge.c
@@ -150,7 +150,7 @@ UINT GetEthDeviceHash()
 	}
 	FreeToken(t);
 
-	Hash(hash, tmp, StrLen(tmp), true);
+	Sha0(hash, tmp, StrLen(tmp));
 
 	Copy(&num, hash, sizeof(UINT));
 
@@ -174,7 +174,7 @@ UINT GetEthDeviceHash()
 	}
 	MsFreeAdapterList(a);
 
-	Hash(hash, tmp, StrLen(tmp), true);
+	Sha0(hash, tmp, StrLen(tmp));
 
 	Copy(&num, hash, sizeof(UINT));
 

--- a/src/Cedar/BridgeWin32.c
+++ b/src/Cedar/BridgeWin32.c
@@ -1337,7 +1337,7 @@ UINT Win32EthGenIdFromGuid(char *guid)
 	Trim(tmp);
 	StrUpper(tmp);
 
-	HashSha1(hash, tmp, StrLen(tmp));
+	Sha1(hash, tmp, StrLen(tmp));
 
 	Copy(&i, hash, sizeof(UINT));
 

--- a/src/Cedar/CM.c
+++ b/src/Cedar/CM.c
@@ -1166,7 +1166,7 @@ void CmSettingDlgUpdate(HWND hWnd, CM_SETTING_DLG *d)
 		bool password_ok = false;
 		UCHAR hash[SHA1_SIZE];
 
-		Hash(hash, tmp1, StrLen(tmp1), true);
+		Sha0(hash, tmp1, StrLen(tmp1));
 		if (Cmp(hash, d->HashedPassword, sizeof(hash)) == 0)
 		{
 			password_ok = true;
@@ -1221,7 +1221,7 @@ void CmSettingDlgOnOk(HWND hWnd, CM_SETTING_DLG *d)
 		{
 			if (StrLen(tmp1) >= 1)
 			{
-				Hash(a.HashedPassword, tmp1, StrLen(tmp1), true);
+				Sha0(a.HashedPassword, tmp1, StrLen(tmp1));
 			}
 		}
 	}

--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -253,7 +253,7 @@ void CiGetCurrentMachineHashOld(void *data)
 	Trim(name);
 	StrUpper(name);
 
-	Hash(data, name, StrLen(name), true);
+	Sha0(data, name, StrLen(name));
 }
 
 // Get current machine hash
@@ -272,7 +272,7 @@ void CiGetCurrentMachineHash(void *data)
 	Trim(name);
 	StrUpper(name);
 
-	Hash(data, name, StrLen(name), true);
+	Sha0(data, name, StrLen(name));
 }
 
 // Get current machine hash (without using domain name)
@@ -297,7 +297,7 @@ void CiGetCurrentMachineHashNew(void *data)
 	Trim(name);
 	StrUpper(name);
 
-	Hash(data, name, StrLen(name), true);
+	Sha0(data, name, StrLen(name));
 }
 
 
@@ -5722,7 +5722,7 @@ L_TRY:
 
 	SetTimeout(s, 10000);
 
-	Hash(hash_password, password, StrLen(password), true);
+	Sha0(hash_password, password, StrLen(password));
 
 	if (key != NULL)
 	{
@@ -8772,7 +8772,7 @@ bool CtGetPasswordSetting(CLIENT *c, RPC_CLIENT_PASSWORD_SETTING *a)
 		return false;
 	}
 
-	Hash(hash, "", 0, true);
+	Sha0(hash, "", 0);
 	if (Cmp(hash, c->EncryptedPassword, SHA1_SIZE) == 0)
 	{
 		a->IsPasswordPresented = false;
@@ -8801,7 +8801,7 @@ bool CtSetPassword(CLIENT *c, RPC_CLIENT_PASSWORD *pass)
 	if (StrCmp(str, "********") != 0)
 	{
 		// Hash the password
-		Hash(c->EncryptedPassword, str, StrLen(str), true);
+		Sha0(c->EncryptedPassword, str, StrLen(str));
 	}
 
 	c->PasswordRemoteOnly = pass->PasswordRemoteOnly;
@@ -9154,7 +9154,7 @@ void CiInitConfiguration(CLIENT *c)
 		CLog(c, "LC_LOAD_CONFIG_3");
 		// Do the initial setup because the configuration file does not exist
 		// Clear the password
-		Hash(c->EncryptedPassword, "", 0, true);
+		Sha0(c->EncryptedPassword, "", 0);
 		// Initialize the client configuration
 		// Disable remote management
 		c->Config.AllowRemoteConfig = false;
@@ -9773,7 +9773,7 @@ bool CiReadSettingFromCfg(CLIENT *c, FOLDER *root)
 
 	if (CfgGetByte(root, "EncryptedPassword", c->EncryptedPassword, SHA1_SIZE) == false)
 	{
-		Hash(c->EncryptedPassword, "", 0, true);
+		Sha0(c->EncryptedPassword, "", 0);
 	}
 
 	c->PasswordRemoteOnly = CfgGetBool(root, "PasswordRemoteOnly");
@@ -10439,7 +10439,7 @@ CLIENT *CiNewClient()
 
 	c->NotifyCancelList = NewList(NULL);
 
-	Hash(c->EncryptedPassword, "", 0, true);
+	Sha0(c->EncryptedPassword, "", 0);
 
 #ifdef	OS_WIN32
 	c->GlobalPulse = MsOpenOrCreateGlobalPulse(CLIENT_GLOBAL_PULSE_NAME);

--- a/src/Cedar/Command.c
+++ b/src/Cedar/Command.c
@@ -7789,7 +7789,7 @@ UINT PsClusterSettingMember(CONSOLE *c, char *cmd_name, wchar_t *str, void *para
 
 		pw = GetParamStr(o, "PASSWORD");
 
-		Hash(t.MemberPassword, pw, StrLen(pw), true);
+		Sha0(t.MemberPassword, pw, StrLen(pw));
 		t.PublicIp = StrToIP32(GetParamStr(o, "IP"));
 		t.ServerType = SERVER_TYPE_FARM_MEMBER;
 
@@ -10468,7 +10468,7 @@ UINT PsHubCreate(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 		pass = GetParamStr(o, "PASSWORD");
 	}
 
-	Hash(t.HashedPassword, pass, StrLen(pass), true);
+	Sha0(t.HashedPassword, pass, StrLen(pass));
 	HashPassword(t.SecurePassword, ADMINISTRATOR_USERNAME, pass);
 	t.Online = true;
 
@@ -10520,7 +10520,7 @@ UINT PsHubCreateDynamic(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 		pass = GetParamStr(o, "PASSWORD");
 	}
 
-	Hash(t.HashedPassword, pass, StrLen(pass), true);
+	Sha0(t.HashedPassword, pass, StrLen(pass));
 	HashPassword(t.SecurePassword, ADMINISTRATOR_USERNAME, pass);
 	t.Online = true;
 
@@ -10572,7 +10572,7 @@ UINT PsHubCreateStatic(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 		pass = GetParamStr(o, "PASSWORD");
 	}
 
-	Hash(t.HashedPassword, pass, StrLen(pass), true);
+	Sha0(t.HashedPassword, pass, StrLen(pass));
 	HashPassword(t.SecurePassword, ADMINISTRATOR_USERNAME, pass);
 	t.Online = true;
 
@@ -11102,7 +11102,7 @@ UINT PsSetHubPassword(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 	// Change the settings
 	pw = GetParamStr(o, "[password]");
 	HashPassword(t.SecurePassword, ADMINISTRATOR_USERNAME, pw);
-	Hash(t.HashedPassword, pw, StrLen(pw), true);
+	Sha0(t.HashedPassword, pw, StrLen(pw));
 
 	// Write the configuration of Virtual HUB
 	ret = ScSetHub(ps->Rpc, &t);
@@ -22110,7 +22110,7 @@ UINT PsServerPasswordSet(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 	pw = GetParamStr(o, "[password]");
 
 	Zero(&t, sizeof(t));
-	Hash(t.HashedPassword, pw, StrLen(pw), true);
+	Sha0(t.HashedPassword, pw, StrLen(pw));
 
 	ret = ScSetServerPassword(ps->Rpc, &t);
 
@@ -23351,7 +23351,7 @@ UINT PsConnect(CONSOLE *c, char *host, UINT port, char *hub, char *adminhub, wch
 	o.Port = port;
 	o.ProxyType = PROXY_DIRECT;
 
-	Hash(hashed_password, password, StrLen(password), true);
+	Sha0(hashed_password, password, StrLen(password));
 
 	if (IsEmptyStr(password) == false)
 	{
@@ -23386,7 +23386,7 @@ UINT PsConnect(CONSOLE *c, char *host, UINT port, char *hub, char *adminhub, wch
 
 				if (pass != NULL)
 				{
-					Hash(hashed_password, pass, StrLen(pass), true);
+					Sha0(hashed_password, pass, StrLen(pass));
 					Free(pass);
 				}
 				else

--- a/src/Cedar/Connection.c
+++ b/src/Cedar/Connection.c
@@ -2995,7 +2995,7 @@ UINT GetMachineRand()
 	Zero(pcname, sizeof(pcname));
 	GetMachineName(pcname, sizeof(pcname));
 
-	HashSha1(hash, pcname, StrLen(pcname));
+	Sha1(hash, pcname, StrLen(pcname));
 
 	return READ_UINT(hash);
 }

--- a/src/Cedar/DDNS.c
+++ b/src/Cedar/DDNS.c
@@ -635,7 +635,7 @@ UINT DCRegister(DDNS_CLIENT *c, bool ipv6, DDNS_REGISTER_PARAM *p, char *replace
 		PackAddStr(req, "current_azure_ip", current_azure_ip);
 	}
 
-	HashSha1(key_hash, key_str, StrLen(key_str));
+	Sha1(key_hash, key_str, StrLen(key_str));
 	BinToStr(key_hash_str, sizeof(key_hash_str), key_hash, sizeof(key_hash));
 	StrLower(key_hash_str);
 
@@ -963,7 +963,7 @@ DDNS_CLIENT *NewDDNSClient(CEDAR *cedar, UCHAR *key, INTERNET_SETTING *t)
 		Copy(c->Key, key, SHA1_SIZE);
 	}
 
-	HashSha1(key_hash, c->Key, sizeof(c->Key));
+	Sha1(key_hash, c->Key, sizeof(c->Key));
 
 
 	if (t != NULL)
@@ -1035,7 +1035,7 @@ void DCGenNewKey(UCHAR *key)
 	GetCurrentMachineIpProcessHash(hash);
 	WriteBuf(b, hash, sizeof(hash));
 
-	HashSha1(key, b->Buf, b->Size);
+	Sha1(key, b->Buf, b->Size);
 	Rand(rand, sizeof(rand));
 
 	for (i = 0;i < SHA1_SIZE;i++)

--- a/src/Cedar/EM.c
+++ b/src/Cedar/EM.c
@@ -626,7 +626,7 @@ UINT EmPasswordDlg(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, void *para
 		{
 		case IDOK:
 			GetTxtA(hWnd, E_PASSWORD1, pass1, sizeof(pass1));
-			Hash(hash, pass1, StrLen(pass1), true);
+			Sha0(hash, pass1, StrLen(pass1));
 			Zero(&t, sizeof(t));
 			Copy(t.HashedPassword, hash, SHA1_SIZE);
 			if (CALL(hWnd, EcSetPassword(r, &t)) == false)

--- a/src/Cedar/EtherLog.c
+++ b/src/Cedar/EtherLog.c
@@ -236,7 +236,7 @@ UINT EcConnect(char *host, UINT port, char *password, RPC **rpc)
 	SetTimeout(s, 5000);
 
 	// Hash the password
-	Hash(password_hash, password, StrLen(password), true);
+	Sha0(password_hash, password, StrLen(password));
 
 	// Receive the random number
 	Zero(rand, sizeof(rand));
@@ -1127,7 +1127,7 @@ void ElLoadConfigFromFolder(EL *e, FOLDER *root)
 
 	if (CfgGetByte(root, "AdminPassword", e->HashedPassword, sizeof(e->HashedPassword)) != sizeof(e->HashedPassword))
 	{
-		Hash(e->HashedPassword, "", 0, true);
+		Sha0(e->HashedPassword, "", 0);
 	}
 
 	if (ELOG_IS_BETA == false)
@@ -1185,7 +1185,7 @@ bool ElLoadConfig(EL *e)
 	else
 	{
 		char *pass = "";
-		Hash(e->HashedPassword, pass, StrLen(pass), true);
+		Sha0(e->HashedPassword, pass, StrLen(pass));
 		e->AutoDeleteCheckDiskFreeSpaceMin = DISK_FREE_SPACE_DEFAULT;
 	}
 

--- a/src/Cedar/Hub.c
+++ b/src/Cedar/Hub.c
@@ -2719,7 +2719,7 @@ BUF *BuildRedirectToUrlPayload(HUB *hub, SESSION *s, char *redirect_url)
 			WriteBuf(b2, tmp, StrLen(tmp));
 			WriteBuf(b2, secret, StrLen(secret));
 
-			HashSha1(hash, b2->Buf, b2->Size);
+			Sha1(hash, b2->Buf, b2->Size);
 
 			BinToStr(hash_str, sizeof(hash_str), hash, sizeof(hash));
 
@@ -3344,7 +3344,7 @@ UINT64 UsernameToInt64(char *name)
 		return 0;
 	}
 
-	Hash(hash, tmp, StrLen(tmp), true);
+	Sha0(hash, tmp, StrLen(tmp));
 	Copy(&ret, hash, sizeof(ret));
 
 	return ret;
@@ -4282,7 +4282,7 @@ DISCARD_PACKET:
 									UCHAR hash[MD5_SIZE];
 									UINT64 tick_diff = Tick64() - s->LastDLinkSTPPacketSendTick;
 
-									Hash(hash, packet->PacketData, packet->PacketSize, false);
+									Md5(hash, packet->PacketData, packet->PacketSize);
 
 									if ((s->LastDLinkSTPPacketSendTick != 0) &&
 										(tick_diff < 750ULL) &&
@@ -5403,7 +5403,7 @@ void StorePacketToHubPa(HUB_PA *dest, SESSION *src, void *data, UINT size, PKT *
 				if (session->Policy != NULL && session->Policy->CheckMac)
 				{
 					UCHAR hash[MD5_SIZE];
-					Hash(hash, packet->PacketData, packet->PacketSize, false);
+					Md5(hash, packet->PacketData, packet->PacketSize);
 
 					Copy(session->LastDLinkSTPPacketDataHash, hash, MD5_SIZE);
 					session->LastDLinkSTPPacketSendTick = Tick64();
@@ -6889,7 +6889,7 @@ void GenHubIpAddress(IP *ip, char *name)
 	StrCat(tmp2, sizeof(tmp2), tmp1);
 	StrUpper(tmp2);
 
-	Hash(hash, tmp2, StrLen(tmp2), true);
+	Sha0(hash, tmp2, StrLen(tmp2));
 
 	Zero(ip, sizeof(IP));
 	ip->addr[0] = 172;
@@ -6917,7 +6917,7 @@ void GenHubMacAddress(UCHAR *mac, char *name)
 	StrCat(tmp2, sizeof(tmp2), tmp1);
 	StrUpper(tmp2);
 
-	Hash(hash, tmp2, StrLen(tmp2), true);
+	Sha0(hash, tmp2, StrLen(tmp2));
 
 	mac[0] = 0x00;
 	mac[1] = SE_HUB_MAC_ADDR_SIGN;
@@ -6990,7 +6990,7 @@ HUB *NewHub(CEDAR *cedar, char *HubName, HUB_OPTION *option)
 	}
 
 	h = ZeroMalloc(sizeof(HUB));
-	Hash(h->HashedPassword, "", 0, true);
+	Sha0(h->HashedPassword, "", 0);
 	HashPassword(h->SecurePassword, ADMINISTRATOR_USERNAME, "");
 	h->lock = NewLock();
 	h->lock_online = NewLock();

--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -459,7 +459,7 @@ IPC *NewIPC(CEDAR *cedar, char *client_name, char *postfix, char *hubname, char 
 	WriteBufStr(b, client_name);
 	WriteBufStr(b, crypt_name);
 
-	HashSha1(unique, b->Buf, b->Size);
+	Sha1(unique, b->Buf, b->Size);
 
 	FreeBuf(b);
 

--- a/src/Cedar/Layer3.c
+++ b/src/Cedar/Layer3.c
@@ -823,7 +823,7 @@ void L3GenerateMacAddress(L3IF *f)
 	WriteBuf(b, &f->IpAddress, sizeof(f->IpAddress));
 
 	GenMacAddress(f->MacAddress);
-	Hash(hash, b->Buf, b->Size, true);
+	Sha0(hash, b->Buf, b->Size);
 	Copy(f->MacAddress + 2, hash, 4);
 	f->MacAddress[1] = 0xA3;
 	FreeBuf(b);

--- a/src/Cedar/NM.c
+++ b/src/Cedar/NM.c
@@ -263,7 +263,7 @@ UINT NmChangePasswordProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, voi
 		{
 		case IDOK:
 			Zero(&t, sizeof(t));
-			Hash(t.HashedPassword, tmp1, StrLen(tmp1), true);
+			Sha0(t.HashedPassword, tmp1, StrLen(tmp1));
 
 			if (CALL(hWnd, NcSetPassword(r, &t)))
 			{
@@ -1411,7 +1411,7 @@ UINT NmLogin(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, void *param)
 		{
 		case IDOK:
 			GetTxtA(hWnd, E_PASSWORD, tmp, sizeof(tmp));
-			Hash(login->hashed_password, tmp, StrLen(tmp), true);
+			Sha0(login->hashed_password, tmp, StrLen(tmp));
 			EndDialog(hWnd, true);
 			break;
 
@@ -1463,7 +1463,7 @@ RETRY_PASSWORD:
 				Zero(&login, sizeof(login));
 				login.Hostname = t->Hostname;
 				login.Port = t->Port;
-				Hash(login.hashed_password, "", 0, true);
+				Sha0(login.hashed_password, "", 0);
 
 				if (flag)
 				{

--- a/src/Cedar/Nat.c
+++ b/src/Cedar/Nat.c
@@ -1193,7 +1193,7 @@ void NiAdminThread(THREAD *thread, void *param)
 					{
 						UCHAR test[SHA1_SIZE];
 						// Password match
-						Hash(test, "", 0, true);
+						Sha0(test, "", 0);
 						SecurePassword(test, test, random);
 
 #if	0
@@ -1793,7 +1793,7 @@ NAT *NiNewNatEx(SNAT *snat, VH_OPTION *o)
 	NAT *n = ZeroMalloc(sizeof(NAT));
 
 	n->lock = NewLock();
-	Hash(n->HashedPassword, "", 0, true);
+	Sha0(n->HashedPassword, "", 0);
 	n->HaltEvent = NewEvent();
 
 	//n->Cedar = NewCedar(NULL, NULL);

--- a/src/Cedar/NativeStack.c
+++ b/src/Cedar/NativeStack.c
@@ -509,7 +509,7 @@ void NsGenMacAddressSignatureForMachine(UCHAR *dst_last_2, UCHAR *src_mac_addr_4
 	WriteBuf(b, src_mac_addr_4, 4);
 	WriteBufStr(b, machine_name);
 
-	HashSha1(hash, b->Buf, b->Size);
+	Sha1(hash, b->Buf, b->Size);
 
 	FreeBuf(b);
 
@@ -533,7 +533,7 @@ void NsGenMacAddress(void *dest, char *mac_address_seed, char *device_name)
 
 	StrLower(tmp);
 
-	HashSha1(hash, tmp, StrLen(tmp));
+	Sha1(hash, tmp, StrLen(tmp));
 
 	mac[0] = NS_MAC_ADDRESS_BYTE_1;
 	mac[1] = hash[1];
@@ -562,7 +562,7 @@ IPTABLES_STATE *StartAddIpTablesEntryForNativeStack(void *seed, UINT seed_size)
 
 		ret->EntryList = NewListFast(NULL);
 
-		HashSha1(ret->SeedHash, seed, seed_size);
+		Sha1(ret->SeedHash, seed, seed_size);
 
 		// Create a pair of entry
 		e = ZeroMalloc(sizeof(IPTABLES_ENTRY));

--- a/src/Cedar/NullLan.c
+++ b/src/Cedar/NullLan.c
@@ -145,7 +145,7 @@ void NullGenerateMacAddress(UCHAR *mac, UINT id, UINT seq)
 #endif	// OS_WIN32
 	WriteBufStr(b, name);
 
-	HashSha1(hash, b->Buf, b->Size);
+	Sha1(hash, b->Buf, b->Size);
 
 	FreeBuf(b);
 

--- a/src/Cedar/Proto_IKE.c
+++ b/src/Cedar/Proto_IKE.c
@@ -3937,7 +3937,7 @@ BUF *IkeStrToVendorId(char *str)
 		BUF *buf;
 		UCHAR hash[MD5_SIZE];
 
-		Hash(hash, str, StrLen(str), false);
+		Md5(hash, str, StrLen(str));
 
 		buf = MemToBuf(hash, sizeof(hash));
 

--- a/src/Cedar/Proto_IkePacket.c
+++ b/src/Cedar/Proto_IkePacket.c
@@ -2965,13 +2965,7 @@ void IkeHMac(IKE_HASH *h, void *dst, void *key, UINT key_size, void *data, UINT 
 {
 	MD *md = NULL;
 
-	// Validate arguments
-	if (h == NULL || dst == NULL || (key == NULL && key_size != 0) || (data == NULL && data_size != 0))
-	{
-		return;
-	}
-
-	switch(h->HashId)
+	switch (h->HashId)
 	{
 	case IKE_HASH_MD5_ID:
 		md = NewMd("MD5");
@@ -2992,12 +2986,22 @@ void IkeHMac(IKE_HASH *h, void *dst, void *key, UINT key_size, void *data, UINT 
 
 	if (md == NULL)
 	{
-		Debug("IkeHMac(): The MD object is NULL! Either NewMd() failed or the current algorithm is not handled by the switch-case block.");
+		Debug("IkeHMac(): The MD object is NULL! Either NewMd() failed or the current algorithm is not handled by the switch-case block.\n");
 		return;
 	}
 
-	SetMdKey(md, key, key_size);
-	MdProcess(md, dst, data, data_size);
+	if (SetMdKey(md, key, key_size) == false)
+	{
+		Debug("IkeHMac(): SetMdKey() failed!\n");
+		goto cleanup;
+	}
+
+	if (MdProcess(md, dst, data, data_size) == 0)
+	{
+		Debug("IkeHMac(): MdProcess() returned 0!\n");
+	}
+
+cleanup:
 	FreeMd(md);
 }
 

--- a/src/Cedar/Proto_PPP.c
+++ b/src/Cedar/Proto_PPP.c
@@ -2676,7 +2676,7 @@ void MsChapV2_GenerateChallenge8(UCHAR *dst, UCHAR *client_challenge, UCHAR *ser
 		WriteBuf(b, username2, StrLen(username2));
 	}
 
-	HashSha1(hash, b->Buf, b->Size);
+	Sha1(hash, b->Buf, b->Size);
 
 	FreeBuf(b);
 
@@ -2739,14 +2739,14 @@ void MsChapV2Server_GenerateResponse(UCHAR *dst, UCHAR *nt_password_hash_hash, U
 	WriteBuf(b, nt_password_hash_hash, 16);
 	WriteBuf(b, client_response, 24);
 	WriteBuf(b, magic1, StrLen(magic1));
-	HashSha1(digest, b->Buf, b->Size);
+	Sha1(digest, b->Buf, b->Size);
 	FreeBuf(b);
 
 	b = NewBuf();
 	WriteBuf(b, digest, sizeof(digest));
 	WriteBuf(b, challenge8, 8);
 	WriteBuf(b, magic2, StrLen(magic2));
-	HashSha1(dst, b->Buf, b->Size);
+	Sha1(dst, b->Buf, b->Size);
 	FreeBuf(b);
 }
 

--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -873,7 +873,7 @@ void GenerateMachineUniqueHash(void *data)
 	WriteBuf(b, osinfo->OsVendorName, StrLen(osinfo->OsVendorName));
 	WriteBuf(b, osinfo->OsVersion, StrLen(osinfo->OsVersion));
 
-	Hash(data, b->Buf, b->Size, true);
+	Sha0(data, b->Buf, b->Size);
 
 	FreeBuf(b);
 }

--- a/src/Cedar/Radius.c
+++ b/src/Cedar/Radius.c
@@ -2396,7 +2396,7 @@ BUF *RadiusEncryptPassword(char *password, UCHAR *random, UCHAR *secret, UINT se
 		{
 			WriteBuf(tmp, c[i - 1], 16);
 		}
-		Hash(b[i], tmp->Buf, tmp->Size, false);
+		Md5(b[i], tmp->Buf, tmp->Size);
 		FreeBuf(tmp);
 
 		// Calculation of c[i]

--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -3152,7 +3152,7 @@ bool SmSetupInit(HWND hWnd, SM_SETUP *s)
 		char *password = "";
 
 		Zero(&t, sizeof(t));
-		Hash(t.HashedPassword, password, StrLen(password), true);
+		Sha0(t.HashedPassword, password, StrLen(password));
 		HashPassword(t.SecurePassword, ADMINISTRATOR_USERNAME, password);
 		StrCpy(t.HubName, sizeof(t.HubName), s->HubName);
 		t.HubType = HUB_TYPE_STANDALONE;
@@ -15243,7 +15243,7 @@ UINT SmChangeServerPasswordDlg(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam
 				}
 			}
 			Zero(&t, sizeof(t));
-			Hash(t.HashedPassword, tmp1, StrLen(tmp1), true);
+			Sha0(t.HashedPassword, tmp1, StrLen(tmp1));
 			Copy(hash, t.HashedPassword, sizeof(hash));
 			if (CALL(hWnd, ScSetServerPassword(p->Rpc, &t)) == false)
 			{
@@ -15905,7 +15905,7 @@ void SmFarmDlgOnOk(HWND hWnd, SM_SERVER *p)
 			GetTxtA(hWnd, E_PASSWORD, pass, sizeof(pass));
 			if (StrCmp(pass, HIDDEN_PASSWORD) != 0)
 			{
-				Hash(t.MemberPassword, pass, StrLen(pass), true);
+				Sha0(t.MemberPassword, pass, StrLen(pass));
 			}
 		}
 
@@ -17545,7 +17545,7 @@ void SmEditHubOnOk(HWND hWnd, SM_EDIT_HUB *s)
 
 	if (s->EditMode == false || StrCmp(pass1, HIDDEN_PASSWORD) != 0)
 	{
-		Hash(t.HashedPassword, pass1, StrLen(pass1), true);
+		Sha0(t.HashedPassword, pass1, StrLen(pass1));
 		HashPassword(t.SecurePassword, ADMINISTRATOR_USERNAME, pass1);
 	}
 
@@ -19128,7 +19128,7 @@ ENTER_PASSWORD:
 		pass = SmPassword(hWnd, s->ClientOption.Hostname);
 		if (pass != NULL)
 		{
-			Hash(s->HashedPassword, pass, StrLen(pass), true);
+			Sha0(s->HashedPassword, pass, StrLen(pass));
 			Free(pass);
 			ok = true;
 		}
@@ -19173,7 +19173,7 @@ ENTER_PASSWORD:
 			RPC_TEST flag;
 			bool cancel = false;
 
-			Hash(test, "", 0, true);
+			Sha0(test, "", 0);
 
 			if (Cmp(test, s->HashedPassword, SHA1_SIZE) == 0 || Cmp(test, rpc->VpnServerHashedPassword, SHA1_SIZE) == 0)
 			{
@@ -19450,7 +19450,7 @@ void SmEditSettingDlgInit(HWND hWnd, SM_EDIT_SETTING *p)
 	{
 		UCHAR test[SHA1_SIZE];
 
-		Hash(test, "", 0, true);
+		Sha0(test, "", 0);
 		if (Cmp(test, s->HashedPassword, SHA1_SIZE) != 0)
 		{
 			SetTextA(hWnd, E_PASSWORD, HIDDEN_PASSWORD);
@@ -19585,7 +19585,7 @@ void SmEditSettingDlgUpdate(HWND hWnd, SM_EDIT_SETTING *p)
 		GetTxtA(hWnd, E_PASSWORD, tmp, sizeof(tmp));
 		if (StrCmp(tmp, HIDDEN_PASSWORD) != 0)
 		{
-			Hash(s->HashedPassword, tmp, StrLen(tmp), true);
+			Sha0(s->HashedPassword, tmp, StrLen(tmp));
 		}
 	}
 
@@ -19787,7 +19787,7 @@ bool SmAddSettingDlg(HWND hWnd, wchar_t *new_name, UINT new_name_size)
 		if (SmGetSetting(tmp) == NULL)
 		{
 			UniStrCpy(s.Title, sizeof(s.Title), tmp);
-			Hash(s.HashedPassword, "", 0, true);
+			Sha0(s.HashedPassword, "", 0);
 			s.ServerAdminMode = true;
 			break;
 		}
@@ -20111,7 +20111,7 @@ void SmInitDefaultSettingList()
 
 			UniStrCpy(s->Title, sizeof(s->Title), _UU("SM_LOCALHOST"));
 			s->ServerAdminMode = true;
-			Hash(s->HashedPassword, "", 0, true);
+			Sha0(s->HashedPassword, "", 0);
 			UniStrCpy(s->ClientOption.AccountName, sizeof(s->ClientOption.AccountName), s->Title);
 			StrCpy(s->ClientOption.Hostname, sizeof(s->ClientOption.Hostname), "localhost");
 			s->ClientOption.Port = GC_DEFAULT_PORT;
@@ -20610,7 +20610,7 @@ void SmParseCommandLine()
 					b = StrToBin(password);
 					if (b == NULL || b->Size != SHA1_SIZE)
 					{
-						Hash(s->HashedPassword, password, StrLen(password), true);
+						Sha0(s->HashedPassword, password, StrLen(password));
 					}
 					else
 					{

--- a/src/Cedar/Sam.c
+++ b/src/Cedar/Sam.c
@@ -467,7 +467,7 @@ void SecurePassword(void *secure_password, void *password, void *random)
 	b = NewBuf();
 	WriteBuf(b, password, SHA1_SIZE);
 	WriteBuf(b, random, SHA1_SIZE);
-	Hash(secure_password, b->Buf, b->Size, true);
+	Sha0(secure_password, b->Buf, b->Size);
 
 	FreeBuf(b);
 }

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -2519,7 +2519,7 @@ void SiLoadInitialConfiguration(SERVER *s)
 
 	// Initialize the password
 	{
-		Hash(s->HashedPassword, "", 0, true);
+		Sha0(s->HashedPassword, "", 0);
 	}
 
 	// Set the encryption algorithm name to default
@@ -5103,7 +5103,7 @@ void SiLoadHubCfg(SERVER *s, FOLDER *f, char *name)
 		// Password
 		if (CfgGetByte(f, "HashedPassword", h->HashedPassword, sizeof(h->HashedPassword)) != sizeof(h->HashedPassword))
 		{
-			Hash(h->HashedPassword, "", 0, true);
+			Sha0(h->HashedPassword, "", 0);
 		}
 		if (CfgGetByte(f, "SecurePassword", h->SecurePassword, sizeof(h->SecurePassword)) != sizeof(h->SecurePassword))
 		{
@@ -5942,7 +5942,7 @@ void SiLoadServerCfg(SERVER *s, FOLDER *f)
 		// Password
 		if (CfgGetByte(f, "HashedPassword", s->HashedPassword, sizeof(s->HashedPassword)) != sizeof(s->HashedPassword))
 		{
-			Hash(s->HashedPassword, "", 0, true);
+			Sha0(s->HashedPassword, "", 0);
 		}
 
 		if (s->ServerType != SERVER_TYPE_STANDALONE)

--- a/src/Cedar/Session.c
+++ b/src/Cedar/Session.c
@@ -2284,7 +2284,7 @@ SESSION *NewServerSessionEx(CEDAR *cedar, CONNECTION *c, HUB *h, char *username,
 		StrUpper(tmp);
 		Trim(tmp);
 
-		Hash(hash, tmp, StrLen(tmp), true);
+		Sha0(hash, tmp, StrLen(tmp));
 
 		s->IpcMacAddress[0] = 0xCA;
 		s->IpcMacAddress[1] = hash[1];

--- a/src/Cedar/UdpAccel.c
+++ b/src/Cedar/UdpAccel.c
@@ -870,7 +870,7 @@ void UdpAccelCalcKey(UCHAR *key, UCHAR *common_key, UCHAR *iv)
 	Copy(tmp, common_key, UDP_ACCELERATION_COMMON_KEY_SIZE);
 	Copy(tmp + UDP_ACCELERATION_COMMON_KEY_SIZE, iv, UDP_ACCELERATION_PACKET_IV_SIZE);
 
-	HashSha1(key, tmp, sizeof(tmp));
+	Sha1(key, tmp, sizeof(tmp));
 }
 
 // Set the current time

--- a/src/Cedar/Virtual.c
+++ b/src/Cedar/Virtual.c
@@ -9384,7 +9384,7 @@ UINT GetFreeDhcpIpAddressByRandom(VH *v, UCHAR *mac)
 		WRITE_UINT(&rand_seed[0], i);
 		Copy(rand_seed + sizeof(UINT), mac, 6);
 
-		Hash(hash, rand_seed, sizeof(rand_seed), false);
+		Md5(hash, rand_seed, sizeof(rand_seed));
 
 		rand_int = READ_UINT(hash);
 
@@ -10300,7 +10300,7 @@ void GenMacAddress(UCHAR *mac)
 	WriteBuf(b, rand_data, sizeof(rand_data));
 
 	// Hash
-	Hash(hash, b->Buf, b->Size, true);
+	Sha0(hash, b->Buf, b->Size);
 
 	// Generate a MAC address
 	mac[0] = 0x5E;

--- a/src/Cedar/WebUI.c
+++ b/src/Cedar/WebUI.c
@@ -206,7 +206,7 @@ static wchar_t *WpLogin(WEBUI *wu, LIST *params)
 
 	// Administrator authentication
 	Rand(random,sizeof(random));
-	Hash(securepass, password, StrLen(password), true);
+	Sha0(securepass, password, StrLen(password));
 	SecurePassword(securepass, securepass, random);
 	result = AdminCheckPassword(wu->Cedar, random, securepass, hubname, false, NULL);
 
@@ -730,7 +730,7 @@ static wchar_t *WpNewHub(WEBUI *wu, LIST *params)
 
 		Zero(&t, sizeof(t));
 		StrCpy(t.HubName, sizeof(t.HubName), hubname);
-		Hash(t.HashedPassword, passwd, StrLen(passwd), true);
+		Sha0(t.HashedPassword, passwd, StrLen(passwd));
 		HashPassword(t.SecurePassword, ADMINISTRATOR_USERNAME, passwd);
 		t.Online = true;
 		t.HubType = HUB_TYPE_STANDALONE;

--- a/src/Cedar/WinUi.c
+++ b/src/Cedar/WinUi.c
@@ -1893,7 +1893,7 @@ UINT GetOnceMsgHash(wchar_t *title, wchar_t *message)
 	// 2013.5.19: Exclude the title from the hash calculation
 	//WriteBuf(b, title, UniStrSize(title));
 	WriteBuf(b, message, UniStrSize(message));
-	HashSha1(hash, b->Buf, b->Size);
+	Sha1(hash, b->Buf, b->Size);
 	FreeBuf(b);
 
 	Copy(&ret, hash, sizeof(UINT));

--- a/src/Cedar/Wpc.c
+++ b/src/Cedar/Wpc.c
@@ -267,7 +267,7 @@ bool WpcParsePacket(WPC_PACKET *packet, BUF *buf)
 	b = WpcDataEntryToBuf(WpcFindDataEntry(o, "PACK"));
 	if (b != NULL)
 	{
-		HashSha1(hash, b->Buf, b->Size);
+		Sha1(hash, b->Buf, b->Size);
 
 		packet->Pack = BufToPack(b);
 		FreeBuf(b);
@@ -362,7 +362,7 @@ BUF *WpcGeneratePacket(PACK *pack, X *cert, K *key)
 	}
 
 	pack_data = PackToBuf(pack);
-	HashSha1(hash, pack_data->Buf, pack_data->Size);
+	Sha1(hash, pack_data->Buf, pack_data->Size);
 
 	if (cert != NULL && key != NULL)
 	{

--- a/src/Mayaqua/Cfg.c
+++ b/src/Mayaqua/Cfg.c
@@ -466,7 +466,7 @@ bool CfgSaveExW3(CFG_RW *rw, FOLDER *f, wchar_t *name, UINT *written_size, bool 
 		return false;
 	}
 	// Hash the contents
-	Hash(hash, b->Buf, b->Size, true);
+	Sha0(hash, b->Buf, b->Size);
 
 	// Compare the contents to be written with the content which was written last
 	if (rw != NULL)
@@ -661,7 +661,7 @@ FOLDER *CfgReadW(wchar_t *name)
 		// Check the hash 
 		ReadBuf(b, hash1, sizeof(hash1));
 
-		Hash(hash2, ((UCHAR *)b->Buf) + 8 + SHA1_SIZE, b->Size - 8 - SHA1_SIZE, true);
+		Sha0(hash2, ((UCHAR *)b->Buf) + 8 + SHA1_SIZE, b->Size - 8 - SHA1_SIZE);
 
 		if (Cmp(hash1, hash2, SHA1_SIZE) != 0)
 		{
@@ -1105,7 +1105,7 @@ BUF *CfgFolderToBufBin(FOLDER *f)
 	CfgOutputFolderBin(b, f);
 
 	// Hash
-	Hash(((UCHAR *)b->Buf) + 8, ((UCHAR *)b->Buf) + 8 + SHA1_SIZE, b->Size - 8 - SHA1_SIZE, true);
+	Sha0(((UCHAR *)b->Buf) + 8, ((UCHAR *)b->Buf) + 8 + SHA1_SIZE, b->Size - 8 - SHA1_SIZE);
 
 	return b;
 }

--- a/src/Mayaqua/Encrypt.h
+++ b/src/Mayaqua/Encrypt.h
@@ -374,10 +374,6 @@ extern LOCK **ssl_lock_obj;
 CRYPT *NewCrypt(void *key, UINT size);
 void FreeCrypt(CRYPT *c);
 void Encrypt(CRYPT *c, void *dst, void *src, UINT size);
-void Hash(void *dst, void *src, UINT size, bool sha);
-void HashSha1(void *dst, void *src, UINT size);
-void HashMd4(void *dst, void *src, UINT size);
-void HashMd4(void *dst, void *src, UINT size);
 void InitCryptLibrary();
 void Rand(void *buf, UINT size);
 UINT HashToUINT(void *data, UINT size);
@@ -491,13 +487,7 @@ void DesFreeKeyValue(DES_KEY_VALUE *v);
 void Des3Encrypt2(void *dest, void *src, UINT size, DES_KEY_VALUE *k1, DES_KEY_VALUE *k2, DES_KEY_VALUE *k3, void *ivec);
 void Des3Decrypt2(void *dest, void *src, UINT size, DES_KEY_VALUE *k1, DES_KEY_VALUE *k2, DES_KEY_VALUE *k3, void *ivec);
 void Sha(UINT sha_type, void *dst, void *src, UINT size);
-void Sha0(void *dst, void *src, UINT size);
-void Sha1(void *dst, void *src, UINT size);
-void Sha2_256(void *dst, void *src, UINT size);
-void Sha2_384(void *dst, void *src, UINT size);
-void Sha2_512(void *dst, void *src, UINT size);
 
-void Md5(void *dst, void *src, UINT size);
 void DesEncrypt(void *dest, void *src, UINT size, DES_KEY_VALUE *k, void *ivec);
 void DesDecrypt(void *dest, void *src, UINT size, DES_KEY_VALUE *k, void *ivec);
 void DesEcbEncrypt(void *dst, void *src, void *key_7bytes);
@@ -528,21 +518,30 @@ unsigned long OpenSSL_Id(void);
 void FreeOpenSSLThreadState();
 char *OpenSSL_Error();
 
+// Encryption/Decryption
 CIPHER *NewCipher(char *name);
 void FreeCipher(CIPHER *c);
 void SetCipherKey(CIPHER *c, void *key, bool enc);
 UINT CipherProcess(CIPHER *c, void *iv, void *dest, void *src, UINT size);
 
+// Hashing
 MD *NewMd(char *name);
 MD *NewMdEx(char *name, bool hmac);
-void FreeMd(MD *md);
 bool SetMdKey(MD *md, void *key, UINT key_size);
 UINT MdProcess(MD *md, void *dest, void *src, UINT size);
-void Enc_tls1_PRF(unsigned char *label, int label_len, const unsigned char *sec,
-				  int slen, unsigned char *out1, int olen);
-
+void FreeMd(MD *md);
+void HashMd4(void *dst, void *src, UINT size);
+void HashSha1(void *dst, void *src, UINT size);
+void Md5(void *dst, void *src, UINT size);
+void Sha(UINT sha_type, void *dst, void *src, UINT size);
+void Sha0(void *dst, void *src, UINT size);
+void Sha1(void *dst, void *src, UINT size);
+void Sha2_256(void *dst, void *src, UINT size);
+void Sha2_384(void *dst, void *src, UINT size);
+void Sha2_512(void *dst, void *src, UINT size);
 UINT HMacSha1(void *dst, void *key, UINT key_size, void *data, UINT data_size);
 UINT HMacMd5(void *dst, void *key, UINT key_size, void *data, UINT data_size);
+void Enc_tls1_PRF(unsigned char *label, int label_len, const unsigned char *sec, int slen, unsigned char *out1, int olen);
 
 int GetSslClientCertIndex();
 

--- a/src/Mayaqua/Encrypt.h
+++ b/src/Mayaqua/Encrypt.h
@@ -359,9 +359,10 @@ struct CIPHER
 struct MD
 {
 	char Name[MAX_PATH];
-	bool isNullMd;
+	bool IsNullMd;
+	bool IsHMac;
 	const struct evp_md_st *Md;
-	struct hmac_ctx_st *Ctx;
+	void *Ctx;
 	UINT Size;
 };
 
@@ -490,6 +491,7 @@ void DesFreeKeyValue(DES_KEY_VALUE *v);
 void Des3Encrypt2(void *dest, void *src, UINT size, DES_KEY_VALUE *k1, DES_KEY_VALUE *k2, DES_KEY_VALUE *k3, void *ivec);
 void Des3Decrypt2(void *dest, void *src, UINT size, DES_KEY_VALUE *k1, DES_KEY_VALUE *k2, DES_KEY_VALUE *k3, void *ivec);
 void Sha(UINT sha_type, void *dst, void *src, UINT size);
+void Sha0(void *dst, void *src, UINT size);
 void Sha1(void *dst, void *src, UINT size);
 void Sha2_256(void *dst, void *src, UINT size);
 void Sha2_384(void *dst, void *src, UINT size);
@@ -524,6 +526,7 @@ void OpenSSL_FreeLock();
 void OpenSSL_Lock(int mode, int n, const char *file, int line);
 unsigned long OpenSSL_Id(void);
 void FreeOpenSSLThreadState();
+char *OpenSSL_Error();
 
 CIPHER *NewCipher(char *name);
 void FreeCipher(CIPHER *c);
@@ -531,14 +534,15 @@ void SetCipherKey(CIPHER *c, void *key, bool enc);
 UINT CipherProcess(CIPHER *c, void *iv, void *dest, void *src, UINT size);
 
 MD *NewMd(char *name);
+MD *NewMdEx(char *name, bool hmac);
 void FreeMd(MD *md);
-void SetMdKey(MD *md, void *key, UINT key_size);
-void MdProcess(MD *md, void *dest, void *src, UINT size);
+bool SetMdKey(MD *md, void *key, UINT key_size);
+UINT MdProcess(MD *md, void *dest, void *src, UINT size);
 void Enc_tls1_PRF(unsigned char *label, int label_len, const unsigned char *sec,
 				  int slen, unsigned char *out1, int olen);
 
-void HMacSha1(void *dst, void *key, UINT key_size, void *data, UINT data_size);
-void HMacMd5(void *dst, void *key, UINT key_size, void *data, UINT data_size);
+UINT HMacSha1(void *dst, void *key, UINT key_size, void *data, UINT data_size);
+UINT HMacMd5(void *dst, void *key, UINT key_size, void *data, UINT data_size);
 
 int GetSslClientCertIndex();
 

--- a/src/Mayaqua/Kernel.c
+++ b/src/Mayaqua/Kernel.c
@@ -714,7 +714,7 @@ void HashInstanceName(char *name, UINT size, char *instance_name)
 	Trim(tmp);
 	StrUpper(tmp);
 
-	Hash(hash, tmp, StrLen(tmp), SHA1_SIZE);
+	Sha0(hash, tmp, StrLen(tmp));
 	BinToStr(key, sizeof(key), hash, 5);
 	key[10] = 0;
 
@@ -745,7 +745,7 @@ void HashInstanceNameLocal(char *name, UINT size, char *instance_name)
 	Trim(tmp);
 	StrUpper(tmp);
 
-	Hash(hash, tmp, StrLen(tmp), SHA1_SIZE);
+	Sha0(hash, tmp, StrLen(tmp));
 	BinToStr(key, sizeof(key), hash, 5);
 	key[10] = 0;
 

--- a/src/Mayaqua/Memory.c
+++ b/src/Mayaqua/Memory.c
@@ -147,7 +147,7 @@ PRAND *NewPRand(void *key, UINT key_size)
 
 	r = ZeroMalloc(sizeof(PRAND));
 
-	HashSha1(r->Key, key, key_size);
+	Sha1(r->Key, key, key_size);
 
 	r->Rc4 = NewCrypt(key, key_size);
 
@@ -2459,7 +2459,7 @@ BUF *FileToBuf(IO *o)
 	}
 
 	// Take a hash
-	Hash(hash2, buf, size, false);
+	Md5(hash2, buf, size);
 
 	// Compare the hashes
 	if (Cmp(hash1, hash2, sizeof(hash1)) != 0)
@@ -2664,7 +2664,7 @@ bool BufToFile(IO *o, BUF *b)
 	}
 
 	// Hash the data
-	Hash(hash, b->Buf, b->Size, false);
+	Md5(hash, b->Buf, b->Size);
 
 	size = Endian32(b->Size);
 

--- a/src/Mayaqua/Microsoft.c
+++ b/src/Mayaqua/Microsoft.c
@@ -988,7 +988,7 @@ void *MsOpenOrCreateGlobalPulse(char *name)
 	Trim(tmp);
 	StrUpper(tmp);
 
-	HashSha1(hash, name, StrLen(name));
+	Sha1(hash, name, StrLen(name));
 
 	BinToStr(tmp, sizeof(tmp), hash, sizeof(hash));
 
@@ -2110,13 +2110,13 @@ void MsRegistWindowsFirewallEx(char *title, char *exe)
 	tmp_size = StrLen(data) * 4;
 	tmp = ZeroMalloc(tmp_size);
 
-	HashSha1(hashbin, exe, StrLen(exe));
+	Sha1(hashbin, exe, StrLen(exe));
 	BinToStr(hash, sizeof(hash), hashbin, 6);
 
 	ReplaceStrEx(tmp, tmp_size, data, "$TITLE$", title, false);
 	ReplaceStrEx(tmp, tmp_size, tmp, "$PATH$", exe, false);
 
-	HashSha1(file_hash_bin, tmp, StrLen(tmp));
+	Sha1(file_hash_bin, tmp, StrLen(tmp));
 	BinToStr(file_hash_str, sizeof(file_hash_str), file_hash_bin, sizeof(file_hash_bin));
 
 	if (MsIsVista() == false || MsRegReadIntEx2(REG_LOCAL_MACHINE, SOFTETHER_FW_SCRIPT_HASH, file_hash_str, false, true) == 0)
@@ -2357,7 +2357,7 @@ void *MsLoadLibraryAsDataFileW(wchar_t *name)
 		return NULL;
 	}
 
-	Hash(hash, name, UniStrLen(name), true);
+	Sha0(hash, name, UniStrLen(name));
 
 	BinToStr(hash_str, sizeof(hash_str), hash, 4);
 
@@ -2404,7 +2404,7 @@ void *MsLoadLibraryW(wchar_t *name)
 		return NULL;
 	}
 
-	Hash(hash, name, UniStrSize(name), true);
+	Sha0(hash, name, UniStrSize(name));
 
 	BinToStr(hash_str, sizeof(hash_str), hash, 4);
 
@@ -4075,7 +4075,7 @@ void MsGenerateUserModeSvcGlobalPulseName(char *name, UINT size, char *svc_name)
 	UniTrim(tmp);
 	UniStrUpper(tmp);
 
-	HashSha1(hash, tmp, UniStrLen(tmp) * sizeof(wchar_t));
+	Sha1(hash, tmp, UniStrLen(tmp) * sizeof(wchar_t));
 
 	BinToStr(name, size, hash, sizeof(hash));
 }
@@ -8365,7 +8365,7 @@ void MsGenMacAddress(UCHAR *mac)
 	now = SystemTime64();
 	Copy(hash_src, &now, sizeof(now));
 
-	Hash(hash, hash_src, sizeof(hash_src), true);
+	Sha0(hash, hash_src, sizeof(hash_src));
 
 	mac[0] = 0x5E;
 	mac[1] = hash[0];
@@ -12017,7 +12017,7 @@ bool MsCheckIsAdmin()
 	DWORD size;
 	char name[MAX_SIZE];
 
-	HashSha1(exe_hash, MsGetExeFileNameW(), UniStrLen(MsGetExeFileNameW()));
+	Sha1(exe_hash, MsGetExeFileNameW(), UniStrLen(MsGetExeFileNameW()));
 
 	Format(name, sizeof(name), name_tag, *((UINT *)exe_hash));
 

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -559,7 +559,7 @@ UINT GetCurrentDDnsFqdnHash()
 	Trim(name);
 	StrUpper(name);
 
-	HashSha1(hash, name, StrLen(name));
+	Sha1(hash, name, StrLen(name));
 
 	Copy(&ret, hash, sizeof(UINT));
 
@@ -2555,7 +2555,7 @@ void RUDPBulkSend(RUDP_STACK *r, RUDP_SESSION *se, void *data, UINT data_size)
 	Copy(iv, se->BulkNextIv, SHA1_SIZE);
 	Copy(crypt_key_src + 0, se->BulkSendKey->Data, SHA1_SIZE);
 	Copy(crypt_key_src + SHA1_SIZE, iv, SHA1_SIZE);
-	HashSha1(crypt_key, crypt_key_src, SHA1_SIZE * 2);
+	Sha1(crypt_key, crypt_key_src, SHA1_SIZE * 2);
 	c = NewCrypt(crypt_key, sizeof(crypt_key));
 	Encrypt(c, buf + SHA1_SIZE + SHA1_SIZE, buf + SHA1_SIZE + SHA1_SIZE, sizeof(UINT64) + data_size + padding_size);
 	FreeCrypt(c);
@@ -2567,7 +2567,7 @@ void RUDPBulkSend(RUDP_STACK *r, RUDP_SESSION *se, void *data, UINT data_size)
 	if (se->UseHMac == false)
 	{
 		Copy(buf + 0, se->BulkSendKey->Data, SHA1_SIZE);
-		HashSha1(sign, buf, SHA1_SIZE + SHA1_SIZE + sizeof(UINT64) + data_size + padding_size);
+		Sha1(sign, buf, SHA1_SIZE + SHA1_SIZE + sizeof(UINT64) + data_size + padding_size);
 		Copy(buf + 0, sign, SHA1_SIZE);
 	}
 	else
@@ -2690,7 +2690,7 @@ bool RUDPCheckSignOfRecvPacket(RUDP_STACK *r, RUDP_SESSION *se, void *recv_data,
 	// Verification the signature (segment packet)
 	Copy(sign, p, SHA1_SIZE);
 	Copy(p, se->Key_Recv, SHA1_SIZE);
-	HashSha1(sign2, p, recv_size);
+	Sha1(sign2, p, recv_size);
 
 	if (r->Protocol == RUDP_PROTOCOL_DNS || r->Protocol == RUDP_PROTOCOL_ICMP)
 	{
@@ -2713,7 +2713,7 @@ bool RUDPCheckSignOfRecvPacket(RUDP_STACK *r, RUDP_SESSION *se, void *recv_data,
 	{
 		Copy(sign, p, SHA1_SIZE);
 		Copy(p, se->BulkRecvKey->Data, SHA1_SIZE);
-		HashSha1(sign2, p, recv_size);
+		Sha1(sign2, p, recv_size);
 		Copy(p, sign, SHA1_SIZE);
 
 		if (Cmp(sign, sign2, SHA1_SIZE) == 0)
@@ -2765,7 +2765,7 @@ bool RUDPProcessBulkRecvPacket(RUDP_STACK *r, RUDP_SESSION *se, void *recv_data,
 	{
 		Copy(sign, p, SHA1_SIZE);
 		Copy(p, se->BulkRecvKey->Data, SHA1_SIZE);
-		HashSha1(sign2, p, recv_size);
+		Sha1(sign2, p, recv_size);
 		Copy(p, sign, SHA1_SIZE);
 
 		if (Cmp(sign, sign2, SHA1_SIZE) != 0)
@@ -2814,7 +2814,7 @@ bool RUDPProcessBulkRecvPacket(RUDP_STACK *r, RUDP_SESSION *se, void *recv_data,
 	}
 	Copy(keygen + 0, se->BulkRecvKey->Data, SHA1_SIZE);
 	Copy(keygen + SHA1_SIZE, iv, SHA1_SIZE);
-	HashSha1(key, keygen, sizeof(keygen));
+	Sha1(key, keygen, sizeof(keygen));
 
 	c = NewCrypt(key, sizeof(key));
 	Encrypt(c, p, p, size);
@@ -2910,7 +2910,7 @@ bool RUDPProcessRecvPacket(RUDP_STACK *r, RUDP_SESSION *se, void *recv_data, UIN
 	// Validate the signature
 	Copy(sign, p, SHA1_SIZE);
 	Copy(p, se->Key_Recv, SHA1_SIZE);
-	HashSha1(sign2, p, recv_size);
+	Sha1(sign2, p, recv_size);
 	Copy(p, sign, SHA1_SIZE);
 
 	if (r->Protocol == RUDP_PROTOCOL_DNS || r->Protocol == RUDP_PROTOCOL_ICMP)
@@ -2942,7 +2942,7 @@ bool RUDPProcessRecvPacket(RUDP_STACK *r, RUDP_SESSION *se, void *recv_data, UIN
 	}
 	Copy(keygen + 0, iv, SHA1_SIZE);
 	Copy(keygen + SHA1_SIZE, se->Key_Recv, SHA1_SIZE);
-	HashSha1(key, keygen, sizeof(keygen));
+	Sha1(key, keygen, sizeof(keygen));
 
 	c = NewCrypt(key, sizeof(key));
 	Encrypt(c, p, p, size);
@@ -3505,13 +3505,13 @@ void RUDPSendSegmentNow(RUDP_STACK *r, RUDP_SESSION *se, UINT64 seq_no, void *da
 	// Encrypt
 	Copy(keygen + 0, iv, SHA1_SIZE);
 	Copy(keygen + SHA1_SIZE, se->Key_Send, SHA1_SIZE);
-	HashSha1(key, keygen, sizeof(keygen));
+	Sha1(key, keygen, sizeof(keygen));
 	c = NewCrypt(key, sizeof(key));
 	Encrypt(c, dst + SHA1_SIZE * 2, dst + SHA1_SIZE * 2, current_size - (SHA1_SIZE * 2));
 	FreeCrypt(c);
 
 	// Sign
-	HashSha1(sign, dst, current_size);
+	Sha1(sign, dst, current_size);
 	if (r->Protocol == RUDP_PROTOCOL_DNS || r->Protocol == RUDP_PROTOCOL_ICMP)
 	{
 		XorData(sign, sign, r->SvcNameHash, SHA1_SIZE);
@@ -3671,26 +3671,26 @@ RUDP_SESSION *RUDPNewSession(bool server_mode, IP *my_ip, UINT my_port, IP *your
 	b = NewBuf();
 	WriteBuf(b, init_key, SHA1_SIZE);
 	WriteBufStr(b, "zurukko");
-	HashSha1(key1, b->Buf, b->Size);
+	Sha1(key1, b->Buf, b->Size);
 	FreeBuf(b);
 
 	b = NewBuf();
 	WriteBuf(b, init_key, SHA1_SIZE);
 	WriteBuf(b, key1, SHA1_SIZE);
 	WriteBufStr(b, "yasushineko");
-	HashSha1(key2, b->Buf, b->Size);
+	Sha1(key2, b->Buf, b->Size);
 	FreeBuf(b);
 
 	// Generate the magic number for the KeepAlive
 	b = NewBuf();
 	WriteBuf(b, init_key, SHA1_SIZE);
 	WriteBufStr(b, "Magic_KeepAliveRequest");
-	HashSha1(se->Magic_KeepAliveRequest, b->Buf, b->Size);
+	Sha1(se->Magic_KeepAliveRequest, b->Buf, b->Size);
 	FreeBuf(b);
 	b = NewBuf();
 	WriteBuf(b, init_key, SHA1_SIZE);
 	WriteBufStr(b, "Magic_KeepAliveResponse");
-	HashSha1(se->Magic_KeepAliveResponse, b->Buf, b->Size);
+	Sha1(se->Magic_KeepAliveResponse, b->Buf, b->Size);
 	FreeBuf(b);
 
 	if (server_mode == false)
@@ -3852,7 +3852,7 @@ void RUDPMainThread(THREAD *thread, void *param)
 							{
 								UCHAR hash[SHA1_SIZE];
 
-								HashSha1(hash, ((UCHAR *)p->Data) + ip_header_size + sizeof(ICMP_HEADER) + sizeof(ICMP_ECHO) + SHA1_SIZE,
+								Sha1(hash, ((UCHAR *)p->Data) + ip_header_size + sizeof(ICMP_HEADER) + sizeof(ICMP_ECHO) + SHA1_SIZE,
 									p->Size - (ip_header_size + sizeof(ICMP_HEADER) + sizeof(ICMP_ECHO) + SHA1_SIZE));
 
 								if (Cmp(hash, ((UCHAR *)p->Data) + ip_header_size + sizeof(ICMP_HEADER) + sizeof(ICMP_ECHO), SHA1_SIZE) == 0)
@@ -3990,7 +3990,7 @@ void RUDPMainThread(THREAD *thread, void *param)
 				Copy(icmp_data, p->Data, p->Size);
 
 				// Hash
-				HashSha1(hash, icmp_data, p->Size);
+				Sha1(hash, icmp_data, p->Size);
 
 				// Checksum calculation
 				icmp_header->Checksum = IpChecksum(dst_data, dst_size);
@@ -4166,7 +4166,7 @@ void RUDPGetRegisterHostNameByIP(char *dst, UINT size, IP *ip)
 	{
 		UCHAR hash[SHA1_SIZE];
 
-		HashSha1(hash, ip->addr, 4);
+		Sha1(hash, ip->addr, 4);
 		BinToStr(tmp, sizeof(tmp), hash, 2);
 	}
 	else
@@ -4661,7 +4661,7 @@ UINT GetHostIPAddressHash32()
 
 	WriteBuf(b, rand_port_numbers, sizeof(rand_port_numbers));
 
-	HashSha1(hash, b->Buf, b->Size);
+	Sha1(hash, b->Buf, b->Size);
 
 	FreeBuf(b);
 
@@ -5291,7 +5291,7 @@ RUDP_STACK *NewRUDP(bool server_mode, char *svc_name, RUDP_STACK_INTERRUPTS_PROC
 	Trim(tmp);
 	StrLower(tmp);
 
-	HashSha1(r->SvcNameHash, tmp, StrLen(tmp));
+	Sha1(r->SvcNameHash, tmp, StrLen(tmp));
 
 	r->Client_IcmpId = (USHORT)(Rand32() % 65534 + 1);
 	r->Client_IcmpSeqNo = (USHORT)(Rand32() % 65534 + 1);
@@ -5310,7 +5310,7 @@ RUDP_STACK *NewRUDP(bool server_mode, char *svc_name, RUDP_STACK_INTERRUPTS_PROC
 #endif	// OS_WIN32
 
 		pid = Endian32(pid);
-		HashSha1(pid_hash, &pid, sizeof(UINT));
+		Sha1(pid_hash, &pid, sizeof(UINT));
 
 		pid_us = READ_USHORT(pid_hash);
 		if (pid_us == 0 || pid_us == 0xFFFF)
@@ -5564,7 +5564,7 @@ void GetCurrentMachineIpProcessHashInternal(void *hash)
 	}
 	FreeHostIPAddressList(ip_list);
 
-	HashSha1(hash, b->Buf, b->Size);
+	Sha1(hash, b->Buf, b->Size);
 
 	FreeBuf(b);
 
@@ -10677,7 +10677,7 @@ ROUTE_TABLE *GetRouteTable()
 		WriteBuf(buf, e, sizeof(ROUTE_ENTRY));
 	}
 
-	Hash(hash, buf->Buf, buf->Size, false);
+	Md5(hash, buf->Buf, buf->Size);
 
 	FreeBuf(buf);
 
@@ -11108,7 +11108,7 @@ SOCK *NewUDPEx2Rand(bool ipv6, IP *ip, void *rand_seed, UINT rand_seed_size, UIN
 		WriteBuf(buf, rand_seed, rand_seed_size);
 		WriteBufInt(buf, i);
 
-		HashSha1(hash, buf->Buf, buf->Size);
+		Sha1(hash, buf->Buf, buf->Size);
 
 		FreeBuf(buf);
 
@@ -11160,7 +11160,7 @@ SOCK *NewUDPEx2RandMachineAndExePath(bool ipv6, IP *ip, UINT num_retry, UCHAR ra
 	WriteBufChar(b, rand_port_id);
 	//WriteBufInt(b, GetHostIPAddressHash32());
 
-	HashSha1(hash, b->Buf, b->Size);
+	Sha1(hash, b->Buf, b->Size);
 
 	FreeBuf(b);
 
@@ -18092,7 +18092,7 @@ UINT64 GetHostIPAddressListHash()
 
 	WriteBufStr(buf, "test");
 
-	HashSha1(hash, buf->Buf, buf->Size);
+	Sha1(hash, buf->Buf, buf->Size);
 
 	FreeBuf(buf);
 
@@ -20926,7 +20926,7 @@ PACK *RecvPackWithHash(SOCK *s)
 		return false;
 	}
 
-	HashSha1(hash1, data, sz);
+	Sha1(hash1, data, sz);
 	if (RecvAll(s, hash2, sizeof(hash2), s->SecureMode) == false)
 	{
 		Free(data);
@@ -20987,7 +20987,7 @@ bool SendPackWithHash(SOCK *s, PACK *p)
 
 	SendAdd(s, &sz, sizeof(UINT));
 	SendAdd(s, b->Buf, b->Size);
-	HashSha1(hash, b->Buf, b->Size);
+	Sha1(hash, b->Buf, b->Size);
 	SendAdd(s, hash, sizeof(hash));
 
 	FreeBuf(b);

--- a/src/Mayaqua/Table.c
+++ b/src/Mayaqua/Table.c
@@ -1205,7 +1205,7 @@ void GenerateUnicodeCacheFileName(wchar_t *name, UINT size, wchar_t *strfilename
 	UniStrCat(hashtemp, sizeof(hashtemp), exe);
 	UniStrLower(hashtemp);
 
-	Hash(hash, hashtemp, UniStrLen(hashtemp) * sizeof(wchar_t), true);
+	Sha0(hash, hashtemp, UniStrLen(hashtemp) * sizeof(wchar_t));
 	BinToStrW(hashstr, sizeof(hashstr), hash, 4);
 	UniFormat(tmp, sizeof(tmp), UNICODE_CACHE_FILE, hashstr);
 	UniStrLower(tmp);
@@ -1266,7 +1266,7 @@ void SaveUnicodeCache(wchar_t *strfilename, UINT strfilesize, UCHAR *hash)
 		WriteBuf(b, t->unistr, UniStrLen(t->unistr) * sizeof(wchar_t));
 	}
 
-	Hash(binhash, b->Buf, b->Size, false);
+	Md5(binhash, b->Buf, b->Size);
 	WriteBuf(b, binhash, MD5_SIZE);
 
 	GenerateUnicodeCacheFileName(name, sizeof(name), strfilename, strfilesize, hash);
@@ -1316,7 +1316,7 @@ bool LoadUnicodeCache(wchar_t *strfilename, UINT strfilesize, UCHAR *hash)
 	SeekBuf(b, 0, 0);
 	FileClose(io);
 
-	Hash(binhash, b->Buf, b->Size >= MD5_SIZE ? (b->Size - MD5_SIZE) : 0, false);
+	Md5(binhash, b->Buf, b->Size >= MD5_SIZE ? (b->Size - MD5_SIZE) : 0);
 	Copy(binhash_2, ((UCHAR *)b->Buf) + (b->Size >= MD5_SIZE ? (b->Size - MD5_SIZE) : 0), MD5_SIZE);
 	if (Cmp(binhash, binhash_2, MD5_SIZE) != 0)
 	{
@@ -1419,7 +1419,7 @@ bool LoadTableMain(wchar_t *filename)
 		return false;
 	}
 
-	Hash(hash, b->Buf, b->Size, false);
+	Md5(hash, b->Buf, b->Size);
 
 	if (LoadUnicodeCache(filename, b->Size, hash) == false)
 	{

--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -2288,7 +2288,7 @@ void UnixGenPidFileName(char *name, UINT size)
 	StrCat(exe_name, sizeof(exe_name), ":pid_hash");
 	StrUpper(exe_name);
 
-	Hash(hash, exe_name, StrLen(exe_name), false);
+	Md5(hash, exe_name, StrLen(exe_name));
 	BinToStr(tmp1, sizeof(tmp1), hash, sizeof(hash));
 
 	Format(name, size, "%s/.pid_%s", dir, tmp1);
@@ -2333,7 +2333,7 @@ void UnixGenCtlFileName(char *name, UINT size)
 	StrCat(exe_name, sizeof(exe_name), ":pid_hash");
 	StrUpper(exe_name);
 
-	Hash(hash, exe_name, StrLen(exe_name), false);
+	Md5(hash, exe_name, StrLen(exe_name));
 	BinToStr(tmp1, sizeof(tmp1), hash, sizeof(hash));
 
 	Format(name, size, "%s/.ctl_%s", dir, tmp1);


### PR DESCRIPTION
Changes proposed in this pull request:
- `Hash()` has been removed because it was ambiguous, `Md5()` and `Sha0()` are proper replacements.
- `HashSha1()` has been marked as deprecated in favor of `Sha1()`.
- `Sha()` has been marked as deprecated in favor of the individual functions.
- `HMacMd5()` and `HMacSha1()` now share a common implementation handled by the new `Internal_HMac()` function.
- `NewMd()` and `MdProcess()` now support plain hashing (without the key).
- `NewMd()`, `SetMdKey()` and `MdProcess()` now check the OpenSSL functions' return value and in case of failure a debug message is printed along with the error string, if available.
- `SetMdKey()`'s return value has been changed from `void` to `bool`, so that it's possible to know whether the function succeeded or not.
- `MdProcess()`' return value has been changed from `void` to `UINT` (`unsigned int`) and the function now returns the number of bytes written by `HMAC_Final()` or `EVP_DigestFinal_ex()`.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.