### PR TITLE
Enable debug messages and memory check with debug configuration

### DIFF
--- a/src/Cedar/SW.c
+++ b/src/Cedar/SW.c
@@ -783,7 +783,11 @@ UINT SWExec()
 		MayaquaMinimalMode();
 	}
 
+#ifdef DEBUG
+	InitMayaqua(true, true, 0, NULL);
+#else
 	InitMayaqua(false, false, 0, NULL);
+#endif
 	InitCedar();
 
 	if (is_datafile_exists == false)

--- a/src/Mayaqua/Microsoft.c
+++ b/src/Mayaqua/Microsoft.c
@@ -4565,7 +4565,11 @@ void CALLBACK MsServiceDispatcher(DWORD argc, LPTSTR *argv)
 
 	//// Initialization
 	// Start of the Mayaqua
+#ifdef DEBUG
+	InitMayaqua(true, true, 0, NULL);
+#else
 	InitMayaqua(false, false, 0, NULL);
+#endif
 
 	// Stop the MS-IME
 	MsDisableIme();
@@ -4740,7 +4744,11 @@ UINT MsService(char *name, SERVICE_FUNCTION *start, SERVICE_FUNCTION *stop, UINT
 	}
 
 	// Start of the Mayaqua
+#ifdef DEBUG
+	InitMayaqua(true, true, 0, NULL);
+#else
 	InitMayaqua(false, false, 0, NULL);
+#endif
 
 	// Stop the MS-IME
 	MsDisableIme();

--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -2753,7 +2753,11 @@ RESTART_PROCESS:
 	}
 	else if (argc >= 3 && StrCmpi(argv[1], UNIX_SVC_ARG_START) == 0 && StrCmpi(argv[2], UNIX_SVC_ARG_FOREGROUND) == 0)
 	{
+#ifdef DEBUG
+		InitMayaqua(true, true, argc, argv);
+#else
 		InitMayaqua(false, false, argc, argv);
+#endif
 		UnixExecService(name, start, stop);
 		FreeMayaqua();
 	}
@@ -2769,7 +2773,11 @@ void UnixServiceMain(int argc, char *argv[], char *name, SERVICE_FUNCTION *start
 {
 	UINT mode = 0;
 	// Start of the Mayaqua
+#ifdef DEBUG
+	InitMayaqua(true, true, argc, argv);
+#else
 	InitMayaqua(false, false, argc, argv);
+#endif
 
 	if (argc >= 2)
 	{

--- a/src/hamcorebuilder/hamcorebuilder.c
+++ b/src/hamcorebuilder/hamcorebuilder.c
@@ -136,7 +136,11 @@
 int main(int argc, char *argv[])
 {
 	MayaquaMinimalMode();
+#ifdef DEBUG
+	InitMayaqua(true, true, argc, argv);
+#else
 	InitMayaqua(false, false, argc, argv);
+#endif
 	InitCedar();
 
 	Print("hamcore.se2 Build Utility\n");

--- a/src/vpncmd/vpncmd.c
+++ b/src/vpncmd/vpncmd.c
@@ -143,7 +143,11 @@ int main(int argc, char *argv[])
 	SetConsoleTitleA(CEDAR_PRODUCT_STR " VPN Command Line Utility");
 #endif	// OS_WIN32
 
+#ifdef DEBUG
+	InitMayaqua(true, true, argc, argv);
+#else
 	InitMayaqua(false, false, argc, argv);
+#endif
 	InitCedar();
 
 	s = GetCommandLineUniStr();

--- a/src/vpncmgr/vpncmgr.c
+++ b/src/vpncmgr/vpncmgr.c
@@ -136,7 +136,11 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	InitProcessCallOnce();
 
+#ifdef DEBUG
+	InitMayaqua(true, true, 0, NULL);
+#else
 	InitMayaqua(false, false, 0, NULL);
+#endif
 	InitCedar();
 
 

--- a/src/vpndrvinst/vpndrvinst.c
+++ b/src/vpndrvinst/vpndrvinst.c
@@ -355,7 +355,11 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	InitProcessCallOnce();
 
+#ifdef DEBUG
+	InitMayaqua(true, true, 0, NULL);
+#else
 	InitMayaqua(false, false, 0, NULL);
+#endif
 	EnableProbe(false);
 	InitCedar();
 	SetHamMode();

--- a/src/vpninstall/vpninstall.c
+++ b/src/vpninstall/vpninstall.c
@@ -1635,9 +1635,13 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	INSTANCE *instance;
 	InitProcessCallOnce();
+#ifdef DEBUG
+	is_debug = true;
+#else
 	is_debug = false;
+#endif
 	MayaquaMinimalMode();
-	InitMayaqua(false, is_debug, 0, NULL);
+	InitMayaqua(is_debug, is_debug, 0, NULL);
 	InitCedar();
 	ViSetSkip();
 	ViLoadStringTables();

--- a/src/vpnsmgr/vpnsmgr.c
+++ b/src/vpnsmgr/vpnsmgr.c
@@ -134,7 +134,11 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	InitProcessCallOnce();
 
+#ifdef DEBUG
+	InitMayaqua(true, true, 0, NULL);
+#else
 	InitMayaqua(false, false, 0, NULL);
+#endif
 	InitCedar();
 	SMExec();
 	FreeCedar();


### PR DESCRIPTION
This pull request changes all the calls to `InitMayaqua()` so that the memory check and debug functions are enabled if `DEBUG` is defined.

---

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

I choose option 1.