### PR TITLE
fix localization files, missing strings were taken from "en"

### DIFF
--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -6711,6 +6711,8 @@ CMD_AccountDetailSet_Prompt_BRIDGE	启用桥/路由器模式 (yes/no):
 CMD_AccountDetailSet_Prompt_MONITOR	启用监控模式 (yes/no): 
 CMD_AccountDetailSet_Prompt_NOTRACK	禁用路由表项调节器 (yes/no): 
 CMD_AccountDetailSet_Prompt_NOQOS	禁用 QoS 控制功能 (yes/no): 
+CMD_AccountDetailSet_DISABLEUDP Specify "yes" when disabling UDP acceleration function. Normally "no" is specified.
+CMD_AccountDetailSet_Prompt_DISABLEUDP   Disable UDP Acceleration Function (yes/no):
 
 
 # AccountRename 命令

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -7201,4 +7201,5 @@ SW_LINK_NAME_LANGUAGE_COMMENT				%s の表示言語を変更します。
 SW_LINK_NAME_DEBUG							デバッグ情報収集ツール
 SW_LINK_NAME_DEBUG_COMMENT					SoftEther VPN のデバッグ情報を収集します。サポート担当者から依頼があった場合のみ使用してください。
 
-
+CMD_AccountDetailSet_DISABLEUDP	Specify "yes" when disabling UDP acceleration function. Normally "no" is specified.
+CMD_AccountDetailSet_Prompt_DISABLEUDP	 Disable UDP Acceleration Function (yes/no):

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -1105,24 +1105,6 @@ SVC_VPNBRIDGE_TITLE SoftEther VPN Bridge
 SVC_VPNBRIDGE_DESCRIPT SoftEther VPN Bridge 프로세스를 관리합니다. SoftEther VPN Bridge는이 컴퓨터에 연결되어있는 네트워크와 원격지에있는 SoftEther VPN Server 사이를 브리지 연결합니다. 이 서비스가 중지되면이 컴퓨터 SoftEther VPN Bridge는 중지하고 브리지 연결을 통한 통신 할 수 없습니다.
 
 
-# 서비스 정의 (SoftEther VPN Client)
-SVC_SEVPNCLIENT_NAME sevpnclient
-SVC_SEVPNCLIENT_TITLE SoftEther VPN Client
-SVC_SEVPNCLIENT_DESCRIPT SoftEther VPN Client의 가상 LAN 카드 장치 드라이버 및 연결 서비스를 관리합니다. 이 서비스가 중지되면이 컴퓨터 SoftEther VPN Client를 사용하여 SoftEther VPN Server에 연결할 수 없습니다.
-
-
-# 서비스 정의 (SoftEther VPN Server)
-SVC_SEVPNSERVER_NAME sevpnserver
-SVC_SEVPNSERVER_TITLE SoftEther VPN Server
-SVC_SEVPNSERVER_DESCRIPT SoftEther VPN Server 서버 프로세스를 관리합니다. SoftEther VPN Server는 고성능 SoftEther VPN Server 기능을 TCP/IP 프로토콜을 통해 제공합니다. 이 서비스가 중지되면이 컴퓨터 SoftEther VPN Server를 중지하고 SoftEther VPN Client는이 컴퓨터에 VPN 연결 할 수 없습니다.
-
-
-# 서비스 정의 (SoftEther VPN Bridge)
-SVC_SEVPNBRIDGE_NAME sevpnbridge
-SVC_SEVPNBRIDGE_TITLE SoftEther VPN Bridge
-SVC_SEVPNBRIDGE_DESCRIPT SoftEther VPN Bridge 프로세스를 관리합니다. SoftEther VPN Bridge는이 컴퓨터에 연결되어있는 네트워크와 원격지에있는 SoftEther VPN Server 사이를 브리지 연결합니다. 이 서비스가 중지되면이 컴퓨터 SoftEther VPN Bridge는 중지하고 브리지 연결을 통한 통신 할 수 없습니다.
-
-
 # 서비스 정의 (SoftEther VPN User-mode Router)
 SVC_VPNROUTER_NAME vpnrouter
 SVC_VPNROUTER_TITLE SoftEther VPN Router
@@ -4426,7 +4408,7 @@ CMD_DISCONNECTED_MSG \n --- 오류 --- \n \n 관리 호스트와의 통신 세�
 CMD_VPNCMD SoftEther VPN 명령 줄 관리 유틸리티
 CMD_VPNCMD_HELP vpncmd 프로그램은 SoftEther VPN 소프트웨어를 명령 줄에서 관리 할 수있는 유틸리티입니다. vpncmd를 사용하면 로컬 또는 원격 컴퓨터에서 실행되는 VPN Client, VPN Server 및 VPN Bridge에 연결하여 해당 서비스를 관리 할 수 있습니다. 또한 VPN Tools 모드를 사용하여 VPN Server와 VPN Client에 연결되어 있지 않아도 사용할 수있는 인증서 작성 및 속도 측정 기능 등을 호출 할 수 있습니다. \nvpncmd는/IN 및/OUT 매개 변수로 파일 이름을 지정하면 실행할 명령을 열거 한 파일에 따라 명령을 일괄 실행하거나 실행 결과를 파일로 내보낼 수 있습니다. 일반적으로 vpncmd을 시작하면 명령 프롬프트가 표시되지만/IN 매개 변수에서 입력 파일을 지정하면 입력 파일의 모든 행의 실행이 완료되면 자동으로 종료됩니다. 또한/CMD 매개 변수에서 실행할 명령을 지정하면 해당 명령의 실행이 완료되면 자동으로 종료됩니다./IN 파라미터 및/CMD 매개 변수는 동시에 지정할 수 없습니다. vpncmd 프로그램의 종료 코드는 마지막으로 실행 한 명령의 오류 코드 (성공했을 경우는 0)입니다. \nWindows 환경에서는 관리자 권한으로 한 번 이상 vpncmd를 시작하면 다음부터는 Windows의 명령 프롬프트와 파일 이름을 지정하고 실행을 열고 vpncmd를 입력하는 것만으로 vpncmd을 시작할 수 있도록 합니다. UNIX 시스템에서 같은 일을 실현하기 위해 PATH 환경 변수를 수동으로 적절히 설정할 수 있습니다.
 CMD_VPNCMD_ARGS vpncmd [host:port] [/CLIENT |/SERVER |/TOOLS] [/HUB:hub] [/ADMINHUB:adminhub] [/PASSWORD:password] [/IN:infile] [/OUT:outfile] [/CMD commands...]
-CMD_VPNCMD_ [host:port] 호스트 이름:포트 번호] 형식의 매개 변수를 지정하면 그 호스트에 자동으로 연결합니다. 지정하지 않으면 연결 정보를 입력하라는 메시지가 표시됩니다. VPN Client에 연결하는 경우 포트 번호는 지정할 수 없습니다.
+CMD_VPNCMD_[host:port] 호스트 이름:포트 번호] 형식의 매개 변수를 지정하면 그 호스트에 자동으로 연결합니다. 지정하지 않으면 연결 정보를 입력하라는 메시지가 표시됩니다. VPN Client에 연결하는 경우 포트 번호는 지정할 수 없습니다.
 CMD_VPNCMD_CLIENT VPN Client에 연결하고 관리합니다./SERVER 함께 지정할 수 없습니다.
 CMD_VPNCMD_SERVER VPN Server 또는 VPN Bridge에 연결하고 관리합니다./CLIENT 함께 지정할 수 없습니다.
 CMD_VPNCMD_TOOLS VPN Tools 명령을 사용할 수 프롬프트를 표시합니다. 여기에는 인증서 간이 도구 (MakeCert 명령) 및 통신 속도 측정 도구 (SpeedTest 명령) 등이 포함됩니다.
@@ -4490,7 +4472,7 @@ CMD_ServerStatusGet_Args ServerStatusGet
 CMD_ListenerCreate TCP 리스너 추가
 CMD_ListenerCreate_Help 서버에 새로운 TCP 리스너를 추가합니다. TCP 리스너를 추가하면 서버는 지정된 TCP/IP 포트 번호에서 클라이언트의 연결 대기를 시작합니다. \n 번 추가 한 TCP 리스너는 ListenerDelete 명령으로 제거 할 수 있습니다. \n 또한, 현재 등록되어있는 TCP 리스너 목록은 ListenerList 명령에서 얻을 수 있습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ListenerCreate_Args ListenerCreate [port]
-CMD_ListenerCreate_ [port] 새로 추가하는 TCP/IP 리스너의 포트 번호를 정수로 지정합니다. 이미 다른 프로그램이 사용하는 포트 번호를 사용할 수 있지만 그 프로그램이 포트의 사용을 종료 할 때까지 VPN Server는 해당 포트를 사용할 수 없습니다. 포트 번호는 1 이상 65535 이하로 지정하십시오.
+CMD_ListenerCreate_[port] 새로 추가하는 TCP/IP 리스너의 포트 번호를 정수로 지정합니다. 이미 다른 프로그램이 사용하는 포트 번호를 사용할 수 있지만 그 프로그램이 포트의 사용을 종료 할 때까지 VPN Server는 해당 포트를 사용할 수 없습니다. 포트 번호는 1 이상 65535 이하로 지정하십시오.
 CMD_ListenerCreate_PortPrompt 새로 추가하는 TCP/IP 리스너 포트 번호:
 
 
@@ -4498,7 +4480,7 @@ CMD_ListenerCreate_PortPrompt 새로 추가하는 TCP/IP 리스너 포트 번호
 CMD_ListenerDelete TCP 리스너 제거
 CMD_ListenerDelete_Help 서버에 등록되어있는 TCP 리스너를 제거합니다. TCP 수신기가 동작 상태에있을 경우 자동으로 작동을 중지하고 청취자가 삭제됩니다. \n 또한, 현재 등록되어있는 TCP 리스너 목록은 ListenerList 명령에서 얻을 수 있습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ListenerDelete_Args ListenerDelete [port]
-CMD_ListenerDelete_ [port] 삭제할 TCP/IP 리스너의 포트 번호를 정수로 지정합니다.
+CMD_ListenerDelete_[port] 삭제할 TCP/IP 리스너의 포트 번호를 정수로 지정합니다.
 CMD_ListenerDelete_PortPrompt 삭제하는 TCP/IP 리스너 포트 번호:
 
 
@@ -4514,7 +4496,7 @@ CMD_ListenerList_Column2 상태
 CMD_ListenerEnable TCP 수신기의 동작 개시
 CMD_ListenerEnable_Help 현재 서버에 등록되어있는 TCP 리스너가 정지하고있는 경우는, 그 동작을 시작합니다. \n 또한, 현재 등록되어있는 TCP 리스너 목록은 ListenerList 명령에서 얻을 수 있습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ListenerEnable_Args ListenerEnable [port]
-CMD_ListenerEnable_ [port] 시작하는 TCP/IP 리스너의 포트 번호를 정수로 지정합니다.
+CMD_ListenerEnable_[port] 시작하는 TCP/IP 리스너의 포트 번호를 정수로 지정합니다.
 CMD_ListenerEnable_PortPrompt 시작하는 TCP/IP 리스너 포트 번호:
 
 
@@ -4522,7 +4504,7 @@ CMD_ListenerEnable_PortPrompt 시작하는 TCP/IP 리스너 포트 번호:
 CMD_ListenerDisable TCP 수신기의 동작 정지
 CMD_ListenerDisable_Help 현재 서버에 등록되어있는 TCP 리스너가 실행중인 경우 작동을 중지합니다. \n 또한, 현재 등록되어있는 TCP 리스너 목록은 ListenerList 명령에서 얻을 수 있습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ListenerDisable_Args ListenerDisable [port]
-CMD_ListenerDisable_ [port] 중지 TCP/IP 리스너의 포트 번호를 정수로 지정합니다.
+CMD_ListenerDisable_[port] 중지 TCP/IP 리스너의 포트 번호를 정수로 지정합니다.
 CMD_ListenerDisable_PortPrompt 시작하는 TCP/IP 리스너 포트 번호:
 
 
@@ -4530,7 +4512,7 @@ CMD_ListenerDisable_PortPrompt 시작하는 TCP/IP 리스너 포트 번호:
 CMD_ServerPasswordSet VPN Server 관리자 암호 설정
 CMD_ServerPasswordSet_Help VPN Server 관리자 암호를 설정합니다. 매개 변수로 암호를 지정 할 수 있습니다. 매개 변수를 지정하지 않으면, 패스워드와 그 확인 입력을위한 프롬프트가 표시됩니다. 비밀번호를 매개 변수로 주었을 경우, 암호가 일시적으로 화면에 표시되기 때문에 위험합니다. 가능한 매개 변수를 지정하지 않고 암호 프롬프트를 사용하여 암호를 입력 할 것을 권장합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ServerPasswordSet_Args ServerPasswordSet [password]
-CMD_ServerPasswordSet_ [password] 새로운 암호를 지정합니다.
+CMD_ServerPasswordSet_[password] 새로운 암호를 지정합니다.
 
 
 # ClusterSettingGet 명령
@@ -4564,7 +4546,7 @@ CMD_ClusterSettingController_ONLY "yes"를 지정하면 VPN Server가 클러스�
 CMD_ClusterSettingMember VPN Server 유형을 클러스터 구성원으로 설정
 CMD_ClusterSettingMember_Help VPN Server 유형을 "클러스터 구성원 서버"로 설정합니다. 클러스터 구성원 서버는 여러 대의 VPN Server에서 클러스터링을 구축하는 경우에있어서의 특정 기존 클러스터 컨트롤러가 중심이되어 구성된 클러스터에 속하는 다른 구성원 컴퓨터에서 클러스터에 필요한만큼 여러 추가 수 있습니다. \n 클러스터 구성원 서버로 VPN Server를 설정하려면 사전에 참가할 예정 클러스터 컨트롤러의 관리자에 컨트롤러의 IP 주소와 포트 번호이 VPN Server의 공용 IP 주소 및 공개 포트 번호 (필요한 경우) 및 암호를 문의해야합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령을 실행하면 VPN Server가 자동으로 다시 시작합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다.
 CMD_ClusterSettingMember_Args ClusterSettingMember [server:port] [/IP:ip] [/PORTS:ports] [/PASSWORD:password] [/WEIGHT:weight]
-CMD_ClusterSettingMember_ [server:port] 호스트 이름:포트 번호] 형식의 매개 변수에 연결할 클러스터 컨트롤러의 호스트 이름 또는 IP 주소 및 포트 번호를 지정합니다.
+CMD_ClusterSettingMember_[server:port] 호스트 이름:포트 번호] 형식의 매개 변수에 연결할 클러스터 컨트롤러의 호스트 이름 또는 IP 주소 및 포트 번호를 지정합니다.
 CMD_ClusterSettingMember_IP 이 서버의 공용 IP 주소를 지정합니다. 공개 IP 주소를 지정하지 않으면 "/IP:none"과 같이 지정하십시오. 공개 IP 주소를 지정하지 않으면 클러스터 컨트롤러에 연결할 때 사용되는 네트워크 인터페이스의 IP 주소가 자동으로 사용됩니다.
 CMD_ClusterSettingMember_PORTS 이 서버의 공개 포트 번호 목록을 지정합니다. 공개 포트 번호는 적어도 하나 이상 설정해야 복수 설정할 수 있습니다. 이 경우 "/PORTS:443,992,8888"와 같이 콤마 기호로 구분합니다.
 CMD_ClusterSettingMember_PASSWORD 연결된 컨트롤러에 연결하기위한 암호를 지정합니다. 연결된 컨트롤러 관리 비밀번호와 동일합니다.
@@ -4586,7 +4568,7 @@ CMD_ClusterMemberList_Args ClusterMemberList
 CMD_ClusterMemberInfoGet 클러스터 구성원의 정보 검색
 CMD_ClusterMemberInfoGet_Help VPN Server가 클러스터 컨트롤러로 작동하는 경우 해당 클러스터의 클러스터 구성원 서버 ID를 지정하여 그 구성원 서버의 정보를 얻을 수 있습니다. \n 지정된 클러스터 구성원 서버의 서버 유형, 연결 설정 시간, IP 주소, 호스트 이름, 지점, 공개 포트의 목록, 실행중인 가상 HUB 수 , 1 개째의 가상 HUB, 세션, TCP 연결 개수를 취득 할 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다.
 CMD_ClusterMemberInfoGet_Args ClusterMemberInfoGet [id]
-CMD_ClusterMemberInfoGet_ [id] 정보를 얻으려면 클러스터 구성원의 ID를 지정합니다. 클러스터 구성원 서버의 ID는 ClusterMemberList 명령에서 얻을 수 있습니다.
+CMD_ClusterMemberInfoGet_[id] 정보를 얻으려면 클러스터 구성원의 ID를 지정합니다. 클러스터 구성원 서버의 ID는 ClusterMemberList 명령에서 얻을 수 있습니다.
 CMD_ClusterMemberInfoGet_PROMPT_ID 정보를 얻을 클러스터 멤버 ID:
 
 
@@ -4594,7 +4576,7 @@ CMD_ClusterMemberInfoGet_PROMPT_ID 정보를 얻을 클러스터 멤버 ID:
 CMD_ClusterMemberCertGet 클러스터 구성원의 인증서 취득
 CMD_ClusterMemberCertGet_Help VPN Server가 클러스터 컨트롤러로 작동하는 경우 해당 클러스터의 클러스터 구성원 서버 ID를 지정하여 그 구성원 서버의 게시 된 X.509 인증서를 취득 할 수 있습니다. 인증서는 X.509 형식의 파일로 저장할 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다.
 CMD_ClusterMemberCertGet_Args ClusterMemberCertGet [id] [/SAVECERT:cert]
-CMD_ClusterMemberCertGet_ [id] 인증서를 취득하는 클러스터 구성원의 ID를 지정합니다. 클러스터 구성원 서버의 ID는 ClusterMemberList 명령에서 얻을 수 있습니다.
+CMD_ClusterMemberCertGet_[id] 인증서를 취득하는 클러스터 구성원의 ID를 지정합니다. 클러스터 구성원 서버의 ID는 ClusterMemberList 명령에서 얻을 수 있습니다.
 CMD_ClusterMemberCertGet_SAVECERT 취득한 인증서를 저장하는 파일의 경로 이름을 지정합니다. 인증서는 X.509 형식으로 저장됩니다.
 CMD_ClusterMemberCertGet_PROMPT_ID 인증서를 취득하는 클러스터 구성원 ID:
 
@@ -4608,7 +4590,7 @@ CMD_ClusterConnectionStatusGet_Args ClusterConnectionStatusGet
 CMD_Debug 디버깅 명령의 실행
 CMD_Debug_Help VPN Server/Bridge 실행중인 프로세스 디버깅 명령을 실행합니다. \n이 명령은 소프트 이사 (주)에서 지원의 지시가있을 경우에만 사용하십시오. \n 함부로이 명령을 사용하면 실행중인 VPN Server/Bridge가 정지하는 원인이됩니다.
 CMD_Debug_Args Debug [id] [/ARG:arg]
-CMD_Debug_ [id] 디버깅 명령 번호를 정수로 지정합니다.
+CMD_Debug_[id] 디버깅 명령 번호를 정수로 지정합니다.
 CMD_Debug_ARG 디버그 명령에 전달되는 문자열을 지정합니다. 공백이 포함 된 경우 ""로 묶어야합니다.
 CMD_Debug_Msg1 디버깅 명령을 보내는 중...
 CMD_Debug_Msg2 디버깅 명령의 동작이 완료되었습니다. \n 반환 값:\"%S \"
@@ -4617,7 +4599,7 @@ CMD_Debug_Msg2 디버깅 명령의 동작이 완료되었습니다. \n 반환 �
 CMD_Crash VPN Server/Bridge 과정에서 오류를 발생시킨 프로세스를 강제 종료
 CMD_Crash_Help VPN Server/Bridge 실행중인 프로세스에 치명적인 오류 (메모리 보호 위반 등)를 발생시키고 프로세스를 중단시킵니다. 그 결과, VPN Server/Bridge가 서비스 모드로 부팅하는 경우 자동으로 프로세스가 다시 시작합니다. VPN Server가 사용자 모드로 부팅하는 경우, 프로세스가 자동으로 다시 시작하지 않습니다. \n이 명령은 VPN Server/Bridge에서 어떤 복구 할 수없는 오류가 발생하거나 프로세스가 폭주하고있는 경우 즉시 프로세스를 다시 시작해야 할 것 같은 경우에 이용하십시오 . 이 명령을 실행하면 현재 VPN Server/Bridge에 연결되어있는 모든 VPN 세션이 끊어집니다. 또한 VPN Server가 메모리에 보유하고있는 저장되지 않은 모든 데이터가 손실됩니다. \n이 명령을 실행하기 전에 Flush 명령을 실행하여 VPN Server/Bridge 저장되지 않은 구성 데이터를 설정 파일에 강제 저장하는 것이 좋습니다. \n이 명령은 VPN Server/Bridge 전체 관리자 만 실행할 수 있습니다.
 CMD_Crash_Args Crash [yes]
-CMD_Crash_ [yes] 확인을 위해 "yes"를 지정하십시오.
+CMD_Crash_[yes] 확인을 위해 "yes"를 지정하십시오.
 CMD_Crash_Msg VPN Server에 충돌 명령을 보낼 수 있습니다. VPN Server는 즉시 중단하기위한 명령이 성공했는지 여부를 반환받을 수 없습니다. 이 명령을 실행 한 후에는 vpncmd는 VPN Server 사이의 연결을 끊습니다.
 CMD_Crash_Confirm 정말 VPN Server 충돌 하시겠습니까? \n 하시겠습니까 경우 "yes"를 입력하십시오:
 CMD_Crash_Aborted Crash 명령이 중단되었습니다.
@@ -4635,14 +4617,14 @@ CMD_Flush_Msg2 쓰기에 성공했습니다. 파일 크기는 %S bytes입니다.
 CMD_ServerCertGet VPN Server의 SSL 인증서 취득
 CMD_ServerCertGet_Help VPN Server가 연결된 클라이언트에 제공하는 SSL 인증서를 가져옵니다. 인증서는 X.509 형식의 파일로 저장할 수 있습니다.
 CMD_ServerCertGet_Args ServerCertGet [cert]
-CMD_ServerCertGet_ [cert] 취득한 인증서를 저장하는 파일의 경로 이름을 지정합니다. 인증서는 X.509 형식으로 저장됩니다.
+CMD_ServerCertGet_[cert] 취득한 인증서를 저장하는 파일의 경로 이름을 지정합니다. 인증서는 X.509 형식으로 저장됩니다.
 
 
 # ServerKeyGet 명령
 CMD_ServerKeyGet VPN Server의 SSL 인증서 비밀 키의 취득
 CMD_ServerKeyGet_Help VPN Server가 연결된 클라이언트에 제공하는 SSL 인증서의 개인 키를 가져옵니다. 개인 키는 Base 64로 인코딩 된 파일에 저장할 수 있습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ServerKeyGet_Args ServerKeyGet [key]
-CMD_ServerKeyGet_ [key] 취득한 비밀 키를 저장하는 파일의 경로 이름을 지정합니다. 비밀 키는 Base 64 인코딩되어 저장됩니다.
+CMD_ServerKeyGet_[key] 취득한 비밀 키를 저장하는 파일의 경로 이름을 지정합니다. 비밀 키는 Base 64 인코딩되어 저장됩니다.
 
 
 # ServerCertSet 명령
@@ -4664,7 +4646,7 @@ CMD_ServerCipherGet_CIPHERS 사용 가능한 암호화 알고리즘 이름 목�
 CMD_ServerCipherSet VPN 통신에 사용되는 암호화 알고리즘 설정
 CMD_ServerCipherSet_Help VPN Server와 연결된 클라이언트 사이의 통신에 사용되는 SSL 연결의 암호화 및 전자 서명에 사용되는 알고리즘을 설정합니다. \n 알고리즘 명을 지정하면 이후이 VPN Server에 연결하는 VPN Client와 VPN Bridge 사이에서 지정한 알고리즘을 사용하여 데이터를 암호화됩니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ServerCipherSet_Args ServerCipherSet [name]
-CMD_ServerCipherSet_ [name] 설정해야 루루 암호화 및 전자 서명 알고리즘을 지정합니다. 사용 가능한 알고리즘 목록은 ServerCipherGet 명령에서 얻을 수 있습니다.
+CMD_ServerCipherSet_[name] 설정해야 루루 암호화 및 전자 서명 알고리즘을 지정합니다. 사용 가능한 알고리즘 목록은 ServerCipherGet 명령에서 얻을 수 있습니다.
 CMD_ServerCipherSet_PROMPT_NAME 지정하는 암호화 알고리즘 명:
 
 # TUNDownOnDisconnectEnable command
@@ -4722,7 +4704,7 @@ CMD_KeepGet_COLUMN_5 현재 상태
 CMD_SyslogEnable syslog 송신 기능 설정
 CMD_SyslogEnable_Help syslog 송신 기능의 사용 방법과 사용하는 syslog 서버를 설정합니다.
 CMD_SyslogEnable_Args SyslogEnable [1|2|3] [/HOST:host:port]
-CMD_SyslogEnable_ [1|2|3] syslog 송신 기능 사용 설정을 1~3 중 하나의 정수로 지정합니다. \n1:서버 로그를 syslog로. \n2:서버 및 가상 HUB 보안 로그를 syslog로. \n3:서버 가상 HUB 보안 및 패킷 로그를 syslog로.
+CMD_SyslogEnable_[1|2|3] syslog 송신 기능 사용 설정을 1~3 중 하나의 정수로 지정합니다. \n1:서버 로그를 syslog로. \n2:서버 및 가상 HUB 보안 로그를 syslog로. \n3:서버 가상 HUB 보안 및 패킷 로그를 syslog로.
 CMD_SyslogEnable_HOST 호스트 이름:포트 번호 형식으로 syslog 서버의 호스트 이름 또는 IP 주소와 포트 번호를 지정합니다. 포트 번호를 생략하면 514을 사용합니다.
 CMD_SyslogEnable_MINMAX syslog 송신 기능 사용 설정은 1~3 중 하나의 정수를 지정하십시오.
 CMD_SyslogEnable_Prompt_123 syslog 송신 기능 사용 설정 (1~3):
@@ -4754,14 +4736,14 @@ CMD_ConnectionList_Args ConnectionList
 CMD_ConnectionGet VPN Server에 연결중인 TCP 연결의 정보 검색
 CMD_ConnectionGet_Help VPN Server에 연결된 지정된 TCP/IP 연결에 대한 자세한 정보를 얻을 수 있습니다. \n [연결 이름, 연결 유형 연결되는 호스트 이름, 접근 IP 주소, 원본 포트 번호 (TCP), 연결 시간, 서버 제품 이름, 서버 버전, 서버 빌드 번호, 클라이언트 제품 이름, 클라이언트 버전, 클라이언트 빌드 번호를 취득 할 수 있습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ConnectionGet_Args ConnectionGet [name]
-CMD_ConnectionGet_ [name] 정보를 얻을 연결 이름을 지정합니다. 연결 이름 목록은 ConnectionList 명령에서 얻을 수 있습니다.
+CMD_ConnectionGet_[name] 정보를 얻을 연결 이름을 지정합니다. 연결 이름 목록은 ConnectionList 명령에서 얻을 수 있습니다.
 CMD_ConnectionGet_PROMPT_NAME 정보를 얻을 연결 이름:
 
 # ConnectionDisconnect 명령
 CMD_ConnectionDisconnect VPN Server에 연결중인 TCP 연결의 절단
 CMD_ConnectionDisconnect_Help VPN Server에 연결된 지정된 TCP/IP 연결을 강제로 종료합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ConnectionDisconnect_Args ConnectionDisconnect [name]
-CMD_ConnectionDisconnect_ [name] 절단하는 연결 이름을 지정합니다. 연결 이름 목록은 ConnectionList 명령에서 얻을 수 있습니다.
+CMD_ConnectionDisconnect_[name] 절단하는 연결 이름을 지정합니다. 연결 이름 목록은 ConnectionList 명령에서 얻을 수 있습니다.
 CMD_ConnectionDisconnect_PROMPT_NAME 절단 연결 이름:
 
 
@@ -4781,7 +4763,7 @@ CMD_BridgeList_Args BridgeList
 CMD_BridgeCreate 로컬 브리지 연결 만들기
 CMD_BridgeCreate_Help 새로운 로컬 브리지 연결을 VPN Server에 만듭니다. \n 로컬 브리지를 사용하면이 VPN Server에서 실행되는 가상 HUB와 물리적 Ethernet 장치 (LAN 카드) 사이에서 레이어 2 브리지를 구성 할 수 있습니다. \n 시스템에 tap 장치 (가상 네트워크 인터페이스)를 작성하고 가상 HUB 사이에서 브리지 연결 할 수 있습니다 (tap 장치는 Linux 버전에서만 지원됩니다). \n 브리지 대상 Ethernet 장치 (LAN 카드)에는 실행중인 모든 LAN 카드 사이에서 브리지 수 있지만 고부하 환경에서 브리지 전용 LAN 카드를 준비하는 것이 좋습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_BridgeCreate_Args BridgeCreate [hubname] [/DEVICE:device_name] [/TAP:yes|no]
-CMD_BridgeCreate_ [hubname] 브리지 가상 HUB를 지정합니다. 가상 HUB 목록은 HubList 명령에서 얻을 수 있습니다. 그러나 반드시 현재 실행중인 가상 HUB 이름을 지정할 필요가 없습니다. 현재 작동하지 않거나 존재하지 않는 가상 HUB 이름을 지정하면 해당 가상 HUB가 실제로 작동을 시작했을 때 로컬 브리지 연결을 사용할 수 있습니다.
+CMD_BridgeCreate_[hubname] 브리지 가상 HUB를 지정합니다. 가상 HUB 목록은 HubList 명령에서 얻을 수 있습니다. 그러나 반드시 현재 실행중인 가상 HUB 이름을 지정할 필요가 없습니다. 현재 작동하지 않거나 존재하지 않는 가상 HUB 이름을 지정하면 해당 가상 HUB가 실제로 작동을 시작했을 때 로컬 브리지 연결을 사용할 수 있습니다.
 CMD_BridgeCreate_DEVICE 브리지 대상 Ethernet 장치 (LAN 카드) 이름 또는 tap 장치 이름을 지정합니다. Ethernet 장치 이름 목록은 BridgeDeviceList 명령에서 얻을 수 있습니다.
 CMD_BridgeCreate_TAP 브리지 대상으로 LAN 카드가 아닌 tap 장치를 사용하는 경우는 yes를 지정합니다 (Linux 버전 만 지원됩니다). 생략 한 경우 no로 간주됩니다.
 CMD_BridgeCreate_PROMPT_HUBNAME 브리지 가상 HUB 이름:
@@ -4793,7 +4775,7 @@ CMD_BridgeCreate_PROMPT_TAP tap 장치를 사용합니까? (yes/no):
 CMD_BridgeDelete 로컬 브리지 삭제
 CMD_BridgeDelete_Help 기존의 로컬 브리지 연결을 제거합니다. 현재 로컬 브리지 목록은 BridgeDeviceList 명령에서 얻을 수 있습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_BridgeDelete_Args BridgeDelete [hubname] [/DEVICE:device_name]
-CMD_BridgeDelete_ [hubname] 삭제 로컬 브리지의 가상 HUB를 지정합니다.
+CMD_BridgeDelete_[hubname] 삭제 로컬 브리지의 가상 HUB를 지정합니다.
 CMD_BridgeDelete_DEVICE 제거 로컬 브리지 장치 이름 (LAN 카드 이름 또는 tap 장치 이름)을 지정합니다.
 CMD_BridgeDelete_PROMPT_HUBNAME 삭제 브리지 가상 HUB 이름:
 CMD_BridgeDelete_PROMPT_DEVICE 삭제 브리지 장치 이름:
@@ -4816,7 +4798,7 @@ CMD_Reboot_RESETCONFIG yes를 지정하면 현재 VPN Server가 가지고있는 
 CMD_ConfigGet VPN Server의 현재 구성 가져 오기
 CMD_ConfigGet_Help VPN Server의 현재 구성의 내용을 구조화 된 텍스트 파일 (.config 파일)로 가져옵니다. 이 명령을 실행 한 순간의 VPN Server의 상태를 얻을 수 있습니다. \n 설정 파일의 내용은 매개 변수를 지정하지 않으면 화면에 그대로 표시됩니다. 매개 변수에 저장할 파일 이름을 지정하면 해당 파일 이름에 내용이 저장됩니다. \n 설정 파일은 일반 텍스트 에디터 등으로 편집 가능합니다. 편집 한 구성을 VPN Server에 쓰려면 ConfigSet 명령을 사용합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ConfigGet_Args ConfigGet [path]
-CMD_ConfigGet_ [path] 설정 파일의 내용을 파일에 저장하려면 파일 이름을 지정합니다. 아무것도 지정하지 않는 경우는 구성 내용은 화면에 표시됩니다. 설정 파일에 멀티 바이트 문자가 포함 된 경우 Unicode (UTF-8)로 인코딩되어 저장됩니다.
+CMD_ConfigGet_[path] 설정 파일의 내용을 파일에 저장하려면 파일 이름을 지정합니다. 아무것도 지정하지 않는 경우는 구성 내용은 화면에 표시됩니다. 설정 파일에 멀티 바이트 문자가 포함 된 경우 Unicode (UTF-8)로 인코딩되어 저장됩니다.
 CMD_ConfigGet_FILENAME Config 이름:"%S"크기:%u
 CMD_ConfigGet_FILE_SAVE_FAILED 지정된 파일의 작성에 실패했습니다.
 
@@ -4825,7 +4807,7 @@ CMD_ConfigGet_FILE_SAVE_FAILED 지정된 파일의 작성에 실패했습니다.
 CMD_ConfigSet VPN Server로 구성 쓰기
 CMD_ConfigSet_Help VPN Server 컨피규레이션을 씁니다. 이 명령을 실행하면 지정된 설정 파일의 내용이 VPN Server에 적용되고 VPN Server 프로그램이 자동으로 재부팅되고 새로운 구성의 내용에 따라 동작을 시작합니다. \n 구성 파일은 모든 내용을 관리자가 기술하는 것은 어렵 기 때문에, ConfigGet 명령은 먼저 현재 VPN Server의 구성 내용을 검색하고 파일에 저장하고 그 내용을 일반 텍스트 편집기에서 편집 한 것을 ConfigSet 명령 VPN Server에 다시 쓸 것을 권장합니다. \n이 명령은 VPN Server에 대한 지식이 가지고 계신 분을위한 명령이며 잘못된 구성 파일을 작성한 경우, 오류가 발생하거나 현재 설정이 손실 될 가능성 가 있으므로주의하십시오. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_ConfigSet_Args ConfigSet [path]
-CMD_ConfigSet_ [path] 기록 설정 파일의 파일 이름을 지정합니다. 기록 파일에 멀티 바이트 문자가 포함되어있는 경우 Unicode (UTF-8)로 인코딩되어 있어야합니다.
+CMD_ConfigSet_[path] 기록 설정 파일의 파일 이름을 지정합니다. 기록 파일에 멀티 바이트 문자가 포함되어있는 경우 Unicode (UTF-8)로 인코딩되어 있어야합니다.
 CMD_ConfigSet_PROMPT_PATH 서버에 업로드하는 Config 파일의 경로 이름:
 CMD_ConfigSet_FILE_LOAD_FAILED 지정된 파일의 읽기에 실패했습니다.
 
@@ -4840,7 +4822,7 @@ CMD_RouterList_Args RouterList
 CMD_RouterAdd 새로운 가상 레이어 3 스위치의 정의
 CMD_RouterAdd_Help VPN Server에 새 가상 레이어 3 스위치를 정의합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge에서는 작동하지 않습니다. \n \n 가상 레이어 3 스위치 기능 설명] \n이 VPN Server에서 실행중인 여러 가상 HUB간에 가상 레이어 3 스위치를 정의하고 다른 IP 네트워크를 라우팅 할 수 있습니다. \n \n 가상 레이어 3 스위치 기능에 대한주의] \n 가상 레이어 3 스위치 기능은 네트워크 및 IP 라우팅 관련 지식을 가지고 계신 분이나 네트워크 관리자를위한 기능입니다. 일반적인 VPN 기능을 사용할 경우 가상 레이어 3 스위치 기능을 사용할 필요가 없습니다. \n 가상 레이어 3 스위치 기능을 사용하려면 IP 라우팅에 관한 충분한 지식을 가지고 계신에 네트워크에 미치는 영향을 충분히 고려하고 설정하십시오.
 CMD_RouterAdd_Args RouterAdd [name]
-CMD_RouterAdd_ [name] 새로 만든 가상 레이어 3 스위치의 이름을 지정합니다. 이미 존재하는 가상 레이어 3 스위치와 동일한 이름을 붙일 수 없습니다.
+CMD_RouterAdd_[name] 새로 만든 가상 레이어 3 스위치의 이름을 지정합니다. 이미 존재하는 가상 레이어 3 스위치와 동일한 이름을 붙일 수 없습니다.
 CMD_RouterAdd_PROMPT_NAME 만드는 가상 레이어 3 스위치의 이름:
 
 
@@ -4848,7 +4830,7 @@ CMD_RouterAdd_PROMPT_NAME 만드는 가상 레이어 3 스위치의 이름:
 CMD_RouterDelete 가상 레이어 3 스위치 제거
 CMD_RouterDelete_Help VPN Server에 정의 된 기존의 가상 레이어 3 스위치를 제거합니다. 지정된 가상 레이어 3 스위치가 작동중인 경우 자동으로 작동을 중지하고 삭제를 선택합니다. \n 기존 가상 레이어 3 스위치 목록을 검색하려면 RouterList 명령을 사용합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge에서는 작동하지 않습니다.
 CMD_RouterDelete_Args RouterDelete [name]
-CMD_RouterDelete_ [name] 삭제하는 가상 레이어 3 스위치의 이름을 지정합니다.
+CMD_RouterDelete_[name] 삭제하는 가상 레이어 3 스위치의 이름을 지정합니다.
 CMD_RouterDelete_PROMPT_NAME 삭제하는 가상 레이어 3 스위치의 이름:
 
 
@@ -4856,7 +4838,7 @@ CMD_RouterDelete_PROMPT_NAME 삭제하는 가상 레이어 3 스위치의 이름
 CMD_RouterStart 가상 레이어 3 스위치의 동작의 시작
 CMD_RouterStart_Help VPN Server에 정의 된 기존의 가상 레이어 3 스위치의 동작이 정지하고있는 경우는, 그 동작을 시작합니다. \n 기존 가상 레이어 3 스위치 목록을 검색하려면 RouterList 명령을 사용합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge에서는 작동하지 않습니다. \n \n 가상 레이어 3 스위치 기능 설명] \n이 VPN Server에서 실행중인 여러 가상 HUB간에 가상 레이어 3 스위치를 정의하고 다른 IP 네트워크를 라우팅 할 수 있습니다. \n \n 가상 레이어 3 스위치 기능에 대한주의] \n 가상 레이어 3 스위치 기능은 네트워크 및 IP 라우팅 관련 지식을 가지고 계신 분이나 네트워크 관리자를위한 기능입니다. 일반적인 VPN 기능을 사용할 경우 가상 레이어 3 스위치 기능을 사용할 필요가 없습니다. \n 가상 레이어 3 스위치 기능을 사용하려면 IP 라우팅에 관한 충분한 지식을 가지고 계신에 네트워크에 미치는 영향을 충분히 고려하고 설정하십시오.
 CMD_RouterStart_Args RouterStart [name]
-CMD_RouterStart_ [name] 시작하는 가상 레이어 3 스위치의 이름을 지정합니다.
+CMD_RouterStart_[name] 시작하는 가상 레이어 3 스위치의 이름을 지정합니다.
 CMD_RouterStart_PROMPT_NAME 시작하는 가상 레이어 3 스위치의 이름:
 
 
@@ -4864,7 +4846,7 @@ CMD_RouterStart_PROMPT_NAME 시작하는 가상 레이어 3 스위치의 이름:
 CMD_RouterStop 가상 레이어 3 스위치의 동작의 정지
 CMD_RouterStop_Help VPN Server에 정의 된 기존의 가상 레이어 3 스위치의 동작이 실행되는 경우 작동을 중지합니다. \n 기존 가상 레이어 3 스위치 목록을 검색하려면 RouterList 명령을 사용합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다.
 CMD_RouterStop_Args RouterStop [name]
-CMD_RouterStop_ [name] 중지 할 가상 레이어 3 스위치의 이름을 지정합니다.
+CMD_RouterStop_[name] 중지 할 가상 레이어 3 스위치의 이름을 지정합니다.
 CMD_RouterStop_PROMPT_NAME 중지 할 가상 레이어 3 스위치의 이름:
 
 
@@ -4872,7 +4854,7 @@ CMD_RouterStop_PROMPT_NAME 중지 할 가상 레이어 3 스위치의 이름:
 CMD_RouterIfList 가상 레이어 3 스위치에 등록되어있는 인터페이스 목록을 검색
 CMD_RouterIfList_Help 지정된 가상 레이어 3 스위치에 가상 인터페이스가 정의되어있는 경우 가상 인터페이스 목록을 가져옵니다. \n1 개의 가상 레이어 3 스위치는 복수의 가상 인터페이스와 라우팅 테이블을 정의 할 수 있습니다. \n 가상 인터페이스는 가상 HUB와 관련된 가상 HUB가 작동하는 동안 가상 HUB에서 하나의 IP 호스트처럼 동작합니다. 여러 가상 HUB에 대해 별도의 IP 네트워크에 소속 된 가상 인터페이스가 정의되어있을 때, 그 인터페이스간에 IP 라우팅이 자동으로 이루어집니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge에서는 작동하지 않습니다.
 CMD_RouterIfList_Args RouterIfList [name]
-CMD_RouterIfList_ [name] 가상 레이어 3 스위치의 이름을 지정합니다.
+CMD_RouterIfList_[name] 가상 레이어 3 스위치의 이름을 지정합니다.
 CMD_RouterIfList_PROMPT_NAME 가상 레이어 3 스위치의 이름:
 
 
@@ -4880,7 +4862,7 @@ CMD_RouterIfList_PROMPT_NAME 가상 레이어 3 스위치의 이름:
 CMD_RouterIfAdd 가상 레이어 3 스위치 가상 인터페이스 추가
 CMD_RouterIfAdd_Help 지정된 가상 레이어 3 스위치에 동일한 VPN Server에서 실행되는 가상 HUB에 연결하는 가상 인터페이스를 추가합니다. \n1 개의 가상 레이어 3 스위치는 복수의 가상 인터페이스와 라우팅 테이블을 정의 할 수 있습니다. \n 가상 인터페이스는 가상 HUB와 관련된 가상 HUB가 작동하는 동안 가상 HUB에서 하나의 IP 호스트처럼 동작합니다. 여러 가상 HUB에 대해 별도의 IP 네트워크에 소속 된 가상 인터페이스가 정의되어있을 때, 그 인터페이스간에 IP 라우팅이 자동으로 이루어집니다. \n 가상 인터페이스가 속한 IP 네트워크 공간과 인터페이스 자신의 IP 주소를 정의해야합니다. \n 또한 인터페이스가 연결 대상 가상 HUB 이름을 지정해야합니다. \n 가상 HUB 이름은 현재 존재하지 않는 가상 HUB를 지정할 수도 있습니다. \n 가상 인터페이스는 가상 HUB에서 하나의 IP 주소를 가지고 있어야합니다. 또한 IP 주소가 속한 IP 네트워크의 서브넷 마스크를 지정해야합니다. \n 여러 가상 HUB의 IP 공간끼리의 가상 레이어 3 스위치를 통한 라우팅은 여기에 지정된 IP 주소에 따라 작동합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge에서는 작동하지 않습니다. \n이 명령을 실행하려면 작업 할 가상 레이어 3 스위치가 정지하고있을 필요가 있습니다. 만약 정지하지 않은 경우 RouterStop 명령으로 정지시킨 후이 명령을 실행하십시오.
 CMD_RouterIfAdd_Args RouterIfAdd [name] [/HUB:hub] [/IP:ip/mask]
-CMD_RouterIfAdd_ [name] 가상 레이어 3 스위치의 이름을 지정합니다.
+CMD_RouterIfAdd_[name] 가상 레이어 3 스위치의 이름을 지정합니다.
 CMD_RouterIfAdd_HUB 새로 추가하는 가상 인터페이스가 연결된 가상 HUB 이름을 지정합니다. 가상 HUB 목록은 HubList 명령에서 얻을 수 있습니다. 그러나 반드시 현재 실행중인 가상 HUB 이름을 지정할 필요가 없습니다. 현재 작동하지 않거나 존재하지 않는 가상 HUB 이름을 지정하면 해당 가상 HUB가 실제로 작동을 시작했을 때, 가상 레이어 3 스위치가 활성화됩니다.
 CMD_RouterIfAdd_IP IP 주소/서브넷 마스크의 형식으로 새로 추가하는 가상 인터페이스가 가지는 IP 주소와 서브넷 마스크를 지정합니다. IP 주소는 192.168.0.1과 같이 10 진수를 점으로 구분하여 지정합니다. 서브넷 마스크는 255.255.255.0과 같이 10 진수를 점으로 구분하여 지정하거나 24와 같이 처음부터 비트 길이를 10 진수로 지정할 수 있습니다.
 CMD_RouterIfAdd_PROMPT_NAME 가상 레이어 3 스위치의 이름:
@@ -4892,7 +4874,7 @@ CMD_RouterIfAdd_PROMPT_IP IP 주소/서브넷 마스크:
 CMD_RouterIfDel 가상 레이어 3 스위치의 가상 인터페이스 삭제
 CMD_RouterIfDel_Help 지정된 가상 레이어 3 스위치에 이미 정의되어있는 가상 인터페이스를 삭제합니다. \n 현재 정의 된 가상 인터페이스 목록은 RouterIfList 명령에서 얻을 수 있습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge에서는 작동하지 않습니다. \n이 명령을 실행하려면 작업 할 가상 레이어 3 스위치가 정지하고있을 필요가 있습니다. 만약 정지하지 않은 경우 RouterStop 명령으로 정지시킨 후이 명령을 실행하십시오.
 CMD_RouterIfDel_Args RouterIfDel [name] [/HUB:hub]
-CMD_RouterIfDel_ [name] 가상 레이어 3 스위치의 이름을 지정합니다.
+CMD_RouterIfDel_[name] 가상 레이어 3 스위치의 이름을 지정합니다.
 CMD_RouterIfDel_HUB 삭제할 가상 인터페이스가 연결된 가상 HUB 이름을 지정합니다.
 
 
@@ -4900,7 +4882,7 @@ CMD_RouterIfDel_HUB 삭제할 가상 인터페이스가 연결된 가상 HUB 이
 CMD_RouterTableList 가상 레이어 3 스위치의 라우팅 테이블 목록 검색
 CMD_RouterTableList_Help 지정된 가상 레이어 3 스위치에서 라우팅 테이블이 정의되어있는 경우 라우팅 테이블의 목록을 가져옵니다. \n 가상 레이어 3 스위치의 IP 라우팅 엔진은 IP 패킷의 목적지 IP 주소가 각 가상 인터페이스 소속 IP 네트워크의 어느 것에도 속하지 않는 경우이 라우팅 테이블을 참조하여 라우팅합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge에서는 작동하지 않습니다.
 CMD_RouterTableList_Args RouterTableList [name]
-CMD_RouterTableList_ [name] 가상 레이어 3 스위치의 이름을 지정합니다.
+CMD_RouterTableList_[name] 가상 레이어 3 스위치의 이름을 지정합니다.
 CMD_RouterTableList_PROMPT_NAME 가상 레이어 3 스위치의 이름:
 
 
@@ -4908,7 +4890,7 @@ CMD_RouterTableList_PROMPT_NAME 가상 레이어 3 스위치의 이름:
 CMD_RouterTableAdd 가상 레이어 3 스위치의 라우팅 테이블 항목 추가
 CMD_RouterTableAdd_Help 지정된 가상 레이어 3 스위치의 라우팅 테이블에 새로운 라우팅 테이블 항목을 추가합니다. \n 가상 레이어 3 스위치의 IP 라우팅 엔진은 IP 패킷의 목적지 IP 주소가 각 가상 인터페이스 소속 IP 네트워크의 어느 것에도 속하지 않는 경우 라우팅 테이블을 참조하여 라우팅합니다. \n 가상 레이어 3 스위치에 추가 라우팅 테이블 항목의 내용을 지정해야합니다. 게이트웨이 주소로는이 가상 레이어 3 스위치의 가상 인터페이스 중 하나와 동일한 IP 네트워크에 소속 된 IP 주소를 지정해야합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge에서는 작동하지 않습니다. \n이 명령을 실행하려면 작업 할 가상 레이어 3 스위치가 정지하고있을 필요가 있습니다. 만약 정지하지 않은 경우 RouterStop 명령으로 정지시킨 후이 명령을 실행하십시오.
 CMD_RouterTableAdd_Args RouterTableAdd [name] [/NETWORK:ip/mask] [/GATEWAY:gwip] [/METRIC:metric]
-CMD_RouterTableAdd_ [name] 가상 레이어 3 스위치의 이름을 지정합니다.
+CMD_RouterTableAdd_[name] 가상 레이어 3 스위치의 이름을 지정합니다.
 CMD_RouterTableAdd_NETWORK IP 주소/서브넷 마스크의 형식으로 새로 추가 라우팅 테이블 항목의 네트워크 주소와 서브넷 마스크를 지정합니다. 네트워크 주소는 192.168.0.1과 같이 10 진수를 점으로 구분하여 지정합니다. 서브넷 마스크는 255.255.255.0과 같이 10 진수를 점으로 구분하여 지정하거나 24와 같이 처음부터 비트 길이를 10 진수로 지정할 수 있습니다. 0.0.0.0/0.0.0.0을 지정하면 기본 경로의 의미입니다.
 CMD_RouterTableAdd_GATEWAY 게이트웨이의 IP 주소를 지정합니다.
 CMD_RouterTableAdd_METRIC 메트릭 값을 지정합니다. 1 이상의 정수로 지정하십시오.
@@ -4922,7 +4904,7 @@ CMD_RouterTableAdd_PROMPT_METRIC 메트릭 값:
 CMD_RouterTableDel 가상 레이어 3 스위치의 라우팅 테이블 항목 삭제
 CMD_RouterTableDel_Help 지정된 가상 레이어 3 스위치에서 정의 된 라우팅 테이블의 항목을 삭제합니다. \n 이미 정의 된 루틴 크 테이블 항목의 목록은 RouterTableList 명령에서 얻을 수 있습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge에서는 작동하지 않습니다. \n이 명령을 실행하려면 작업 할 가상 레이어 3 스위치가 정지하고있을 필요가 있습니다. 만약 정지하지 않은 경우 RouterStop 명령으로 정지시킨 후이 명령을 실행하십시오.
 CMD_RouterTableDel_Args RouterTableDel [name] [/NETWORK:ip/mask] [/GATEWAY:gwip] [/METRIC:metric]
-CMD_RouterTableDel_ [name] 가상 레이어 3 스위치의 이름을 지정합니다.
+CMD_RouterTableDel_[name] 가상 레이어 3 스위치의 이름을 지정합니다.
 CMD_RouterTableDel_NETWORK IP 주소/서브넷 마스크의 형식에서 삭제할 라우팅 테이블 항목의 네트워크 주소를 지정합니다.
 CMD_RouterTableDel_GATEWAY 게이트웨이의 IP 주소를 지정합니다.
 CMD_RouterTableDel_METRIC 메트릭 값을 지정합니다. 1 이상의 정수로 지정하십시오.
@@ -4940,7 +4922,7 @@ CMD_LogFileList_NUM_LOGS 총 %u 개의 로그 파일이 있습니다.
 CMD_LogFileGet 로그 파일 다운로드
 CMD_LogFileGet_Help VPN Server 컴퓨터에 저장되어있는 로그 파일을 다운로드합니다. 로그 파일을 다운로드하려면 먼저 LogFileList 명령으로 로그 파일의 목록을 표시 한 다음 LogFileGet 명령에서 다운로드 할 수 있습니다. VPN Server에 서버 관리 모드로 연결되어있는 경우, 모든 가상 HUB 패킷 로그, 보안 로그 및 VPN Server의 서버 로그를 보거나 다운로드 할 수 있습니다. 가상 HUB 관리 모드로 연결되어있는 경우에는 관리 가상 HUB 패킷 로그 및 보안 로그 만 보거나 다운로드 할 수 있습니다. \n 매개 변수로 파일 이름을 지정한 경우에는 다운로드 한 로그 파일은 파일 이름의 파일에 저장됩니다. 파일 이름을 지정하지 않은 경우 화면에 표시됩니다. \n 로그 파일의 크기가 거대해질 수 있으므로주의하십시오.
 CMD_LogFileGet_Args LogFileGet [name] [/SERVER:server] [/SAVEPATH:savepath]
-CMD_LogFileGet_ [name] 다운로드 로그 파일 이름을 지정합니다. LogFileList 명령에서 다운로드 할 수있는 로그 파일 이름의 목록을 얻을 수 있습니다.
+CMD_LogFileGet_[name] 다운로드 로그 파일 이름을 지정합니다. LogFileList 명령에서 다운로드 할 수있는 로그 파일 이름의 목록을 얻을 수 있습니다.
 CMD_LogFileGet_SERVER 클러스터 컨트롤러에 다운로드 요청을 할 경우 로그 파일이 저장되는 서버 이름을 지정합니다. LogFileGet 명령으로 표시되는 서버를 지정하십시오.
 CMD_LogFileGet_SAVEPATH 다운로드 한 로그 파일을 저장하려면 파일 이름을 지정합니다. 지정하지 않으면 화면에 표시됩니다.
 CMD_LogFileGet_PROMPT_NAME 다운로드 로그 파일 이름:
@@ -4954,7 +4936,7 @@ CMD_LogFileGet_FILESIZE 로그 파일의 파일 크기:%u
 CMD_HubCreate 새로운 가상 HUB 만들기
 CMD_HubCreate_Help VPN Server에 새로운 가상 HUB를 만듭니다. \n 만든 가상 HUB는 즉시 작동을 시작합니다. \nVPN Server가 클러스터에서 실행중인 경우이 명령은 클러스터 컨트롤러에만 적용됩니다. 또한 새로운 가상 HUB는 동적 가상 HUB 역할을합니다. HubSetStatic 명령에서 정적 가상 HUB 변경 될 수 있습니다. 이미 VPN Server에 존재하는 가상 HUB 목록을 검색하려면 HubList 명령을 사용합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge 및 클러스터 구성원 서버로 작동하는 VPN Server에서 작동하지 않습니다. \n 또한 클러스터에서 클러스터 컨트롤러에 가상 HUB 작성 명령을 실행하려면 HubCreateStatic 명령 또는 HubCreateDynamic 명령을 사용하십시오 (클러스터 컨트롤러에 HubCreate 명령을 사용하면 HubCreateDynamic 명령과 동등하게 동작 합니다).
 CMD_HubCreate_Args HubCreate [name] [/PASSWORD:password]
-CMD_HubCreate_ [name] 만들 가상 HUB의 이름을 지정합니다.
+CMD_HubCreate_[name] 만들 가상 HUB의 이름을 지정합니다.
 CMD_HubCreate_PASSWORD 만드는 가상 HUB 관리 암호를 설정하는 경우, 관리자 암호를 지정합니다. 지정하지 않으면 입력하라는 메시지가 표시됩니다.
 CMD_HubCreate_PROMPT_NAME 만드는 가상 HUB의 이름:
 
@@ -4963,7 +4945,7 @@ CMD_HubCreate_PROMPT_NAME 만드는 가상 HUB의 이름:
 CMD_HubCreateDynamic 새로운 동적 가상 HUB 만들기 (클러스터링)
 CMD_HubCreateDynamic_Help VPN Server에 새로운 동적 가상 HUB를 만듭니다. \n 만든 가상 HUB는 즉시 작동을 시작합니다. \nVPN Server가 클러스터에서 실행중인 경우이 명령은 클러스터 컨트롤러에만 적용됩니다. 또한 새로운 가상 HUB는 동적 가상 HUB 역할을합니다. HubSetStatic 명령에서 정적 가상 HUB 변경 될 수 있습니다. 이미 VPN Server에 존재하는 가상 HUB 목록을 검색하려면 HubList 명령을 사용합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge 및 클러스터 구성원 서버 또는 독립 실행 형 서버로 작동하는 VPN Server에서 작동하지 않습니다.
 CMD_HubCreateDynamic_Args HubCreateDynamic [name] [/PASSWORD:password]
-CMD_HubCreateDynamic_ [name] 만들 가상 HUB의 이름을 지정합니다.
+CMD_HubCreateDynamic_[name] 만들 가상 HUB의 이름을 지정합니다.
 CMD_HubCreateDynamic_PASSWORD 만드는 가상 HUB 관리 암호를 설정하는 경우, 관리자 암호를 지정합니다. 지정하지 않으면 입력하라는 메시지가 표시됩니다.
 
 
@@ -4971,7 +4953,7 @@ CMD_HubCreateDynamic_PASSWORD 만드는 가상 HUB 관리 암호를 설정하는
 CMD_HubCreateStatic 새 정적 가상 HUB 만들기 (클러스터링)
 CMD_HubCreateStatic_Help VPN Server에 새 정적 가상 HUB를 만듭니다. \n 만든 가상 HUB는 즉시 작동을 시작합니다. \nVPN Server가 클러스터에서 실행중인 경우이 명령은 클러스터 컨트롤러에만 적용됩니다. 또한 새로운 가상 HUB는 동적 가상 HUB 역할을합니다. HubSetStatic 명령에서 정적 가상 HUB 변경 될 수 있습니다. 이미 VPN Server에 존재하는 가상 HUB 목록을 검색하려면 HubList 명령을 사용합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge 및 클러스터 구성원 서버 또는 독립 실행 형 서버로 작동하는 VPN Server에서 작동하지 않습니다.
 CMD_HubCreateStatic_Args HubCreateStatic [name] [/PASSWORD:password]
-CMD_HubCreateStatic_ [name] 만들 가상 HUB의 이름을 지정합니다.
+CMD_HubCreateStatic_[name] 만들 가상 HUB의 이름을 지정합니다.
 CMD_HubCreateStatic_PASSWORD 만드는 가상 HUB 관리 암호를 설정하는 경우, 관리자 암호를 지정합니다. 지정하지 않으면 입력하라는 메시지가 표시됩니다.
 
 
@@ -4979,7 +4961,7 @@ CMD_HubCreateStatic_PASSWORD 만드는 가상 HUB 관리 암호를 설정하는 
 CMD_HubDelete 가상 HUB 삭제
 CMD_HubDelete_Help VPN Server에서 기존 가상 HUB를 제거합니다. \n 가상 HUB를 제거하면 현재 가상 HUB에 연결되어있는 세션이 끊어지고 새로운 세션이 가상 HUB에 연결할 수 없습니다. \n 또한 가상 HUB의 모든 설정 사용자 개체, 그룹 개체, 인증서 및 계단식가 삭제됩니다. \n 가상 HUB를 삭제하면 되돌릴 수 없습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge 및 클러스터 구성원 서버로 작동하는 VPN Server에서 작동하지 않습니다.
 CMD_HubDelete_Args HubDelete [name]
-CMD_HubDelete_ [name] 삭제할 가상 HUB의 이름을 지정합니다.
+CMD_HubDelete_[name] 삭제할 가상 HUB의 이름을 지정합니다.
 CMD_HubDelete_PROMPT_NAME 삭제할 가상 HUB의 이름:
 
 
@@ -4987,7 +4969,7 @@ CMD_HubDelete_PROMPT_NAME 삭제할 가상 HUB의 이름:
 CMD_HubSetStatic 가상 HUB의 종류를 정적 가상 HUB로 변경
 CMD_HubSetStatic_Help VPN Server가 클러스터에서 동작하는 경우 가상 HUB의 종류를 정적 가상 HUB로 설정합니다. 가상 HUB 유형을 변경하면 현재 가상 HUB에 연결되어있는 모든 세션은 일단 끊어집니다. \n 정적 가상 HUB 역할을하는 가상 HUB가있는 경우, 모든 클러스터 구성원 서버에서 해당 이름의 가상 HUB가 생성됩니다. 가상 HUB에 연결하려고하는 사용자는 각 서버의 부하 상황을 바탕으로 한 알고리즘은 가상 HUB를 호스팅하고있는 하나의 클러스터 구성원에 연결됩니다. \n 정적 가상 HUB는 일례로 기업의 인터넷에서 사내 LAN에 대한 원격 액세스 어플리케이션에서 동시에 수천~수만 단위의 대량의 사용자가 동시에 연결할 수있는 원격 액세스 VPN 용으로 사용할 수 이 가능합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge 및 클러스터 구성원 서버 또는 독립 실행 형 서버로 작동하는 VPN Server에서 작동하지 않습니다. \n이 명령은 빌드 5190보다 새로운 VPN Server는 사용할 수 없습니다.
 CMD_HubSetStatic_Args HubSetStatic [name]
-CMD_HubSetStatic_ [name] 정적 가상 HUB로 설정하는 가상 HUB의 이름을 지정합니다.
+CMD_HubSetStatic_[name] 정적 가상 HUB로 설정하는 가상 HUB의 이름을 지정합니다.
 CMD_HubChange_PROMPT_NAME 설정을 변경하는 가상 HUB의 이름:
 
 
@@ -4995,7 +4977,7 @@ CMD_HubChange_PROMPT_NAME 설정을 변경하는 가상 HUB의 이름:
 CMD_HubSetDynamic 가상 HUB 유형을 동적 가상 HUB로 변경
 CMD_HubSetDynamic_Help VPN Server가 클러스터에서 동작하는 경우 가상 HUB 유형을 동적 가상 HUB로 설정합니다. 가상 HUB 유형을 변경하면 현재 가상 HUB에 연결되어있는 모든 세션은 일단 끊어집니다. \n 클러스터에 정의 된 동적 가상 HUB 클라이언트가 하나도 연결되지 않을 때, 가상 HUB는 모든 클러스터 멤버에 존재하지 않습니다. 동적 가상 HUB에 첫 번째 클라이언트가 연결을 시도하면 클러스터 내에서 가장 부하가 적은 서버가 가상 HUB를 호스팅합니다. 2 대 이상의 클라이언트가 가상 HUB에 연결하려고하면 가상 HUB를 호스팅하는 서버에 자동으로 연결합니다. 각 동적 가상 HUB는 모든 클라이언트가 연결을 끊으면 모든 서버에 실체가 존재하지 않는 상태로 돌아갑니다. \n 동적 가상 HUB의 응용 예는 폭넓게, 예를 들어 사내에서 부과마다 가상 HUB를 정의 해두고, 각 직원이 자신이 속한 부과 가상 HUB에 연결하여 작업 등을 단 한 클러스터를 설치하는 것만으로 집중 관리 할 수 있습니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n 또한이 명령은 VPN Bridge 및 클러스터 구성원 서버 또는 독립 실행 형 서버로 작동하는 VPN Server에서 작동하지 않습니다. \n이 명령은 빌드 5190보다 새로운 VPN Server는 사용할 수 없습니다.
 CMD_HubSetDynamic_Args HubSetDynamic [name]
-CMD_HubSetDynamic_ [name] 동적 가상 HUB로 설정하는 가상 HUB의 이름을 지정합니다.
+CMD_HubSetDynamic_[name] 동적 가상 HUB로 설정하는 가상 HUB의 이름을 지정합니다.
 
 
 # HubList 명령
@@ -5008,7 +4990,7 @@ CMD_HubList_Args HubList
 CMD_Hub 관리하는 가상 HUB의 선택
 CMD_Hub_Help 관리 가상 HUB를 선택합니다. VPN Server에 연결 한 상태 관리 유틸리티는 가상 HUB에 관한 설정·관리하는 명령을 실행하기 전에 관리 할 가상 HUB를 Hub 명령에서 선택해야합니다. \nVPN Server에 가상 HUB 관리 모드로 연결된 상태에서는 관리 대상이되고있는 하나의 가상 HUB를 선택할 수 있으며, 다른 가상 HUB를 선택할 수 없습니다. VPN Server에 서버 관리 모드로 연결된 상태에서는 모든 가상 HUB를 관리 할 수 있습니다. \n 현재 서버에있는 가상 HUB 목록을 검색하려면 HubList 명령을 사용합니다. \nVPN Bridge는 "BRIDGE"라는 가상 HUB 이외를 선택 할 수 없습니다.
 CMD_Hub_Args Hub [name]
-CMD_Hub_ [name] 관리하는 가상 HUB의 이름을 지정합니다. 매개 변수를 지정하지 않은 경우 관리되는 가상 HUB의 선택을 해제합니다.
+CMD_Hub_[name] 관리하는 가상 HUB의 이름을 지정합니다. 매개 변수를 지정하지 않은 경우 관리되는 가상 HUB의 선택을 해제합니다.
 CMD_Hub_Unselected 가상 HUB의 선택을 해제했습니다.
 CMD_Hub_Selected 가상 HUB "%S"를 선택했습니다.
 CMD_Hub_Select_Failed /ADMINHUB에서 지정된 가상 HUB "%S"를 선택하려고하면 다음 오류가 발생했습니다.
@@ -5031,7 +5013,7 @@ CMD_Offline_Args Offline
 CMD_SetMaxSession 가상 HUB 최대 동시 연결 세션 수를 설정하려면
 CMD_SetMaxSession_Help 현재 관리하고있는 가상 HUB의 최대 동시 세션 수를 설정합니다. 최대 동시 세션 수를 초과 한 세션이 VPN Client 및 VPN Bridge에서 연결된 경우 최대 동시 세션 수를 초과 한 시점에서 더 이상 클라이언트는 연결할 수 없습니다. 이 최대 동시 세션 수의 제한 로컬 브리지 가상 NAT 계단식 등에 의해 가상 HUB에 생성 된 세션은 포함되지 않습니다. \n 현재 최대 동시 세션 수 설정은 OptionsGet 명령에서 얻을 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_SetMaxSession_Args SetMaxSession [max_session]
-CMD_SetMaxSession_ [max_session 설정하는 최대 동시 세션 수를 정수로 지정합니다. 0을 지정하면 제한됩니다.
+CMD_SetMaxSession_[max_session] 설정하는 최대 동시 세션 수를 정수로 지정합니다. 0을 지정하면 제한됩니다.
 CMD_SetMaxSession_Prompt 최대 동시 세션 수:
 
 
@@ -5039,7 +5021,7 @@ CMD_SetMaxSession_Prompt 최대 동시 세션 수:
 CMD_SetHubPassword 가상 HUB 관리 암호를 설정하려면
 CMD_SetHubPassword_Help 현재 관리하고있는 가상 HUB의 관리 암호를 설정합니다. 가상 HUB의 관리자 암호가 설정되어있는 경우 가상 HUB에 대해 VPN Server 연결 유틸리티에서 가상 HUB 관리 모드에서 암호를 지정하여 연결할 수 있습니다. 또한 VPN Client 및 VPN Bridge 등에서 사용자 이름을 "Administrator"암호를 가상 HUB 관리자 암호를 지정하여 VPN 연결 할 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_SetHubPassword_Args SetHubPassword [password]
-CMD_SetHubPassword_ [password 설정 암호를 지정합니다. 매개 변수에 암호를 지정하지 않으면 암호를 입력하라는 메시지가 표시됩니다.
+CMD_SetHubPassword_[password] 설정 암호를 지정합니다. 매개 변수에 암호를 지정하지 않으면 암호를 입력하라는 메시지가 표시됩니다.
 
 
 # SetEnumAllow 명령
@@ -5070,7 +5052,7 @@ CMD_OptionsGet_TYPE 가상 HUB의 종류
 CMD_RadiusServerSet 사용자 인증에 사용되는 RADIUS 서버 설정
 CMD_RadiusServerSet_Help 현재 관리하고있는 가상 HUB 사용자가 RADIUS 서버 인증 모드로 접속 한 경우 사용자 이름과 암호를 확인하기 위해 외부 RADIUS 서버를 지정합니다. \nRadius 서버는 VPN Server의 IP 주소의 요청을 수락하도록 설정해야합니다. 또한 Password Authentication Protocol (PAP) 인증이 활성화되어 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_RadiusServerSet_Args RadiusServerSet [server_name:port] [/SECRET:secret] [/RETRY_INTERVAL:interval]
-CMD_RadiusServerSet_ [server_name:port] 호스트 이름:포트 번호 형식으로 사용하는 RADIUS 서버의 호스트 이름 또는 IP 주소와 UDP 포트 번호를 지정합니다. 포트 번호를 생략하면 1812이 사용됩니다.
+CMD_RadiusServerSet_[server_name:port] 호스트 이름:포트 번호 형식으로 사용하는 RADIUS 서버의 호스트 이름 또는 IP 주소와 UDP 포트 번호를 지정합니다. 포트 번호를 생략하면 1812이 사용됩니다.
 CMD_RadiusServerSet_SECRET RADIUS 서버 사이의 통신에 사용되는 공유 비밀 (암호)를 지정합니다.
 CMD_RadiusServerSet_RETRY_INTERVAL RADIUS 서버 사이의 통신에 사용하는 다시 시도 간격을 밀리 초 단위로 지정합니다.
 CMD_RadiusServerSet_Prompt_Host 사용하는 RADIUS 서버의 호스트 이름과 포트 번호:
@@ -5122,7 +5104,7 @@ CMD_Log_7 Ethernet 로그
 CMD_LogEnable 보안 로그 또는 패킷 로그 활성화
 CMD_LogEnable_Help 현재 관리하고있는 가상 HUB의 보안 로그 또는 패킷 로그를 활성화합니다. \n 현재 설정은 LogGet 명령에서 얻을 수 있습니다.
 CMD_LogEnable_Args LogEnable [security|packet]
-CMD_LogEnable_ [security|packet] 활성화 로그 유형을 선택합니다. "security"또는 "packet"중 하나를 지정합니다.
+CMD_LogEnable_[security|packet] 활성화 로그 유형을 선택합니다. "security"또는 "packet"중 하나를 지정합니다.
 CMD_LogEnable_Prompt security 또는 packet을 선택:
 CMD_LogEnable_Prompt_Error 지정이 잘못되었습니다.
 
@@ -5131,14 +5113,14 @@ CMD_LogEnable_Prompt_Error 지정이 잘못되었습니다.
 CMD_LogDisable 보안 로그 또는 패킷 로그 비활성화
 CMD_LogDisable_Help 현재 관리하고있는 가상 HUB의 보안 로그 또는 패킷 로그를 비활성화합니다. \n 현재 설정은 LogGet 명령에서 얻을 수 있습니다.
 CMD_LogDisable_Args LogDisable [security|packet]
-CMD_LogDisable_ [security|packet] 비활성화하는 로그의 종류를 선택합니다. "security"또는 "packet"중 하나를 지정합니다.
+CMD_LogDisable_[security|packet] 비활성화하는 로그의 종류를 선택합니다. "security"또는 "packet"중 하나를 지정합니다.
 
 
 # LogSwitchSet 명령
 CMD_LogSwitchSet 로그 파일 전환주기 설정
 CMD_LogSwitchSet_Help 현재 관리하고있는 가상 HUB를 저장하는 보안 로그 또는 패킷 로그의 로그 파일 전환주기를 설정합니다. 로그 파일 전환주기는 1 초 1 분 단위, 시간 단위, 1 일 단위, 1 개월 단위 또는 전환을하지 않도록 변경할 수 있습니다. \n 현재 설정은 LogGet 명령에서 얻을 수 있습니다.
 CMD_LogSwitchSet_Args LogSwitchSet [security|packet] [/SWITCH:sec|min|hour|day|month|none]
-CMD_LogSwitchSet_ [security|packet 설정을 변경 로그 유형을 선택합니다. "security"또는 "packet"중 하나를 지정합니다.
+CMD_LogSwitchSet_[security|packet] 설정을 변경 로그 유형을 선택합니다. "security"또는 "packet"중 하나를 지정합니다.
 CMD_LogSwitchSet_SWITCH 설정 전환주기를 선택합니다. sec, min, hour, day, month, none에서 지정합니다.
 CMD_LogSwitchSet_Prompt sec, min, hour, day, month, none을 지정:
 
@@ -5164,7 +5146,7 @@ CMD_CAList_COLUMN_ID ID
 CMD_CAAdd 신뢰하는 인증 기관의 인증서 추가
 CMD_CAAdd_Help 현재 관리하고있는 가상 HUB가 신뢰하는 인증 기관의 인증서 목록에 새 인증서를 추가합니다. 등록 된 인증 기관의 인증서 목록은 VPN Client가 서명 된 인증서 인증 모드로 접속 해 왔을 때에 인증서 검증에 사용됩니다. \n 현재 인증서 목록을 검색하려면 CAList 명령을 사용합니다. \n 인증서를 추가하려면 인증서가 X.509 형식의 파일로 저장되어 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CAAdd_Args CAAdd [path]
-CMD_CAAdd_ [path] 등록 X.509 인증서 파일 이름을 지정합니다.
+CMD_CAAdd_[path] 등록 X.509 인증서 파일 이름을 지정합니다.
 CMD_CAAdd_PROMPT_PATH 등록 X.509 인증서 파일 이름:
 
 
@@ -5172,7 +5154,7 @@ CMD_CAAdd_PROMPT_PATH 등록 X.509 인증서 파일 이름:
 CMD_CADelete 신뢰하는 인증 기관의 인증서 삭제
 CMD_CADelete_Help 현재 관리하고있는 가상 HUB가 신뢰하는 인증 기관의 인증서 목록에서 기존 인증서를 삭제합니다. \n 현재 인증서 목록을 검색하려면 CAList 명령을 사용합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CADelete_Args CADelete [id]
-CMD_CADelete_ [id] 삭제할 인증서의 ID를 지정합니다.
+CMD_CADelete_[id] 삭제할 인증서의 ID를 지정합니다.
 CMD_CADelete_PROMPT_ID 삭제할 인증서의 ID:
 
 
@@ -5180,7 +5162,7 @@ CMD_CADelete_PROMPT_ID 삭제할 인증서의 ID:
 CMD_CAGet 신뢰하는 인증 기관의 인증서 취득
 CMD_CAGet_Help 현재 관리하고있는 가상 HUB가 신뢰하는 인증 기관의 인증서 목록에서 기존 인증서를 취득하고 X.509 형식의 파일로 저장합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CAGet_Args CAGet [id] [/SAVECERT:path]
-CMD_CAGet_ [id] 취득하는 인증서의 ID를 지정합니다.
+CMD_CAGet_[id] 취득하는 인증서의 ID를 지정합니다.
 CMD_CAGet_SAVECERT 취득한 인증서를 저장할 파일 이름을 지정합니다.
 CMD_CAGet_PROMPT_ID 얻을 인증서 ID:
 CMD_CAGet_PROMPT_SAVECERT 저장할 파일 이름:
@@ -5196,7 +5178,7 @@ CMD_CascadeList_Args CascadeList
 CMD_CascadeCreate 새로운 계단식 만들기
 CMD_CascadeCreate_Help 현재 관리하고있는 가상 HUB에 새로운 캐스케이드를 만듭니다. \n 캐스케이드를 사용하면이 가상 HUB를 동일하거나 다른 컴퓨터에서 실행중인 다른 가상 HUB 계단식 수 있습니다. \n 계단식 만들려면 초기 매개 변수로 계단식의 이름과 연결된 서버와 연결된 가상 HUB 사용자 이름을 지정해야합니다. 새로운 캐스케이드를 만든 경우 사용자 인증 유형은 익명 인증에 초기 설정된 프록시 서버 설정 및 서버 인증서 유효성 검사 옵션 설정되지 않습니다. 이러한 설정 및 기타 자세한 설정을 변경하려면 계단식 작성한 후 "Cascade"라는 이름으로 시작하는 다른 명령을 사용합니다. \n \n [계단식의 경고 \n 캐스케이드를 사용하면 여러 가상 HUB간에 레이어 2 브리지가 가능하지만 연결 방법을 잘못하면 루프 모양의 계단식 만들어 버리는 경우 수 있습니다. 계단식 기능을 사용할 때 신중하게 네트워크 토폴로지를 설계하십시오. \n \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeCreate_Args CascadeCreate [name] [/SERVER:hostname:port] [/HUB:hubname] [/USERNAME:username]
-CMD_CascadeCreate_ [name] 만들 계단식의 이름을 지정합니다.
+CMD_CascadeCreate_[name] 만들 계단식의 이름을 지정합니다.
 CMD_CascadeCreate_SERVER 호스트 이름:포트 번호 형식으로 연결된 VPN Server의 호스트 이름과 포트 번호를 지정합니다. IP 주소를 지정할 수도 있습니다.
 CMD_CascadeCreate_HUB 연결된 VPN Server의 가상 HUB를 지정합니다.
 CMD_CascadeCreate_USERNAME 연결된 VPN Server에 연결할 때 사용자 인증에 사용할 사용자 이름을 지정합니다.
@@ -5210,7 +5192,7 @@ CMD_CascadeCreate_Prompt_Username 연결하는 사용자 이름:
 CMD_CascadeSet 계단식 연결 설정
 CMD_CascadeSet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 연결하려는 VPN Server의 호스트 이름과 포트 번호 가상 HUB 이름 및 연결에 사용할 사용자 이름을 설정합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeSet_Args CascadeSet [name] [/SERVER:hostname:port] [/HUB:hubname]
-CMD_CascadeSet_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeSet_[name] 설정을 변경 계단식의 이름을 지정합니다.
 CMD_CascadeSet_SERVER 호스트 이름:포트 번호 형식으로 연결된 VPN Server의 호스트 이름과 포트 번호를 지정합니다. IP 주소를 지정할 수도 있습니다.
 CMD_CascadeSet_HUB 연결된 VPN Server의 가상 HUB를 지정합니다.
 
@@ -5219,21 +5201,21 @@ CMD_CascadeSet_HUB 연결된 VPN Server의 가상 HUB를 지정합니다.
 CMD_CascadeGet 계단식 설정 검색
 CMD_CascadeGet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 연결 설정을 가져옵니다. \n 또한 계단식 연결 설정을 변경하려면 계단식 작성한 후 "Cascade"라는 이름으로 시작하는 다른 명령을 사용합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeGet_Args CascadeGet [name]
-CMD_CascadeGet_ [name] 설정을 가져 계단식의 이름을 지정합니다.
+CMD_CascadeGet_[name] 설정을 가져 계단식의 이름을 지정합니다.
 CMD_CascadeGet_Policy [계단식 세션의 보안 정책 설정]
 
 # CascadeDelete 명령
 CMD_CascadeDelete 계단식 삭제
 CMD_CascadeDelete_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 삭제합니다. 지정된 계단식가 온라인 상태 인 경우 자동으로 연결을 끊고 삭제합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeDelete_Args CascadeDelete [name]
-CMD_CascadeDelete_ [name] 삭제 계단식의 이름을 지정합니다.
+CMD_CascadeDelete_[name] 삭제 계단식의 이름을 지정합니다.
 
 
 # CascadeUsernameSet 명령
 CMD_CascadeUsernameSet 계단식 연결하는 데 사용하는 사용자 이름 설정
 CMD_CascadeUsernameSet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server에 연결할 때 사용자 인증에 필요한 사용자 이름을 지정합니다. \n 또한, 사용자 인증 유형을 지정하고 필요한 매개 변수를 지정 할 필요가있을 수 있습니다. 이러한 정보를 변경하려면 CascadeAnonymousSet, CascadePasswordSet, CascadeCertSet 같은 명령을 사용합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeUsernameSet_Args CascadeUsernameSet [name] [/USERNAME:username]
-CMD_CascadeUsernameSet_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeUsernameSet_[name] 설정을 변경 계단식의 이름을 지정합니다.
 CMD_CascadeUsernameSet_USERNAME 계단식가 VPN Server에 연결할 때 사용자 인증에 필요한 사용자 이름을 지정합니다.
 CMD_CascadeUsername_Notice 이 연결 설정의 인증 방법은 현재 암호 인증으로 설정되어 있습니다. 사용자 이름을 변경 한 후 CascadePasswordSet 명령에서 암호를 다시 설정해야합니다.
 
@@ -5242,14 +5224,14 @@ CMD_CascadeUsername_Notice 이 연결 설정의 인증 방법은 현재 암호 �
 CMD_CascadeAnonymousSet 계단식 사용자 인증 유형을 익명 인증으로 설정
 CMD_CascadeAnonymousSet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server에 연결할 때 사용자 인증 방법을 익명 인증으로 설정합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeAnonymousSet_Args CascadeAnonymousSet [name]
-CMD_CascadeAnonymousSet_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeAnonymousSet_[name] 설정을 변경 계단식의 이름을 지정합니다.
 
 
 # CascadePasswordSet 명령
 CMD_CascadePasswordSet 계단식 사용자 인증 유형을 암호 인증 설정
 CMD_CascadePasswordSet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server에 연결할 때 사용자 인증 방법을 암호 인증으로 설정합니다. 암호 인증의 종류에는 표준 암호 인증 및 RADIUS 또는 NT 도메인 인증을 지정합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadePasswordSet_Args CascadePasswordSet [name] [/PASSWORD:password] [/TYPE:standard|radius]
-CMD_CascadePasswordSet_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadePasswordSet_[name] 설정을 변경 계단식의 이름을 지정합니다.
 CMD_CascadePasswordSet_PASSWORD 암호 인증에 사용할 암호를 지정합니다. 지정하지 않으면 암호를 입력하라는 메시지가 표시됩니다.
 CMD_CascadePasswordSet_TYPE 암호 인증 유형으로 "standard"(표준 암호 인증) 또는 "radius"(RADIUS 또는 NT 도메인 인증) 중 하나를 지정합니다.
 CMD_CascadePasswordSet_Prompt_Type standard 또는 radius 지정:
@@ -5260,7 +5242,7 @@ CMD_CascadePasswordSet_Type_Invalid standard 또는 radius의 지정이 잘못�
 CMD_CascadeCertSet 계단식 사용자 인증 유형을 클라이언트 인증서 인증으로 설정
 CMD_CascadeCertSet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server에 연결할 때 사용자 인증 방법을 클라이언트 인증서 인증으로 설정합니다. 인증서로는 X.509 형식의 인증서 파일과 Base 64로 인코딩 된 해당하는 개인 키 파일을 지정해야합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeCertSet_Args CascadeCertSet [name] [/LOADCERT:cert] [/LOADKEY:key]
-CMD_CascadeCertSet_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeCertSet_[name] 설정을 변경 계단식의 이름을 지정합니다.
 CMD_CascadeCertSet_LOADCERT 인증서 인증에서 제시하는 X.509 형식의 인증서 파일 이름을 지정합니다.
 CMD_CascadeCertSet_LOADKEY 인증서에 대응 한 Base 64로 인코딩 된 개인 키 파일 이름을 지정합니다.
 
@@ -5269,7 +5251,7 @@ CMD_CascadeCertSet_LOADKEY 인증서에 대응 한 Base 64로 인코딩 된 개�
 CMD_CascadeCertGet 캐스케이드 접속에 이용하는 클라이언트 인증서 취득
 CMD_CascadeCertGet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 클라이언트 인증서 인증을 사용하려면 클라이언트 인증서로 제공하는 인증서를 취득하여 인증서 파일을 X.509 형식으로 저장합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeCertGet_Args CascadeCertGet [name] [/SAVECERT:cert]
-CMD_CascadeCertGet_ [name] 설정을 가져 계단식의 이름을 지정합니다.
+CMD_CascadeCertGet_[name] 설정을 가져 계단식의 이름을 지정합니다.
 CMD_CascadeCertGet_SAVECERT 취득한 인증서를 X.509 형식으로 저장할 파일 이름을 지정합니다.
 CMD_CascadeCertSet_Not_Auth_Cert 지정한 계단식 클라이언트 인증서 인증 모드는 없습니다.
 CMD_CascadeCertSet_Cert_Not_Exists 지정한 계단식 연결 설정에 인증서가 포함되어 있지 않습니다.
@@ -5279,42 +5261,42 @@ CMD_CascadeCertSet_Cert_Not_Exists 지정한 계단식 연결 설정에 인증�
 CMD_CascadeEncryptEnable 계단식 통신시 암호화 활성화
 CMD_CascadeEncryptEnable_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server 사이에서 VPN 연결을 행하고 통신을 할 때 VPN Server 사이의 통신 내용을 SSL 로 암호화하도록 설정합니다. \n 일반적으로 VPN Server 간의 통신을 SSL로 암호화하여 정보의 도청 및 변조를 방지합니다. 암호화를 비활성화 할 수 있습니다. 암호화를 해제하면 통신 처리량이 향상되지만, 통신 데이터는 일반 텍스트로 네트워크를 통해 흐릅니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeEncryptEnable_Args CascadeEncryptEnable [name]
-CMD_CascadeEncryptEnable_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeEncryptEnable_[name] 설정을 변경 계단식의 이름을 지정합니다.
 
 
 # CascadeEncryptDisable 명령
 CMD_CascadeEncryptDisable 계단식 통신시 암호화 해제
 CMD_CascadeEncryptDisable_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server 사이에서 VPN 연결을 행하고 통신을 할 때 VPN Server 사이의 통신 내용을 암호화 하지 않도록 설정합니다. \n 일반적으로 VPN Server 간의 통신을 SSL로 암호화하여 정보의 도청 및 변조를 방지합니다. 암호화를 비활성화 할 수 있습니다. 암호화를 해제하면 통신 처리량이 향상되지만, 통신 데이터는 일반 텍스트로 네트워크를 통해 흐릅니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeEncryptDisable_Args CascadeEncryptDisable [name]
-CMD_CascadeEncryptDisable_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeEncryptDisable_[name] 설정을 변경 계단식의 이름을 지정합니다.
 
 
 # CascadeCompressEnable 명령
 CMD_CascadeCompressEnable 계단식 통신시 데이터 압축 사용
-CMD_CascadeCompressEnable_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server 사이에서 VPN 연결을 행하고 통신을 할 때 VPN Server 사이의 통신 내용을 압축 하도록 설정합니다. \n 최대 약 80 %정도의 압축을 할 수 있습니다. 그러나 압축하면 클라이언트와 서버 모두에서 CPU 부하가 높아집니다. 회선 속도가 10 Mbps 이상의 경우 압축하면 처리량이 감소하고 역효과가 될 수 있습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
+CMD_CascadeCompressEnable_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server 사이에서 VPN 연결을 행하고 통신을 할 때 VPN Server 사이의 통신 내용을 압축 하도록 설정합니다. \n 최대 약 80 % 정도의 압축을 할 수 있습니다. 그러나 압축하면 클라이언트와 서버 모두에서 CPU 부하가 높아집니다. 회선 속도가 10 Mbps 이상의 경우 압축하면 처리량이 감소하고 역효과가 될 수 있습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeCompressEnable_Args CascadeCompressEnable [name]
-CMD_CascadeCompressEnable_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeCompressEnable_[name] 설정을 변경 계단식의 이름을 지정합니다.
 
 
 # CascadeCompressDisable 명령
 CMD_CascadeCompressDisable 계단식 통신시 데이터 압축 해제
 CMD_CascadeCompressDisable_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server 사이에서 VPN 연결을 행하고 통신을 할 때 VPN Server 사이의 통신 내용을 압축 하지 않도록 설정합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeCompressDisable_Args CascadeCompressDisable [name]
-CMD_CascadeCompressDisable_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeCompressDisable_[name] 설정을 변경 계단식의 이름을 지정합니다.
 
 
 # CascadeProxyNone 명령
 CMD_CascadeProxyNone 계단식 연결 방법을 직접 TCP/IP 연결 설정
 CMD_CascadeProxyNone_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server에 연결할 때 사용할 연결 방법을 [직접 TCP/IP 연결을 설정하고 프록시 서버를 경유하지 않도록합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeProxyNone_Args CascadeProxyNone [name]
-CMD_CascadeProxyNone_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeProxyNone_[name] 설정을 변경 계단식의 이름을 지정합니다.
 
 
 # CascadeProxyHttp 명령
 CMD_CascadeProxyHttp 계단식 연결 방법을 HTTP 프록시 서버를 통해 연결 설정
 CMD_CascadeProxyHttp_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server에 연결할 때 사용할 연결 방법을 HTTP 프록시 서버를 통해 연결을 설정하고 경유 HTTP 프록시 서버의 호스트 이름과 포트 번호, 사용자 이름과 암호 (필요한 경우)을 지정합니다. \n 통해 HTTP 서버는 HTTPS 통신을하기위한 CONNECT 메소드를 지원해야합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeProxyHttp_Args CascadeProxyHttp [name] [/SERVER:hostname:port] [/USERNAME:username] [/PASSWORD:password]
-CMD_CascadeProxyHttp_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeProxyHttp_[name] 설정을 변경 계단식의 이름을 지정합니다.
 CMD_CascadeProxyHttp_SERVER 호스트 이름:포트 번호 형식으로 통해 HTTP 프록시 서버의 호스트 이름 또는 IP 주소와 포트 번호를 지정합니다.
 CMD_CascadeProxyHttp_USERNAME 통해 HTTP 프록시 서버에 연결하기 위해 사용자 인증이 필요한 경우 사용자 이름을 지정합니다. 또한 동시에/PASSWORD 매개 변수도 지정합니다./USERNAME 및/PASSWORD 매개 변수가 지정되지 않은 경우 사용자 인증 데이터를 설정하지 않습니다.
 CMD_CascadeProxyHttp_PASSWORD 통해 HTTP 프록시 서버에 연결하기 위해 사용자 인증이 필요한 경우 암호를 지정합니다./USERNAME 매개 변수와 함께 지정합니다.
@@ -5326,7 +5308,7 @@ CMD_CascadeProxyHttp_Prompt_Server 프록시 서버의 호스트 이름과 포�
 CMD_CascadeProxySocks 계단식 연결 방법을 SOCKS 프록시 서버를 통해 연결 설정
 CMD_CascadeProxySocks_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server에 연결할 때 사용할 연결 방법을 [SOCKS 프록시 서버를 통해 연결을 설정하고 경유 하는 SOCKS 프록시 서버의 호스트 이름과 포트 번호, 사용자 이름과 암호 (필요한 경우)을 지정합니다. \n 통해 SOCKS 서버는 SOCKS 버전 4를 지원해야합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeProxySocks_Args CascadeProxySocks [name] [/SERVER:hostname:port] [/USERNAME:username] [/PASSWORD:password]
-CMD_CascadeProxySocks_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeProxySocks_[name] 설정을 변경 계단식의 이름을 지정합니다.
 CMD_CascadeProxySocks_SERVER 호스트 이름:포트 번호 형식으로 통해 SOCKS 프록시 서버의 호스트 이름 또는 IP 주소와 포트 번호를 지정합니다.
 CMD_CascadeProxySocks_USERNAME 통해 SOCKS 프록시 서버에 연결하기 위해 사용자 인증이 필요한 경우 사용자 이름을 지정합니다. 또한 동시에/PASSWORD 매개 변수도 지정합니다./USERNAME 및/PASSWORD 매개 변수가 지정되지 않은 경우 사용자 인증 데이터를 설정하지 않습니다.
 CMD_CascadeProxySocks_PASSWORD 통해 SOCKS 프록시 서버에 연결하기 위해 사용자 인증이 필요한 경우 암호를 지정합니다./USERNAME 매개 변수와 함께 지정합니다.
@@ -5336,21 +5318,21 @@ CMD_CascadeProxySocks_PASSWORD 통해 SOCKS 프록시 서버에 연결하기 위
 CMD_CascadeServerCertEnable 계단식 서버 인증서 검증 옵션 활성화
 CMD_CascadeServerCertEnable_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server에 연결할 때 연결하려는 VPN Server가 제시하는 SSL 인증서를 신뢰할 수 있는지 여부 검사 옵션을 활성화합니다. \n이 옵션이 활성화되어있는 경우 연결할 서버의 SSL 인증서를 미리 CascadeServerCertSet 명령에 계단식 설정에 저장할하거나 가상 HUB 신뢰하는 인증 기관의 인증서 목록에 서버 SSL 인증서를 서명 한 루트 인증서를 CAAdd 명령 등으로 등록되어 있어야합니다. \n 계단식 서버 인증서 검증 옵션이 활성화되어있는 상태에서 연결 한 VPN Server의 인증서를 신뢰할 수없는 경우 즉시 연결을 해제하고 재 시도를 반복합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeServerCertEnable_Args CascadeServerCertEnable [name]
-CMD_CascadeServerCertEnable_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeServerCertEnable_[name] 설정을 변경 계단식의 이름을 지정합니다.
 
 
 # CascadeServerCertDisable 명령
 CMD_CascadeServerCertDisable 계단식 서버 인증서 검증 옵션 비활성화
 CMD_CascadeServerCertDisable_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server에 연결할 때 연결하려는 VPN Server가 제시하는 SSL 인증서가 신뢰할 수 있는지 여부 검사 옵션을 해제합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeServerCertDisable_Args CascadeServerCertDisable [name]
-CMD_CascadeServerCertDisable_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeServerCertDisable_[name] 설정을 변경 계단식의 이름을 지정합니다.
 
 
 # CascadeServerCertSet 명령
 CMD_CascadeServerCertSet 계단식 서버 별 인증서 설정
 CMD_CascadeServerCertSet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server에 연결할 때 연결하려는 VPN Server가 제시하는 SSL 인증서와 동일한 인증서를 미리 등록합니다. \n 계단식 서버 인증서 검증 옵션이 활성화되어있는 경우 연결할 서버의 SSL 인증서를 미리이 명령에서 계단식 설정에 저장할하거나 가상 HUB의 신뢰 인증 기관의 인증서 목록에 서버의 SSL 인증서를 서명 한 루트 인증서를 CAAdd 명령 등으로 등록되어 있어야합니다. \n 계단식 서버 인증서 검증 옵션이 활성화되어있는 상태에서 연결 한 VPN Server의 인증서를 신뢰할 수없는 경우 즉시 연결을 해제하고 재 시도를 반복합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeServerCertSet_Args CascadeServerCertSet [name] [/LOADCERT:cert]
-CMD_CascadeServerCertSet_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeServerCertSet_[name] 설정을 변경 계단식의 이름을 지정합니다.
 CMD_CascadeServerCertSet_LOADCERT 설정 서버 별 인증서가 저장되어있는 X.509 형식의 인증서 파일 이름을 지정합니다.
 
 
@@ -5358,14 +5340,14 @@ CMD_CascadeServerCertSet_LOADCERT 설정 서버 별 인증서가 저장되어있
 CMD_CascadeServerCertDelete 계단식 서버 별 인증서 삭제
 CMD_CascadeServerCertDelete_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식 서버 별 인증서가 등록되어있는 경우는 그것을 삭제합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeServerCertDelete_Args CascadeServerCertDelete [name]
-CMD_CascadeServerCertDelete_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeServerCertDelete_[name] 설정을 변경 계단식의 이름을 지정합니다.
 
 
 # CascadeServerCertGet 명령
 CMD_CascadeServerCertGet 계단식 서버 별 인증서 취득
 CMD_CascadeServerCertGet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식 서버 별 인증서가 등록되어있는 경우 해당 인증서를 취득하여 X.509 형식의 인증서 파일로 저장합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeServerCertGet_Args CascadeServerCertGet [name] [/SAVECERT:path]
-CMD_CascadeServerCertGet_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeServerCertGet_[name] 설정을 변경 계단식의 이름을 지정합니다.
 CMD_CascadeServerCertGet_SAVECERT 서버 별 인증서를 X.509 형식으로 저장할 인증서 파일 이름을 지정합니다.
 
 
@@ -5373,7 +5355,7 @@ CMD_CascadeServerCertGet_SAVECERT 서버 별 인증서를 X.509 형식으로 저
 CMD_CascadeDetailSet 계단식 고급 통신 설정 설정
 CMD_CascadeDetailSet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 VPN Server와 통신하는 데 사용되는 VPN 프로토콜의 통신 설정을 사용자 정의합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeDetailSet_Args CascadeDetailSet [name] [/MAXTCP:max_connection] [/INTERVAL:interval] [/TTL:disconnect_span] [/HALF:yes|no] [/NOQOS:yes|no]
-CMD_CascadeDetailSet_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadeDetailSet_[name] 설정을 변경 계단식의 이름을 지정합니다.
 CMD_CascadeDetailSet_MAXTCP VPN 통신에 사용하는 TCP 연결 수를 1 이상 32 이하의 정수로 지정합니다. VPN Server 사이의 VPN 통신 세션의 데이터 전송에 복수 개의 TCP 연결을 묶어 사용하여 통신 속도를 향상시킬 수 있습니다. \n주의:서버에 연결 회선이 빠른 경우는 8 개 정도를 전화 접속 등의 느린 경우 1 개를 추천합니다.
 CMD_CascadeDetailSet_INTERVAL 여러 TCP 연결을 설정하고 VPN 통신을 할 때 각 TCP 연결 설정 간격을 초 단위로 지정합니다. 기본값은 1 초입니다.
 CMD_CascadeDetailSet_TTL 각 TCP 연결의 수명을 설정하는 경우, TCP 연결이 설정되고 나서 절단 될 때까지의 수명을 초 단위로 지정합니다. 0을 지정하면 수명은 설정되지 않습니다.
@@ -5391,7 +5373,7 @@ CMD_CascadeDetailSet_Prompt_HALF 반이중 모드를 활성화 (yes/no):
 CMD_CascadePolicySet 계단식 세션의 보안 정책 설정
 CMD_CascadePolicySet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 캐스케이드 연결했을 때 가상 HUB에서 생성 된 세션에 적용 할 보안 정책의 내용을 변경합니다. \n 가상 HUB가 다른 VPN Server에 계단식하면 계단식 원의 가상 HUB는 "계단식 세션"가 새롭게 생성됩니다. 그 계단식 세션에 설정된 보안 정책의 내용을이 명령으로 설정할 수 있습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadePolicySet_Args [name] [/NAME:policy_name] [/VALUE:num|yes|no]
-CMD_CascadePolicySet_ [name] 설정을 변경 계단식의 이름을 지정합니다.
+CMD_CascadePolicySet_[name] 설정을 변경 계단식의 이름을 지정합니다.
 CMD_CascadePolicySet_NAME 값을 변경하는 정책의 이름을 지정합니다. 정책의 이름과 설정 가능한 값의 목록은 PolicyList 명령으로 표시 할 수 있습니다.
 CMD_CascadePolicySet_VALUE 정책의 새 값을 지정합니다. 그 정책이 수치 형의 경우 정수를 지정합니다. 부울 경우는 yes 또는 no를 지정합니다. 설정할 수있는 형식과 값은 PolicyList 명령으로 표시 할 수 있습니다.
 CMD_CascadePolicySet_PROMPT_POLNAME 값을 변경하는 정책의 이름:
@@ -5405,7 +5387,7 @@ CMD_CascadePolicySet_Invalid_Range 정책 "%S"%s의 범위에서 지정하십시
 CMD_PolicyList 보안 정책의 종류와 설정 가능한 값의 목록을 표시
 CMD_PolicyList_Help VPN Server 사용자 및 그룹 계단식 대해 설정할 수있는 보안 정책의 항목 이름, 설명 및 설정할 수있는 값의 목록을 표시합니다. \nPolicyList 명령에 아무것도 인수를 지정하지 않고 시작하면 지원되는 모든 보안 정책의 이름과 설명이 나열됩니다. \nPolicyList 명령의 인수로 이름을 지정하면 그 값에 대한 자세한 설명과 설정 가능한 값의 형태와 범위가 표시됩니다.
 CMD_PolicyList_Args PolicyList [name]
-CMD_PolicyList_ [name] 설명을 표시하는 정책 이름을 지정합니다. 지정하지 않는 경우는 지원되는 모든 보안 정책의 이름과 설명이 나열됩니다.
+CMD_PolicyList_[name] 설명을 표시하는 정책 이름을 지정합니다. 지정하지 않는 경우는 지원되는 모든 보안 정책의 이름과 설명이 나열됩니다.
 CMD_PolicyList_Invalid_Name 지정된 보안 정책 이름이 잘못되었습니다.
 CMD_PolicyList_Column_1 정책 이름
 CMD_PolicyList_Column_2 정책의 간단한 설명
@@ -5424,14 +5406,14 @@ CMD_PolicyList_Range_Int_2 %s 이상 %s 이하 (단 0을 지정하면 설정 없
 CMD_CascadeStatusGet 계단식의 현재 상태의 취득
 CMD_CascadeStatusGet_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식가 현재 온라인 상태 인 경우, 연결 상태 및 기타 정보를 가져옵니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeStatusGet_Args CascadeStatusGet [name]
-CMD_CascadeStatusGet_ [name] 정보를 얻을 계단식의 이름을 지정합니다.
+CMD_CascadeStatusGet_[name] 정보를 얻을 계단식의 이름을 지정합니다.
 
 
 # CascadeRename 명령
 CMD_CascadeRename 계단식 이름 변경
 CMD_CascadeRename_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식의 이름을 변경합니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeRename_Args CascadeRename [name] [/NEW:new_name]
-CMD_CascadeRename_ [name] 이름을 변경 계단식의 현재 이름을 지정합니다.
+CMD_CascadeRename_[name] 이름을 변경 계단식의 현재 이름을 지정합니다.
 CMD_CascadeRename_NEW 변경 후 새 이름을 지정합니다.
 CMD_CascadeRename_PROMPT_OLD 현재의 이름:
 CMD_CascadeRename_PROMPT_NEW 새 이름:
@@ -5442,21 +5424,21 @@ CMD_CascadeRename_PROMPT_NEW 새 이름:
 CMD_CascadeOnline 계단식 온라인 상태로 설정
 CMD_CascadeOnline_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식 온라인 화합니다. 온라인 상태가 된 캐스케이드 연결 설정에 따라 연결 대상 VPN Server에 연결 프로세스를 시작합니다. 온라인 상태가 된 캐스케이드는 CascadeOffline 명령에서 오프라인 상태로 설정 될 때까지 VPN Server에 항상 연결하거나 연결을 시도하고 있습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeOnline_Args CascadeOnline [name]
-CMD_CascadeOnline_ [name] 온라인 상태에 계단식의 이름을 지정합니다.
+CMD_CascadeOnline_[name] 온라인 상태에 계단식의 이름을 지정합니다.
 
 
 # CascadeOffline 명령
 CMD_CascadeOffline 계단식 오프라인 상태로 설정
 CMD_CascadeOffline_Help 현재 관리하고있는 가상 HUB에 등록되어있는 계단식 지정하고 계단식 오프라인 화합니다. 오프라인 된 캐스케이드는 다음 CascadeOnline 명령에서 온라인 상태로 설정 될 때까지 VPN Server에 연결하지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CascadeOffline_Args CascadeOffline [name]
-CMD_CascadeOffline_ [name] 오프라인 상태로 계단식의 이름을 지정합니다.
+CMD_CascadeOffline_[name] 오프라인 상태로 계단식의 이름을 지정합니다.
 
 
 # AccessAdd 명령
 CMD_AccessAdd 액세스 목록에 규칙 추가 (IPv4)
 CMD_AccessAdd_Help 현재 관리하고있는 가상 HUB 액세스 목록에 새 규칙을 추가합니다. \n 액세스 목록은 가상 HUB 내를 흐르는 패킷에 적용되는 패킷 필터 규칙의 집합입니다. 액세스 목록에는 여러 규칙을 등록 할 수 있으며, 각 규칙에 대해 우선 순위를 정의 할 수 있습니다. 모든 패킷 액세스 목록에 등록되어있는 규칙에 지정된 조건에 일치하는 첫 번째 규칙에서 규정 된 동작으로 통과 또는 폐기가 결정됩니다. 어떤 규칙 조건에 일치하지 않은 패킷은 내재적으로 통과 허용됩니다. 또한 AccessAddEx 명령을 사용하여 통과시에 지연 지터 패킷 손실을 발생시킬 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AccessAdd_Args AccessAdd [pass|discard] [/MEMO:memo] [/PRIORITY:priority] [/SRCUSERNAME:username] [/DESTUSERNAME:username] [/SRCMAC:mac/mask] [/DESTMAC:mac/mask] [/SRCIP:ip/mask] [/DESTIP:ip/mask] [/PROTOCOL:tcp|udp|icmpv4|icmpv6|ip|num] [/SRCPORT:start-end] [/DESTPORT:start-end] [/TCPSTATE:established|unestablished]
-CMD_AccessAdd_ [pass|discard] 패킷이 규칙의 조건에 일치하면 동작을 결정합니다. pass를 지정하면 트래버스를 discard를 지정하면 [삭제]를 의미합니다.
+CMD_AccessAdd_[pass|discard] 패킷이 규칙의 조건에 일치하면 동작을 결정합니다. pass를 지정하면 트래버스를 discard를 지정하면 [삭제]를 의미합니다.
 CMD_AccessAdd_MEMO 규칙 설명 (주)을 지정합니다.
 CMD_AccessAdd_PRIORITY 규칙의 우선 순위를 1 이상의 정수로 지정합니다. 우선 순위는 작은 것 일수록 우선 순위가 높습니다.
 CMD_AccessAdd_SRCIP 규칙의 조건으로 보내는 IPv4 주소를 "IP 주소/마스크"의 형식으로 지정합니다. IP 주소는 192.168.0.1과 같이 10 진수를 점으로 구분하여 지정합니다. 마스크는 255.255.255.0과 같이 10 진수를 점으로 구분하여 지정하거나 24와 같이 처음부터 비트 길이를 10 진수로 지정할 수 있습니다. 0.0.0.0/0.0.0.0를 지정하면 모든 호스트를 나타냅니다.
@@ -5489,7 +5471,7 @@ CMD_AccessAdd_Prompt_TCPSTATE TCP 연결 상태 (Established/Unestablished):
 CMD_AccessAddEx 액세스 목록에 규칙 추가 (IPv4 지연 지터 패킷 손실 설정 가능)
 CMD_AccessAddEx_Help 현재 관리하고있는 가상 HUB 액세스 목록에 새 규칙을 추가합니다. 통과시 지연 지터 패킷 손실을 발생시킬 수 있습니다. \n 액세스 목록은 가상 HUB 내를 흐르는 패킷에 적용되는 패킷 필터 규칙의 집합입니다. 액세스 목록에는 여러 규칙을 등록 할 수 있으며, 각 규칙에 대해 우선 순위를 정의 할 수 있습니다. 모든 패킷 액세스 목록에 등록되어있는 규칙에 지정된 조건에 일치하는 첫 번째 규칙에서 규정 된 동작으로 통과 또는 폐기가 결정됩니다. 어떤 규칙 조건에 일치하지 않은 패킷은 내재적으로 통과 허용됩니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AccessAddEx_Args AccessAddEx [pass|discard] [/MEMO:memo] [/PRIORITY:priority] [/SRCUSERNAME:username] [/DESTUSERNAME:username] [/SRCMAC:mac/mask] [/DESTMAC:mac/mask] [/SRCIP:ip/mask] [/DESTIP:ip/mask] [/PROTOCOL:tcp|udp|icmpv4|icmpv6|ip|num] [/SRCPORT:start-end] [/DESTPORT:start-end] [/SRCUSERNAME:username ] [/DESTUSERNAME:username] [/TCPSTATE:established|unestablished] [/DELAY:delay_millisec] [/JITTER:jitter_percent] [/LOSS:loss_percent]
-CMD_AccessAddEx_ [pass|discard] 패킷이 규칙의 조건에 일치하면 동작을 결정합니다. pass를 지정하면 트래버스를 discard를 지정하면 [삭제]를 의미합니다. 지연 지터 패킷 손실 설정은 pass의 경우에만 적용됩니다.
+CMD_AccessAddEx_[pass|discard] 패킷이 규칙의 조건에 일치하면 동작을 결정합니다. pass를 지정하면 트래버스를 discard를 지정하면 [삭제]를 의미합니다. 지연 지터 패킷 손실 설정은 pass의 경우에만 적용됩니다.
 CMD_AccessAddEx_MEMO 규칙 설명 (주)을 지정합니다.
 CMD_AccessAddEx_PRIORITY 규칙의 우선 순위를 1 이상의 정수로 지정합니다. 우선 순위는 작은 것 일수록 우선 순위가 높습니다.
 CMD_AccessAddEx_SRCIP 규칙의 조건으로 보내는 IPv4 주소를 "IP 주소/마스크"의 형식으로 지정합니다. IP 주소는 192.168.0.1과 같이 10 진수를 점으로 구분하여 지정합니다. 마스크는 255.255.255.0과 같이 10 진수를 점으로 구분하여 지정하거나 24와 같이 처음부터 비트 길이를 10 진수로 지정할 수 있습니다. 0.0.0.0/0.0.0.0를 지정하면 모든 호스트를 나타냅니다.
@@ -5503,8 +5485,8 @@ CMD_AccessAddEx_SRCMAC 규칙의 조건으로 소스 MAC 주소를 지정합니�
 CMD_AccessAddEx_DESTMAC 규칙의 조건으로 목적지 MAC 주소를 지정합니다. 지정 방법은/SRCMAC 매개 변수와 같습니다.
 CMD_AccessAddEx_TCPSTATE 규칙의 조건으로 TCP 연결 상태를 지정합니다. Established 또는 Unestablished을 지정합니다.
 CMD_AccessAddEx_DELAY 이 규칙은 패킷이 통과하는 경우에 지연을 발생시킬 수 있습니다. 발생시키고 자하는 지연 시간을 밀리 초 단위로 지정합니다. 무 지정 또는 0을 지정하면 지연은 발생하지 않습니다. 지연은 10000 밀리 초 이하 여야합니다.
-CMD_AccessAddEx_JITTER 이 규칙은 패킷이 통과하는 경우에 지터를 발생시킬 수 있습니다. 지연 값에 대해 지터의 요동을 0 %~ 100 %의 백분율 수치로 지정합니다. 무 지정 또는 0을 지정하면 지터가 발생하지 않습니다.
-CMD_AccessAddEx_LOSS 이 규칙은 패킷이 통과 할 때 패킷 손실을 발생시킬 수 있습니다. 패킷이 손실 될 가능성을 0 %~ 100 %의 백분율 수치로 지정합니다. 무 지정 또는 0을 지정하면 패킷 손실은 발생하지 않습니다.
+CMD_AccessAddEx_JITTER 이 규칙은 패킷이 통과하는 경우에 지터를 발생시킬 수 있습니다. 지연 값에 대해 지터의 요동을 0 % ~ 100 % 의 백분율 수치로 지정합니다. 무 지정 또는 0을 지정하면 지터가 발생하지 않습니다.
+CMD_AccessAddEx_LOSS 이 규칙은 패킷이 통과 할 때 패킷 손실을 발생시킬 수 있습니다. 패킷이 손실 될 가능성을 0 % ~ 100 % 의 백분율 수치로 지정합니다. 무 지정 또는 0을 지정하면 패킷 손실은 발생하지 않습니다.
 
 CMD_AccessAddEx_Prompt_DELAY 발생하는 지연 (밀리 세컨드 단위:0 - 10000):
 CMD_AccessAddEx_Prompt_JITTER 발생시키는 지터의 요동 (백분율:0 - 100):
@@ -5519,7 +5501,7 @@ CMD_AccessAddEx_Eval_LOSS 패킷 손실 비율은 0 - 100의 정수로 지정하
 CMD_AccessAdd6 액세스 목록에 규칙 추가 (IPv6)
 CMD_AccessAdd6_Help 현재 관리하고있는 가상 HUB 액세스 목록에 새 규칙을 추가합니다. \n 액세스 목록은 가상 HUB 내를 흐르는 패킷에 적용되는 패킷 필터 규칙의 집합입니다. 액세스 목록에는 여러 규칙을 등록 할 수 있으며, 각 규칙에 대해 우선 순위를 정의 할 수 있습니다. 모든 패킷 액세스 목록에 등록되어있는 규칙에 지정된 조건에 일치하는 첫 번째 규칙에서 규정 된 동작으로 통과 또는 폐기가 결정됩니다. 어떤 규칙 조건에 일치하지 않은 패킷은 내재적으로 통과 허용됩니다. 또한 AccessAddEx6 명령을 사용하여 통과시에 지연 지터 패킷 손실을 발생시킬 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AccessAdd6_Args AccessAdd6 [pass|discard] [/MEMO:memo] [/PRIORITY:priority] [/SRCUSERNAME:username] [/DESTUSERNAME:username] [/SRCMAC:mac/mask] [/DESTMAC:mac/mask] [/SRCIP:ip/mask] [/DESTIP:ip/mask] [/PROTOCOL:tcp|udp|icmpv4|icmpv6|ip|num] [/SRCPORT:start-end] [/DESTPORT:start-end] [/SRCUSERNAME:username ] [/DESTUSERNAME:username] [/TCPSTATE:established|unestablished]
-CMD_AccessAdd6_ [pass|discard] 패킷이 규칙의 조건에 일치하면 동작을 결정합니다. pass를 지정하면 트래버스를 discard를 지정하면 [삭제]를 의미합니다.
+CMD_AccessAdd6_[pass|discard] 패킷이 규칙의 조건에 일치하면 동작을 결정합니다. pass를 지정하면 트래버스를 discard를 지정하면 [삭제]를 의미합니다.
 CMD_AccessAdd6_MEMO 규칙 설명 (주)을 지정합니다.
 CMD_AccessAdd6_PRIORITY 규칙의 우선 순위를 1 이상의 정수로 지정합니다. 우선 순위는 작은 것 일수록 우선 순위가 높습니다.
 CMD_AccessAdd6_SRCIP 규칙의 조건으로 원본 IPv6 주소를 "IP 주소/마스크"의 형식으로 지정합니다. IPv6 주소는 2001:200:0:1::처럼 16 진수를 콜론으로 구분하여 지정합니다. 마스크는 ffff:ffff:ffff:ffff::처럼 IPv6 형식으로 구분하거나 64와 같이 처음부터 비트 길이를 10 진수로 지정합니다. 단일 IPv6 호스트를 지정하려면 마스크를 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 또는 128로 지정합니다. 모든 IPv6 호스트를 지정하려면 "::/0"으로 지정합니다.
@@ -5552,7 +5534,7 @@ CMD_AccessAdd6_Prompt_TCPSTATE TCP 연결 상태 (Established/Unestablished):
 CMD_AccessAddEx6 액세스 목록에 규칙 추가 (IPv6 지연 지터 패킷 손실 설정 가능)
 CMD_AccessAddEx6_Help 현재 관리하고있는 가상 HUB 액세스 목록에 새 규칙을 추가합니다. 통과시 지연 지터 패킷 손실을 발생시킬 수 있습니다. \n 액세스 목록은 가상 HUB 내를 흐르는 패킷에 적용되는 패킷 필터 규칙의 집합입니다. 액세스 목록에는 여러 규칙을 등록 할 수 있으며, 각 규칙에 대해 우선 순위를 정의 할 수 있습니다. 모든 패킷 액세스 목록에 등록되어있는 규칙에 지정된 조건에 일치하는 첫 번째 규칙에서 규정 된 동작으로 통과 또는 폐기가 결정됩니다. 어떤 규칙 조건에 일치하지 않은 패킷은 내재적으로 통과 허용됩니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AccessAddEx6_Args AccessAddEx6 [pass|discard] [/MEMO:memo] [/PRIORITY:priority] [/SRCUSERNAME:username] [/DESTUSERNAME:username] [/SRCMAC:mac/mask] [/DESTMAC:mac/mask] [/SRCIP:ip/mask] [/DESTIP:ip/mask] [/PROTOCOL:tcp|udp|icmpv4|icmpv6|ip|num] [/SRCPORT:start-end] [/DESTPORT:start-end] [/SRCUSERNAME:username ] [/DESTUSERNAME:username] [/TCPSTATE:established|unestablished] [/DELAY:delay_millisec] [/JITTER:jitter_percent] [/LOSS:loss_percent]
-CMD_AccessAddEx6_ [pass|discard] 패킷이 규칙의 조건에 일치하면 동작을 결정합니다. pass를 지정하면 트래버스를 discard를 지정하면 [삭제]를 의미합니다. 지연 지터 패킷 손실 설정은 pass의 경우에만 적용됩니다.
+CMD_AccessAddEx6_[pass|discard] 패킷이 규칙의 조건에 일치하면 동작을 결정합니다. pass를 지정하면 트래버스를 discard를 지정하면 [삭제]를 의미합니다. 지연 지터 패킷 손실 설정은 pass의 경우에만 적용됩니다.
 CMD_AccessAddEx6_MEMO 규칙 설명 (주)을 지정합니다.
 CMD_AccessAddEx6_PRIORITY 규칙의 우선 순위를 1 이상의 정수로 지정합니다. 우선 순위는 작은 것 일수록 우선 순위가 높습니다.
 CMD_AccessAddEx6_SRCIP 규칙의 조건으로 원본 IPv6 주소를 "IP 주소/마스크"의 형식으로 지정합니다. IPv6 주소는 2001:200:0:1::처럼 16 진수를 콜론으로 구분하여 지정합니다. 마스크는 ffff:ffff:ffff:ffff::처럼 IPv6 형식으로 구분하거나 64와 같이 처음부터 비트 길이를 10 진수로 지정합니다. 단일 IPv6 호스트를 지정하려면 마스크를 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 또는 128로 지정합니다. 모든 IPv6 호스트를 지정하려면 "::/0"으로 지정합니다.
@@ -5566,8 +5548,8 @@ CMD_AccessAddEx6_SRCMAC 규칙의 조건으로 소스 MAC 주소를 지정합니
 CMD_AccessAddEx6_DESTMAC 규칙의 조건으로 목적지 MAC 주소를 지정합니다. 지정 방법은/SRCMAC 매개 변수와 같습니다.
 CMD_AccessAddEx6_TCPSTATE 규칙의 조건으로 TCP 연결 상태를 지정합니다. Established 또는 Unestablished을 지정합니다.
 CMD_AccessAddEx6_DELAY 이 규칙은 패킷이 통과하는 경우에 지연을 발생시킬 수 있습니다. 발생시키고 자하는 지연 시간을 밀리 초 단위로 지정합니다. 무 지정 또는 0을 지정하면 지연은 발생하지 않습니다. 지터는 10000 밀리 초 이하 여야합니다.
-CMD_AccessAddEx6_JITTER 이 규칙은 패킷이 통과하는 경우에 지터를 발생시킬 수 있습니다. 지연 값에 대해 지터의 요동을 0 %~ 100 %의 백분율 수치로 지정합니다. 무 지정 또는 0을 지정하면 지터가 발생하지 않습니다.
-CMD_AccessAddEx6_LOSS 이 규칙은 패킷이 통과 할 때 패킷 손실을 발생시킬 수 있습니다. 패킷이 손실 될 가능성을 0 %~ 100 %의 백분율 수치로 지정합니다. 무 지정 또는 0을 지정하면 패킷 손실은 발생하지 않습니다.
+CMD_AccessAddEx6_JITTER 이 규칙은 패킷이 통과하는 경우에 지터를 발생시킬 수 있습니다. 지연 값에 대해 지터의 요동을 0 % ~ 100 % 의 백분율 수치로 지정합니다. 무 지정 또는 0을 지정하면 지터가 발생하지 않습니다.
+CMD_AccessAddEx6_LOSS 이 규칙은 패킷이 통과 할 때 패킷 손실을 발생시킬 수 있습니다. 패킷이 손실 될 가능성을 0 % ~ 100 % 의 백분율 수치로 지정합니다. 무 지정 또는 0을 지정하면 패킷 손실은 발생하지 않습니다.
 
 CMD_AccessAddEx6_Prompt_DELAY 발생하는 지연 (밀리 세컨드 단위:0 - 10000):
 CMD_AccessAddEx6_Prompt_JITTER 발생시키는 지터의 요동 (백분율:0 - 100):
@@ -5590,7 +5572,7 @@ CMD_AccessList_Args AccessList
 CMD_AccessDelete 액세스 목록에서 규칙을 삭제
 CMD_AccessDelete_Help 현재 관리하고있는 가상 HUB 액세스 목록에 등록되어있는 패킷 필터링 규칙을 사용하여 삭제합니다. \n 규칙을 삭제하려면 규칙의 ID를 지정해야합니다. ID는 AccessList 명령으로 볼 수 있습니다. \n 또한 규칙을 삭제하지 않고 일시적으로 비활성화하려면 AccessDisable 명령을 사용합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AccessDelete_Args AccessDelete [id]
-CMD_AccessDelete_ [id] 삭제할 규칙의 ID 또는 고유 ID를 지정합니다.
+CMD_AccessDelete_[id] 삭제할 규칙의 ID 또는 고유 ID를 지정합니다.
 CMD_Access_Prompt_ID 액세스 목록 규칙 ID 또는 고유 ID:
 
 
@@ -5598,14 +5580,14 @@ CMD_Access_Prompt_ID 액세스 목록 규칙 ID 또는 고유 ID:
 CMD_AccessEnable 액세스 목록 규칙의 활성화
 CMD_AccessEnable_Help 현재 관리하고있는 가상 HUB 액세스 목록에 등록되어있는 패킷 필터링 규칙을 지정하여 활성화합니다. 활성화 된 규칙은 패킷 필터링에 사용됩니다. \n 규칙을 활성화하려면 규칙의 ID를 지정해야합니다. ID는 AccessList 명령으로 볼 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AccessEnable_Args AccessEnable [id]
-CMD_AccessEnable_ [id] 활성화하는 규칙의 ID를 지정합니다.
+CMD_AccessEnable_[id] 활성화하는 규칙의 ID를 지정합니다.
 
 
 # AccessDisable 명령
 CMD_AccessDisable 액세스 목록 규칙 비활성화
 CMD_AccessDisable_Help 현재 관리하고있는 가상 HUB 액세스 목록에 등록되어있는 패킷 필터링 규칙을 지정하여 비활성화합니다. 비활성화 된 규칙은 패킷 필터링에 사용되지 않습니다. \n 규칙을 비활성화하려면 규칙의 ID를 지정해야합니다. ID는 AccessList 명령으로 볼 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AccessDisable_Args AccessDisable [id]
-CMD_AccessDisable_ [id] 비활성화하는 규칙의 ID를 지정합니다.
+CMD_AccessDisable_[id] 비활성화하는 규칙의 ID를 지정합니다.
 
 
 # UserList 명령
@@ -5618,7 +5600,7 @@ CMD_UserList_Args UserList
 CMD_UserCreate 사용자 작성
 CMD_UserCreate_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 새 사용자를 만듭니다. \n 사용자를 만들 때 사용자의 인증 정보를 사용하여 VPN Client가이 가상 HUB에 연결 할 수 있습니다. \nUserCreate 명령을 사용하여 사용자를 만든 경우 해당 사용자의 인증 방법은 암호 인증으로 등록 된 암호로 임의의 문자열이 할당됩니다. 따라서 사용자는 그대로는 가상 HUB에 연결 할 수 없습니다. 사용자를 만든 후 반드시 UserPasswordSet 명령에 사용자 암호를 지정하거나 UserAnonymousSet 명령 UserCertSet 명령 UserSignedSet 명령 UserRadiusSet 명령 또는 UserNTLMSet 명령에서 사용자 인증 방법을 변경하십시오. \n 그러나 사용자 이름을 "*"(별표 1 문자)로 만든 사용자는 자동으로 RADIUS 인증 사용자로 등록됩니다. "*"라는 사용자가 존재하는 경우에만 클라이언트가 VPN Server에 연결했을 때 제시 한 사용자 이름이 기존의 사용자 이름과 일치하지 않는 사용자는 사용자가 입력 한 사용자 이름과 암호를 사용하여 RADIUS 서버 또는 NT 도메인 컨트롤러에 의해 인증 될 수 있으며, 그 경우의 인증 설정 및 보안 정책 설정은 "*"사용자 설정에 따릅니다. \n 번 만든 사용자의 사용자 정보를 변경하려면 UserSet 명령을 사용합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserCreate_Args UserCreate [name] [/GROUP:group] [/REALNAME:realname] [/NOTE:note]
-CMD_UserCreate_ [name] 새로 만든 사용자의 사용자 이름을 지정합니다.
+CMD_UserCreate_[name] 새로 만든 사용자의 사용자 이름을 지정합니다.
 CMD_UserCreate_GROUP 사용자를 그룹에 가입 할 경우 그룹 이름을 지정합니다. 사용자가 어떤 그룹에도 소속하지 않는 경우/GROUP:none을 지정합니다.
 CMD_UserCreate_REALNAME 사용자의 실명을 지정합니다. 지정하지 않으면/REALNAME:none을 지정합니다.
 CMD_UserCreate_NOTE 사용자의 설명을 지정합니다. 지정하지 않으면/NOTE:none을 지정합니다.
@@ -5632,7 +5614,7 @@ CMD_UserCreate_Prompt_NOTE 사용자 설명:
 CMD_UserSet 사용자 정보 변경
 CMD_UserSet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자 정보를 변경합니다. \n이 명령으로 변경할 수있는 사용자 정보는 UserCreate 명령으로 새로 사용자를 만들 때 지정하는 "그룹 이름", "본명"및 "설명"의 3 항목입니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserSet_Args UserSet [name] [/GROUP:group] [/REALNAME:realname] [/NOTE:note]
-CMD_UserSet_ [name] 설정을 변경하려면 사용자 이름을 지정합니다.
+CMD_UserSet_[name] 설정을 변경하려면 사용자 이름을 지정합니다.
 CMD_UserSet_GROUP 사용자를 그룹에 가입 할 경우 그룹 이름을 지정합니다. 사용자가 어떤 그룹에도 소속하지 않는 경우/GROUP:none을 지정합니다.
 CMD_UserSet_REALNAME 사용자의 실명을 지정합니다. 지정하지 않으면/REALNAME:none을 지정합니다.
 CMD_UserSet_NOTE 사용자의 설명을 지정합니다. 지정하지 않으면/NOTE:none을 지정합니다.
@@ -5642,14 +5624,14 @@ CMD_UserSet_NOTE 사용자의 설명을 지정합니다. 지정하지 않으면/
 CMD_UserDelete 사용자 삭제
 CMD_UserDelete_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자를 삭제합니다. 사용자를 삭제하면 해당 사용자는 가상 HUB에 연결할 수 없습니다. \nUserPolicySet 명령을 사용하면 사용자를 삭제하지 않고 일시적으로 로그인을 금지하도록 구성 할 수 있습니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserDelete_Args UserDelete [name]
-CMD_UserDelete_ [name] 제거 할 사용자 이름을 지정합니다.
+CMD_UserDelete_[name] 제거 할 사용자 이름을 지정합니다.
 
 
 # UserGet 명령
 CMD_UserGet 사용자 정보 검색
 CMD_UserGet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자 등록 정보를 소득합니다. \n이 명령에서 얻을 수있는 정보는 "사용자 이름", "본명", "설명", "소속 그룹", "유효 기간", "보안 정책", "인증 방법"및 설정되어있는 인증 방법 속성으로 지정되어있는 파라미터 이외에, 사용자의 통계 데이터입니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserGet_Args UserGet [name]
-CMD_UserGet_ [name] 정보를 얻으려면 사용자 이름을 지정합니다.
+CMD_UserGet_[name] 정보를 얻으려면 사용자 이름을 지정합니다.
 CMD_UserGet_Column_Name 사용자 이름
 CMD_UserGet_Column_RealName 본명
 CMD_UserGet_Column_Note 설명
@@ -5667,14 +5649,14 @@ CMD_UserGet_Policy 이 사용자에 설정된 보안 정책
 CMD_UserAnonymousSet 사용자 인증 방법을 익명 인증으로 설정
 CMD_UserAnonymousSet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자 인증 방법을 "익명 인증"으로 설정합니다. 익명 인증에 설정된 사용자 이름에서 가상 HUB에 연결 한 VPN Client는 어떠한 사용자 인증도받지 않고 무조건 가상 HUB에 연결 할 수 있습니다. 익명 인증 기능은 인터넷 등에서 널리 누구나 접속할 수 있도록 설정으로 공개하는 VPN Server에 이상적입니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserAnonymousSet_Args UserAnonymousSet [name]
-CMD_UserAnonymousSet_ [name] 설정을 변경하려면 사용자 이름을 지정합니다.
+CMD_UserAnonymousSet_[name] 설정을 변경하려면 사용자 이름을 지정합니다.
 
 
 # UserPasswordSet 명령
 CMD_UserPasswordSet 사용자 인증 방법을 암호 인증 설정 암호를 설정
 CMD_UserPasswordSet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자 인증 방법을 "암호 인증"으로 설정합니다. 암호 인증과 가상 HUB 보안 계정 데이터베이스의 사용자 개체에 어떤 암호를 설정해두고 그 이름으로 사용자가 가상 HUB에 연결하려고 할 때 암호를 입력하라는 메시지는 암호 가 일치하는 경우에 연결을 허용하는 인증 방법입니다. \n 사실, 사용자의 암호 해시 저장되므로 VPN Server 설정 파일을 분석해서 원래 암호는 모릅니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserPasswordSet_Args UserPasswordSet [name] [/PASSWORD:password]
-CMD_UserPasswordSet_ [name] 설정을 변경하려면 사용자 이름을 지정합니다.
+CMD_UserPasswordSet_[name] 설정을 변경하려면 사용자 이름을 지정합니다.
 CMD_UserPasswordSet_PASSWORD 사용자가 설정 암호를 지정합니다. 이 매개 변수를 지정하지 않으면 암호를 입력하라는 메시지가 표시됩니다.
 
 
@@ -5682,7 +5664,7 @@ CMD_UserPasswordSet_PASSWORD 사용자가 설정 암호를 지정합니다. 이 
 CMD_UserCertSet 사용자 인증 방법을 고유 인증서 인증으로 설정 인증서를 설정
 CMD_UserCertSet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자 인증 방법을 "고유 인증서 인증"으로 설정합니다. 고유 인증서 인증은 가상 HUB 보안 계정 데이터베이스의 사용자 개체에 대해 하나의 X.509 인증서를 설정해두고 그 이름으로 사용자가 가상 HUB에 연결하려고 할 때 제시 인증서가 등록되어있는 인증서와 일치하며 클라이언트 인증서에 해당 개인 키를 보유하고 있는지 RSA 알고리즘 검증함으로써 연결을 허용하는 인증 방법입니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserCertSet_Args UserCertSet [name] [/LOADCERT:cert]
-CMD_UserCertSet_ [name] 설정을 변경하려면 사용자 이름을 지정합니다.
+CMD_UserCertSet_[name] 설정을 변경하려면 사용자 이름을 지정합니다.
 CMD_UserCertSet_LOADCERT 사용자가 설정하는 인증서를 X.509 인증서 파일 이름을 지정합니다.
 
 
@@ -5690,7 +5672,7 @@ CMD_UserCertSet_LOADCERT 사용자가 설정하는 인증서를 X.509 인증서 
 CMD_UserCertGet 고유 인증서 인증 사용자 등록되어있는 인증서 취득
 CMD_UserCertGet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 「고유 인증서 인증 "사용자에 대해 설정되어있는 X.509 형식의 인증서를 검색하고 파일에 저장합니다. \n 지정된 사용자가 '고유 인증서 인증 "으로 설정되어 있지 않으면 오류가 발생합니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserCertGet_Args UserCertGet [name] [/SAVECERT:cert]
-CMD_UserCertGet_ [name] 정보를 얻으려면 사용자 이름을 지정합니다.
+CMD_UserCertGet_[name] 정보를 얻으려면 사용자 이름을 지정합니다.
 CMD_UserCertGet_SAVECERT 취득한 사용자 인증서를 X.509 형식으로 저장할 파일 이름을 지정합니다.
 CMD_UserCertGet_Not_Cert 사용자 고유 인증서 인증 아닌지 고유 인증서가 설정되어 있지 않습니다.
 
@@ -5699,7 +5681,7 @@ CMD_UserCertGet_Not_Cert 사용자 고유 인증서 인증 아닌지 고유 인�
 CMD_UserSignedSet 사용자 인증 방법을 서명 된 인증서 인증 설정
 CMD_UserSignedSet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자 인증 방법을 "서명 된 인증서 인증"으로 설정합니다. 서명 된 인증서 인증으로 설정되어있는 사용자 이름은 사용자가 가상 HUB에 연결했을 때 사용자가 제시 한 인증서가 가상 HUB 신뢰하는 인증 기관의 인증서 목록에 인증서 중 하나에 의해 서명되어 있는지를 검사하며 클라이언트 인증서에 해당 개인 키를 보유하고 있는지 RSA 알고리즘 검증함으로써 연결을 허용하는 인증 방법입니다. \n 또한 사용자마다 기대하는 증명서의 Common Name (CN) 및 일련 번호를 등록 해두고, 상기의 검증을 통과 한 후 인증서의 내용이 설정된 값과 일치하는 경우에만 연결 를 허용하도록 설정도 가능합니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserSignedSet_Args UserSignedSet [name] [/CN:cn] [/SERIAL:serial]
-CMD_UserSignedSet_ [name] 설정을 변경하려면 사용자 이름을 지정합니다.
+CMD_UserSignedSet_[name] 설정을 변경하려면 사용자 이름을 지정합니다.
 CMD_UserSignedSet_CN 이 매개 변수를 지정한 경우에는 사용자가 제시 한 인증서가 신뢰할 수있는 인증 기관에서 서명되고 있는지를 검증 한 후 그 증명서의 Common Name (CN)의 값을이 매개 변수에 의해 설정된 값과 비교하여 일치하는 경우에만 연결을 허용합니다. "none"을 지정했을 경우,이 체크는 행해지 지 않습니다.
 CMD_UserSignedSet_SERIAL 이 매개 변수를 지정한 경우에는 사용자가 제시 한 인증서가 신뢰할 수있는 인증 기관에서 서명되고 있는지를 검증 한 후 인증서의 일련 번호 값을이 매개 변수에 의해 설정된 값과 비교 하고 일치하는 경우에만 연결을 허용합니다. "none"을 지정했을 경우,이 체크는 행해지 지 않습니다.
 CMD_UserSignedSet_Prompt_CN Common Name (CN) 값을 한정:
@@ -5710,7 +5692,7 @@ CMD_UserSignedSet_Prompt_SERIAL 일련 번호 값을 한정:
 CMD_UserRadiusSet 사용자 인증 방법을 RADIUS 인증 설정
 CMD_UserRadiusSet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자 인증 방법을 "RADIUS 인증"으로 설정합니다. RADIUS 인증으로 설정되어있는 이름으로 사용자가 가상 HUB에 연결했을 때 사용자 이름과 사용자가 입력 한 암호가 RADIUS 서버로 전송 된 RADIUS 서버가 사용자 이름과 암호 검사를 실시한 후 인증 성공하면 사용자의 VPN 연결을 허용합니다. \nRadius 인증을 사용하려면 미리 RadiusServerSet 명령을 사용하여 사용하는 RADIUS 서버를 가상 HUB로 설정해야합니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserRadiusSet_Args UserRadiusSet [name] [/ALIAS:alias_name]
-CMD_UserRadiusSet_ [name] 설정을 변경하려면 사용자 이름을 지정합니다.
+CMD_UserRadiusSet_[name] 설정을 변경하려면 사용자 이름을 지정합니다.
 CMD_UserRadiusSet_ALIAS 이 매개 변수가 설정되어있는 경우 RADIUS 서버에 전송되는 사용자 이름을 가상 HUB에서 사용자 이름과 다른 사용자 이름 일 수 있습니다. 설정하지 않으면,/ALIAS:none을 지정하십시오 (가상 HUB의 사용자 이름이 사용됩니다). 사용자 이름이 "*"의 경우/ALIAS 매개 변수는 무시됩니다. "*"사용자에 대한 설명은 UserCreate/HELP를 입력하면 표시됩니다.
 CMD_UserRadiusSet_Prompt_ALIAS 인증 별칭 이름 (옵션):
 
@@ -5719,7 +5701,7 @@ CMD_UserRadiusSet_Prompt_ALIAS 인증 별칭 이름 (옵션):
 CMD_UserNTLMSet 사용자 인증 방법을 NT 도메인 인증으로 설정
 CMD_UserNTLMSet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자 인증 방법을 "NT 도메인 인증"으로 설정합니다. NT 도메인 인증에 설정되어있는 이름으로 사용자가 가상 HUB에 연결했을 때 사용자 이름과 사용자가 입력 한 암호가 Windows NT/2000/Server 2003/Server 2008/Server 2008 R2/Server 2012 도메인 컨트롤러 또는 Active Directory 서버로 전송 된 인증 서버가 사용자 이름과 암호를 체크 한 후 인증이 성공하면 그 사용자의 VPN 연결을 허용합니다. \nNT 도메인 인증을 사용하려면 VPN Server가 해당 도메인에 연결되어있는 Windows NT 4.0, Windows 2000, Windows XP, Windows Server 2003, Windows Vista, Windows Server 2008, Windows 7, Windows Server 2008 R2, Windows 8, Windows Server 2012 중 하나의 운영 체제에서 실행해야합니다. 자세한 내용은 VPN Server 관리자에게 문의하십시오. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserNTLMSet_Args UserNTLMSet [name] [/ALIAS:alias_name]
-CMD_UserNTLMSet_ [name] 설정을 변경하려면 사용자 이름을 지정합니다.
+CMD_UserNTLMSet_[name] 설정을 변경하려면 사용자 이름을 지정합니다.
 CMD_UserNTLMSet_ALIAS 이 매개 변수가 설정되어있는 경우, NT 도메인 또는 Active Directory에 전송되는 사용자 이름을 가상 HUB에서 사용자 이름과 다른 사용자 이름 일 수 있습니다. 설정하지 않으면,/ALIAS:none을 지정하십시오 (가상 HUB의 사용자 이름이 사용됩니다). 사용자 이름이 "*"의 경우/ALIAS 매개 변수는 무시됩니다. "*"사용자에 대한 설명은 UserCreate/HELP를 입력하면 표시됩니다.
 
 
@@ -5727,14 +5709,14 @@ CMD_UserNTLMSet_ALIAS 이 매개 변수가 설정되어있는 경우, NT 도메�
 CMD_UserPolicyRemove 사용자 보안 정책 제거
 CMD_UserPolicyRemove_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자에 대해 설정되어있는 보안 정책 설정을 제거합니다. 보안 정책 설정이 삭제 된 사용자는 사용자가 속한 그룹의 보안 정책 설정이 적용됩니다. 그룹에 소속되어 있지 않거나 그룹에 보안 정책이 설정되어 있지 않으면 기본 값 (액세스 허용:사용, TCP 연결의 최대 개수:32 개, 제한 시간:20 초)을 따릅니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserPolicyRemove_Args UserPolicyRemove [name]
-CMD_UserPolicyRemove_ [name] 설정을 변경하려면 사용자 이름을 지정합니다.
+CMD_UserPolicyRemove_[name] 설정을 변경하려면 사용자 이름을 지정합니다.
 
 
 # UserPolicySet 명령
 CMD_UserPolicySet 사용자의 보안 정책 설정
 CMD_UserPolicySet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자에 대해 설정된 보안 정책의 내용을 변경합니다. \n 사용자 보안 정책이 설정되어 있지 않은 경우는 새로운 기본 보안 정책을 설정하고 지정된 값을 변경합니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserPolicySet_Args UserPolicySet [name] [/NAME:policy_name] [/VALUE:num|yes|no]
-CMD_UserPolicySet_ [name] 설정을 변경하려면 사용자 이름을 지정합니다.
+CMD_UserPolicySet_[name] 설정을 변경하려면 사용자 이름을 지정합니다.
 CMD_UserPolicySet_NAME 값을 변경하는 정책의 이름을 지정합니다. 정책의 이름과 설정 가능한 값의 목록은 PolicyList 명령으로 표시 할 수 있습니다.
 CMD_UserPolicySet_VALUE 정책의 새 값을 지정합니다. 그 정책이 수치 형의 경우 정수를 지정합니다. 부울 경우는 yes 또는 no를 지정합니다. 설정할 수있는 형식과 값은 PolicyList 명령으로 표시 할 수 있습니다.
 
@@ -5743,7 +5725,7 @@ CMD_UserPolicySet_VALUE 정책의 새 값을 지정합니다. 그 정책이 수�
 CMD_UserExpiresSet 사용자의 유효 기간 설정
 CMD_UserExpiresSet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 사용자의 유효 기간을 설정합니다. 만료 된 사용자는 가상 HUB에 연결할 수 없습니다. \n 현재 등록되어있는 사용자의 목록을 검색하려면 UserList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_UserExpiresSet_Args UserExpiresSet [name] [/EXPIRES:expires]
-CMD_UserExpiresSet_ [name] 설정을 변경하려면 사용자 이름을 지정합니다.
+CMD_UserExpiresSet_[name] 설정을 변경하려면 사용자 이름을 지정합니다.
 CMD_UserExpiresSet_EXPIRES 사용자의 만료 날짜 및 시간을 지정합니다. "2005/10/08 19:30:00"처럼, 년·월·일 ·시·분·초 6 개의 정수를 공백, 슬래시 또는 콜론으로 구분하십시오. 연도는 4 자리로 지정하십시오. 값에 공백을 넣는 경우는 전체 값을 ""로 묶어야합니다. 지정은 현지 시간 (명령 줄 관리 유틸리티를 실행하는 컴퓨터의 기준 시간)에 지정할 수 있습니다./EXPIRES:none을 지정하면, 유효 기간이 해제됩니다.
 CMD_UserExpiresSet_Prompt_EXPIRES 사용자의 유효 기간 (지정 무기한):
 
@@ -5758,7 +5740,7 @@ CMD_GroupList_Args GroupList
 CMD_GroupCreate 그룹 만들기
 CMD_GroupCreate_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 새 그룹을 만듭니다. \n 그룹에 여러 사용자를 등록 할 수 있습니다. 그룹에 사용자를 등록하려면 GroupJoin 명령을 사용합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_GroupCreate_Args GroupCreate [name] [/REALNAME:realname] [/NOTE:note]
-CMD_GroupCreate_ [name] 만들 그룹 이름을 지정합니다.
+CMD_GroupCreate_[name] 만들 그룹 이름을 지정합니다.
 CMD_GroupCreate_REALNAME 그룹의 본명을 지정합니다. 예를 들어, 그룹이 실제 부과 이름에 해당하는 경우에는 그 이름을 지정합니다. 지정하지 않으면/REALNAME:none을 지정합니다.
 CMD_GroupCreate_NOTE 그룹의 설명을 지정합니다. 지정하지 않으면/NOTE:none을 지정합니다.
 CMD_GroupCreate_Prompt_NAME 그룹 이름:
@@ -5770,7 +5752,7 @@ CMD_GroupCreate_Prompt_NOTE 그룹의 설명:
 CMD_GroupSet 그룹 정보 설정
 CMD_GroupSet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 그룹의 정보를 설정합니다. \n 현재 등록되어있는 그룹의 목록을 검색하려면 GroupList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_GroupSet_Args GroupSet [name] [/REALNAME:realname] [/NOTE:note]
-CMD_GroupSet_ [name] 설정을 변경하려면 그룹 이름을 지정합니다.
+CMD_GroupSet_[name] 설정을 변경하려면 그룹 이름을 지정합니다.
 CMD_GroupSet_REALNAME 그룹의 본명을 지정합니다. 예를 들어, 그룹이 실제 부과 이름에 해당하는 경우에는 그 이름을 지정합니다. 지정하지 않으면/REALNAME:none을 지정합니다.
 CMD_GroupSet_NOTE 그룹의 설명을 지정합니다. 지정하지 않으면/NOTE:none을 지정합니다.
 
@@ -5779,14 +5761,14 @@ CMD_GroupSet_NOTE 그룹의 설명을 지정합니다. 지정하지 않으면/NO
 CMD_GroupDelete 그룹 삭제
 CMD_GroupDelete_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 그룹을 삭제합니다. \n 그룹을 삭제하면 해당 그룹에 소속 된 사용자는 모두 무소속됩니다. \n 현재 등록되어있는 그룹의 목록을 검색하려면 GroupList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_GroupDelete_Args GroupDelete [name]
-CMD_GroupDelete_ [name] 삭제할 그룹 이름을 지정합니다
+CMD_GroupDelete_[name] 삭제할 그룹 이름을 지정합니다
 
 
 # GroupGet 명령
 CMD_GroupGet 그룹 정보와 소속 된 사용자 목록을 검색
 CMD_GroupGet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 그룹 정보와 해당 그룹에 소속 된 사용자 목록을 가져옵니다. \n 현재 등록되어있는 그룹의 목록을 검색하려면 GroupList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_GroupGet_Args GroupGet [name]
-CMD_GroupGet_ [name] 정보를 얻으려면 그룹 이름을 지정합니다.
+CMD_GroupGet_[name] 정보를 얻으려면 그룹 이름을 지정합니다.
 CMD_GroupGet_Column_NAME 그룹 이름
 CMD_GroupGet_Column_REALNAME 본명
 CMD_GroupGet_Column_NOTE 설명
@@ -5798,7 +5780,7 @@ CMD_GroupGet_Column_MEMBERS 이 그룹에 속한 사용자 이름 목록
 CMD_GroupJoin 그룹에 사용자를 추가
 CMD_GroupJoin_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 그룹에 보안 계정 데이터베이스의 사용자를 추가합니다. \n 현재 등록되어있는 사용자 및 그룹 목록은 UserList 명령과 GroupList 명령에서 얻을 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_GroupJoin_Args GroupJoin [name] [/USERNAME:username]
-CMD_GroupJoin_ [name] 사용자를 추가 할 그룹 이름을 지정합니다.
+CMD_GroupJoin_[name] 사용자를 추가 할 그룹 이름을 지정합니다.
 CMD_GroupJoin_USERNAME name에 지정된 그룹에 추가 할 사용자 이름을 지정합니다.
 CMD_GroupJoin_Prompt_USERNAME 그룹에 참여하는 사용자 이름:
 
@@ -5807,7 +5789,7 @@ CMD_GroupJoin_Prompt_USERNAME 그룹에 참여하는 사용자 이름:
 CMD_GroupUnjoin 그룹에서 사용자를 제거
 CMD_GroupUnjoin_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 그룹에서 지정한 사용자를 삭제합니다. 그룹에서 사용자가 삭제되면 그 사용자는 무소속입니다. \n 그룹에 현재 소속되어있는 사용자의 목록을 검색하려면 GroupGet 명령을 사용합니다. \n 현재 등록되어있는 그룹의 목록을 검색하려면 GroupList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_GroupUnjoin_Args GroupUnjoin [name]
-CMD_GroupUnjoin_ [name] 그룹에서 제거 할 사용자 이름을 지정합니다.
+CMD_GroupUnjoin_[name] 그룹에서 제거 할 사용자 이름을 지정합니다.
 CMD_GroupUnjoin_Prompt_name 그룹에서 제거 할 사용자 이름:
 
 
@@ -5815,14 +5797,14 @@ CMD_GroupUnjoin_Prompt_name 그룹에서 제거 할 사용자 이름:
 CMD_GroupPolicyRemove 그룹의 보안 정책 삭제
 CMD_GroupPolicyRemove_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 그룹에 대해 설정된 보안 정책 설정을 제거합니다. 소속 된 그룹에 사용자 본체에 보안 정책이 설정되어 있지 않은 사용자는 기본 값 (액세스 허용:사용, TCP 연결의 최대 개수:32 개, 제한 시간:20 초)을 따릅니다. \n 현재 등록되어있는 그룹의 목록을 검색하려면 GroupList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_GroupPolicyRemove_Args GroupPolicyRemove [name]
-CMD_GroupPolicyRemove_ [name] 설정을 변경하려면 그룹 이름을 지정합니다.
+CMD_GroupPolicyRemove_[name] 설정을 변경하려면 그룹 이름을 지정합니다.
 
 
 # GroupPolicySet 명령
 CMD_GroupPolicySet 그룹의 보안 정책 설정
 CMD_GroupPolicySet_Help 현재 관리하고있는 가상 HUB의 보안 계정 데이터베이스에 등록되어있는 그룹에 대해 설정된 보안 정책의 내용을 변경합니다. \n 그룹에 보안 정책이 설정되어 있지 않은 경우는 새로운 기본 보안 정책을 설정하고 지정된 값을 변경합니다. \n 현재 등록되어있는 그룹의 목록을 검색하려면 GroupList 명령을 사용하십시오. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_GroupPolicySet_Args GroupPolicySet [name] [/NAME:policy_name] [/VALUE:num|yes|no]
-CMD_GroupPolicySet_ [name] 설정을 변경하려면 그룹 이름을 지정합니다.
+CMD_GroupPolicySet_[name] 설정을 변경하려면 그룹 이름을 지정합니다.
 CMD_GroupPolicySet_NAME 값을 변경하는 정책의 이름을 지정합니다. 정책의 이름과 설정 가능한 값의 목록은 PolicyList 명령으로 표시 할 수 있습니다.
 CMD_GroupPolicySet_VALUE 정책의 새 값을 지정합니다. 그 정책이 수치 형의 경우 정수를 지정합니다. 부울 경우는 yes 또는 no를 지정합니다. 설정할 수있는 형식과 값은 PolicyList 명령으로 표시 할 수 있습니다.
 
@@ -5837,7 +5819,7 @@ CMD_SessionList_Args SessionList
 CMD_SessionGet 세션 정보 검색
 CMD_SessionGet_Help 현재 관리하고있는 가상 HUB에 연결된 세션을 지정하여 해당 세션의 정보를 가져옵니다. 세션 정보에 연결되는 호스트 이름과 사용자 이름, 버전 정보, 시간 정보, TCP 연결 수, 통신 파라미터 세션 키주고받은 데이터 통계, 다른 클라이언트와 서버의 정보 등이 포함됩니다. \n 현재 연결된 세션 목록을 검색하려면 SessionList 명령을 사용하십시오.
 CMD_SessionGet_Args SessionGet [name]
-CMD_SessionGet_ [name] 정보를 얻으려면 세션 이름을 지정합니다.
+CMD_SessionGet_[name] 정보를 얻으려면 세션 이름을 지정합니다.
 CMD_SessionGet_Prompt_NAME 세션 이름:
 
 
@@ -5845,21 +5827,21 @@ CMD_SessionGet_Prompt_NAME 세션 이름:
 CMD_SessionDisconnect 세션 연결 끊기
 CMD_SessionDisconnect_Help 현재 관리하고있는 가상 HUB에 연결된 세션을 지정하여 해당 세션을 관리자 권한으로 강제 종료합니다. \n 그러나 연결하는 클라이언트 측 설정에서 통신이 두절 된 경우 자동으로 다시 연결 옵션이 활성화되어 있으면 클라이언트는 다시 연결하고 올 가능성이 있습니다. \n 현재 연결된 세션 목록을 검색하려면 SessionList 명령을 사용하십시오.
 CMD_SessionDisconnect_Args SessionDisconnect [name]
-CMD_SessionDisconnect_ [name] 절단하는 세션 이름을 지정합니다.
+CMD_SessionDisconnect_[name] 절단하는 세션 이름을 지정합니다.
 
 
 # MacTable 명령
 CMD_MacTable MAC 주소 테이블 데이터베이스 검색
 CMD_MacTable_Help 현재 관리하고있는 가상 HUB가 보유하고있는 MAC 주소 테이블 데이터베이스를 가져옵니다. \nMAC 주소 테이블 데이터베이스는 가상 HUB가 Ethernet 프레임의 스위칭 동작을 수행하는 데 필요한 테이블에서 가상 HUB는 MAC 주소 테이블 데이터베이스를 기반으로 각 Ethernet 프레임의 배분 대상 세션을 결정합니다. MAC 주소 데이터베이스는 가상 HUB가 흐르는 통신 내용을 자동으로 분석하고 구축합니다. \n 세션 이름을 지정하여 해당 세션에 연관된 MAC 주소 테이블 항목을 검색 할 수 있습니다.
 CMD_MacTable_Args MacTable [session_name]
-CMD_MacTable_ [session_name] 인수로 세션 이름을 지정하면 해당 세션에 연관된 MAC 주소 테이블 항목 만 표시합니다. 지정하지 않으면 모든 항목이 표시됩니다.
+CMD_MacTable_[session_name] 인수로 세션 이름을 지정하면 해당 세션에 연관된 MAC 주소 테이블 항목 만 표시합니다. 지정하지 않으면 모든 항목이 표시됩니다.
 
 
 # MacDelete 명령
 CMD_MacDelete MAC 주소 테이블 항목 삭제
 CMD_MacDelete_Help 현재 관리하고있는 가상 HUB가 보유하고있는 MAC 주소 테이블 데이터베이스를 조작하여 지정된 MAC 주소 테이블 항목을 데이터베이스에서 삭제합니다. \n 현재 MAC 주소 테이블 데이터베이스의 내용을 검색하려면 MacTable 명령을 사용하십시오.
 CMD_MacDelete_Args MacDelete [id]
-CMD_MacDelete_ [id] 삭제 MAC 주소 테이블 항목의 ID를 지정합니다.
+CMD_MacDelete_[id] 삭제 MAC 주소 테이블 항목의 ID를 지정합니다.
 CMD_MacDelete_Prompt 삭제 ID:
 
 
@@ -5867,14 +5849,14 @@ CMD_MacDelete_Prompt 삭제 ID:
 CMD_IpTable IP 주소 테이블 데이터베이스 검색
 CMD_IpTable_Help 현재 관리하고있는 가상 HUB가 보유하고있는 IP 주소 테이블 데이터베이스를 가져옵니다. \nIP 주소 테이블 데이터베이스은 어떤 세션이 어떤 IP 주소를 사용하고 있는지를 항상 가상 HUB 파악하기 위해 자동으로 통신 내용을 분석하여 생성되는 테이블에서 가상 HUB 보안 정책 적용 엔진 에 의해 빈번하게 사용되고 있습니다. \n 세션 이름을 지정하여 해당 세션에 연결된 IP 주소 테이블 항목을 검색 할 수 있습니다.
 CMD_IpTable_Args IpTable [session_name]
-CMD_IpTable_ [session_name] 인수로 세션 이름을 지정하면 해당 세션에 연결된 IP 주소 테이블 항목 만 표시합니다. 지정하지 않으면 모든 항목이 표시됩니다.
+CMD_IpTable_[session_name] 인수로 세션 이름을 지정하면 해당 세션에 연결된 IP 주소 테이블 항목 만 표시합니다. 지정하지 않으면 모든 항목이 표시됩니다.
 
 
 # IpDelete 명령
 CMD_IpDelete IP 주소 테이블 항목 삭제
 CMD_IpDelete_Help 현재 관리하고있는 가상 HUB가 보유하고있는 IP 주소 테이블 데이터베이스를 조작하여 지정된 IP 주소 테이블 항목을 데이터베이스에서 삭제합니다. \n 현재의 IP 주소 테이블 데이터베이스의 내용을 검색하려면 IpTable 명령을 사용하십시오.
 CMD_IpDelete_Args IpDelete [id]
-CMD_IpDelete_ [id] 삭제할 IP 주소 테이블 항목의 ID를 지정합니다.
+CMD_IpDelete_[id] 삭제할 IP 주소 테이블 항목의 ID를 지정합니다.
 
 
 # SecureNatEnable 명령
@@ -6031,7 +6013,7 @@ CMD_AdminOptionList_Args AdminOptionList
 CMD_AdminOptionSet 가상 HUB 관리 옵션 값 설정
 CMD_AdminOptionSet_Help 현재 관리하고있는 가상 HUB로 설정되어있는 가상 HUB 관리 옵션의 값을 변경합니다. \n 가상 HUB 관리 옵션은 VPN Server 관리자가 각 가상 HUB 관리자에 가상 HUB의 관리를 위임하는 경우에 설정 범위를 제한하는 데 사용합니다. \n 가상 HUB 관리 옵션을 추가하고 편집 및 삭제할 수있는 것은이 VPN Server 전체 관리 권한을 가진 관리자 만입니다. 가상 HUB의 관리자는 관리 옵션을 볼 수 있지만 변경할 수 없습니다. \n 그러나 allow_hub_admin_change_option가 1로 설정되어있는 경우 가상 HUB 관리자에서 관리 옵션을 편집 할 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AdminOptionSet_Args AdminOptionSet [name] [/VALUE:value]
-CMD_AdminOptionSet_ [name] 값을 변경 관리 옵션 이름을 지정합니다. AdminOptionList 명령 이름의 목록을 얻을 수 있습니다.
+CMD_AdminOptionSet_[name] 값을 변경 관리 옵션 이름을 지정합니다. AdminOptionList 명령 이름의 목록을 얻을 수 있습니다.
 CMD_AdminOptionSet_VALUE 설정 값을 정수로 지정합니다.
 CMD_AdminOptionSet_Prompt_name 값을 변경하려면 관리 옵션:
 CMD_AdminOptionSet_Prompt_VALUE 설정 값 (정수):
@@ -6047,7 +6029,7 @@ CMD_ExtOptionList_Args ExtOptionList
 CMD_ExtOptionSet 가상 HUB 관리 옵션 값 설정
 CMD_ExtOptionSet_Help 현재 관리하고있는 가상 HUB로 설정되어있는 가상 HUB 확장 옵션 값을 설정합니다. \n 가상 HUB 확장 옵션은 가상 HUB에 관한보다 상세한 설정을 할 수있는 기능입니다. \n 가상 HUB 관리 옵션을 추가하고 편집 및 삭제할 수있는 것은이 VPN Server 전체 관리 권한을 가진 관리자 및 가상 HUB 관리자입니다. \n 그러나 가상 HUB 관리 옵션 deny_hub_admin_change_ext_option가 1로 설정되어있는 경우 가상 HUB의 관리자는 확장 옵션을 편집 할 수 없습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터에서 클러스터 구성원 서버로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_ExtOptionSet_Args ExtOptionSet [name] [/VALUE:value]
-CMD_ExtOptionSet_ [name] 값을 변경하는 확장 옵션 이름을 지정합니다. ExtOptionList 명령 이름의 목록을 얻을 수 있습니다.
+CMD_ExtOptionSet_[name] 값을 변경하는 확장 옵션 이름을 지정합니다. ExtOptionList 명령 이름의 목록을 얻을 수 있습니다.
 CMD_ExtOptionSet_VALUE 설정 값을 정수로 지정합니다.
 CMD_ExtOptionSet_Prompt_name 값을 변경하는 확장 옵션:
 CMD_ExtOptionSet_Prompt_VALUE 설정 값 (정수):
@@ -6078,7 +6060,7 @@ CMD_CrlAdd_L 조건으로 인증서의 로컬 (L)을 지정하려면이 매개 �
 CMD_CrlDel 잘못된 인증서 삭제
 CMD_CrlDel_Help 현재 관리하고있는 가상 HUB로 설정되어있는 잘못된 인증서 목록에서 잘못된 인증서의 정의를 사용하여 삭제합니다. \n 현재 등록 된 잘못된 인증서의 정의 목록은 CrlList 명령에서 얻을 수 있습니다 \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CrlDel_Args CrlDel [id]
-CMD_CrlDel_ [id] 삭제 잘못된 인증서의 정의의 ID를 지정합니다.
+CMD_CrlDel_[id] 삭제 잘못된 인증서의 정의의 ID를 지정합니다.
 CMD_CrlDel_Prompt_ID 삭제 ID:
 
 
@@ -6086,7 +6068,7 @@ CMD_CrlDel_Prompt_ID 삭제 ID:
 CMD_CrlGet 잘못된 인증서 취득
 CMD_CrlGet_Help 현재 관리하고있는 가상 HUB로 설정되어있는 잘못된 인증서 목록에서 잘못된 인증서의 정의를 지정하고 정의 내용을 가져옵니다. \n 현재 등록 된 잘못된 인증서의 정의 목록은 CrlList 명령에서 얻을 수 있습니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_CrlGet_Args CrlGet [id]
-CMD_CrlGet_ [id] 얻을 잘못된 인증서의 정의의 ID를 지정합니다.
+CMD_CrlGet_[id] 얻을 잘못된 인증서의 정의의 ID를 지정합니다.
 CMD_CrlGet_Prompt_ID 얻을 ID:
 CMD_CrlGet_CN 이름 (CN)
 CMD_CrlGet_O 소속 기관 (O)
@@ -6109,7 +6091,7 @@ CMD_AcList_Args AcList
 CMD_AcAdd 접근 IP 제한 목록에 규칙을 추가 (IPv4)
 CMD_AcAdd_Help 현재 관리하고있는 가상 HUB로 설정되어있는 접근 IP 제한 목록에 새 규칙을 추가합니다. \n 여기에서 설정 한 항목은 VPN Client가 가상 HUB에 연결하려고 할 때, 그 클라이언트의 연결을 허용할지 거부할지 여부를 결정하는 데 사용됩니다. \n 규칙 항목의 내용으로 규칙과 일치하는 클라이언트의 IP 주소 또는 IP 주소와 마스크를 지정할 수 있습니다. IP 주소 만 지정하면 단일 지정한 컴퓨터에만이 규칙과 일치하게되지만, IP 네트워크 주소와 마스크를 지정하면 해당 서브넷 범위 내의 모든 컴퓨터가 규칙에 일치하게 됩니다. \n 규칙에 우선 순위를 설정할 수 있습니다. 우선 순위는 1 이상의 정수로 지정하고 값이 작을수록 우선 순위가 높게 평가되고 있습니다. \n 현재 등록 된 접근 IP 제한 목록 규칙 목록을 검색하려면 AcList 명령을 사용합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AcAdd_Args AcAdd [allow|deny] [/PRIORITY:priority] [/IP:ip/mask]
-CMD_AcAdd_ [allow|deny 규칙과 일치하는 클라이언트의 연결을 허용 ( "allow") 또는 거부 ( "deny")을 설정합니다.
+CMD_AcAdd_[allow|deny] 규칙과 일치하는 클라이언트의 연결을 허용 ( "allow") 또는 거부 ( "deny")을 설정합니다.
 CMD_AcAdd_PRIORITY 규칙의 우선 순위를 1 이상의 정수로 지정합니다. 값이 작을수록 우선 순위가 높게 평가되고 있습니다.
 CMD_AcAdd_IP IP 주소/마스크 형식으로 클라이언트 IPv4 주소 범위를 지정합니다. IPv4 주소는 192.168.0.1과 같이 10 진수를 점으로 구분하여 지정합니다. 마스크는 255.255.255.0과 같이 10 진수를 점으로 구분하여 지정하거나 24와 같이 처음부터 비트 길이를 10 진수로 지정합니다. 단일 IPv4 호스트를 지정하려면 마스크를 255.255.255.255 또는 32로 지정합니다.
 CMD_AcAdd_Prompt_AD allow 또는 deny:
@@ -6122,7 +6104,7 @@ CMD_AcAdd_Eval_PRIORITY 우선 순위는 1 이상이어야합니다.
 CMD_AcAdd6 접근 IP 제한 목록에 규칙을 추가 (IPv6)
 CMD_AcAdd6_Help 현재 관리하고있는 가상 HUB로 설정되어있는 접근 IP 제한 목록에 새 규칙을 추가합니다. \n 여기에서 설정 한 항목은 VPN Client가 가상 HUB에 연결하려고 할 때, 그 클라이언트의 연결을 허용할지 거부할지 여부를 결정하는 데 사용됩니다. \n 규칙 항목의 내용으로 규칙과 일치하는 클라이언트의 IP 주소 또는 IP 주소와 마스크를 지정할 수 있습니다. IP 주소 만 지정하면 단일 지정한 컴퓨터에만이 규칙과 일치하게되지만, IP 네트워크 주소와 마스크를 지정하면 해당 서브넷 범위 내의 모든 컴퓨터가 규칙에 일치하게 됩니다. \n 규칙에 우선 순위를 설정할 수 있습니다. 우선 순위는 1 이상의 정수로 지정하고 값이 작을수록 우선 순위가 높게 평가되고 있습니다. \n 현재 등록 된 접근 IP 제한 목록 규칙 목록을 검색하려면 AcList 명령을 사용합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AcAdd6_Args AcAdd6 [allow|deny] [/PRIORITY:priority] [/IP:ip/mask]
-CMD_AcAdd6_ [allow|deny 규칙과 일치하는 클라이언트의 연결을 허용 ( "allow") 또는 거부 ( "deny")을 설정합니다.
+CMD_AcAdd6_[allow|deny] 규칙과 일치하는 클라이언트의 연결을 허용 ( "allow") 또는 거부 ( "deny")을 설정합니다.
 CMD_AcAdd6_PRIORITY 규칙의 우선 순위를 1 이상의 정수로 지정합니다. 값이 작을수록 우선 순위가 높게 평가되고 있습니다.
 CMD_AcAdd6_IP IP 주소/마스크 형식으로 클라이언트 IPv6 주소의 범위를 지정합니다. IPv6 주소는 2001:200:0:1::처럼 16 진수를 콜론으로 구분하여 지정합니다. 마스크는 ffff:ffff:ffff:ffff::처럼 IPv6 형식으로 구분하거나 64와 같이 처음부터 비트 길이를 10 진수로 지정합니다. 단일 IPv6 호스트를 지정하려면 마스크를 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 또는 128로 지정합니다.
 CMD_AcAdd6_Prompt_AD allow 또는 deny:
@@ -6134,7 +6116,7 @@ CMD_AcAdd6_Eval_PRIORITY 우선 순위는 1 이상이어야합니다.
 CMD_AcDel 접근 IP 제한 목록에서 규칙 삭제
 CMD_AcDel_Help 현재 관리하고있는 가상 HUB로 설정되어있는 접근 IP 제한 목록 규칙을 삭제합니다. \n 현재 등록 된 접근 IP 제한 목록 규칙 목록을 검색하려면 AcList 명령을 사용합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_AcDel_Args AcDel [id]
-CMD_AcDel_ [id] 삭제 접근 IP 제한 목록에서 규칙의 ID를 지정합니다.
+CMD_AcDel_[id] 삭제 접근 IP 제한 목록에서 규칙의 ID를 지정합니다.
 CMD_AcDel_Prompt_ID 삭제 규칙 ID:
 
 
@@ -6142,7 +6124,7 @@ CMD_AcDel_Prompt_ID 삭제 규칙 ID:
 CMD_LicenseAdd 새로운 라이센스 키 등록
 CMD_LicenseAdd_Help SoftEther VPN Server에 새 라이센스 키를 등록합니다. \nSoftEther VPN Server를 사용하려면 유효한 라이센스를 취득하고 라이센스 키를 등록해야합니다. 라이센스 키는 36 자리 숫자와 하이픈 ( '-')으로 구성되어있는 라이센스의 소유를 증명하는 키 코드입니다. \n 라이센스 키는 소프트웨어와 함께 라이센스 증서를받은 경우, 라이센스 증서에 인쇄되어 있습니다. 소프트웨어 라이선스를 온라인으로 구입 한 경우 구입시의 Web 사이트의 화면이나 메일 등에 라이센스 키가 포함되어있을 수 있습니다. 또 다른 방법으로 라이센스 키가 포함되어있는 경우도 있습니다. 알 수없는 경우 라이센스 구입처에 문의하십시오. \n \n 현재 등록되어있는 라이센스의 목록을 검색하려면 LicenseList 명령을 사용합니다. \n 현재 VPN Server의 라이센스 상태를 표시하려면 LicenseStatus 명령을 사용합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다.
 CMD_LicenseAdd_Args LicenseAdd [key]
-CMD_LicenseAdd_ [key] 등록 라이센스 키를 지정합니다. 36 자리 숫자를 6 자리마다 하이픈으로 구분합니다.
+CMD_LicenseAdd_[key] 등록 라이센스 키를 지정합니다. 36 자리 숫자를 6 자리마다 하이픈으로 구분합니다.
 CMD_LicenseAdd_Prompt_Key 라이센스 키:
 
 
@@ -6150,7 +6132,7 @@ CMD_LicenseAdd_Prompt_Key 라이센스 키:
 CMD_LicenseDel 등록되어있는 라이센스 제거
 CMD_LicenseDel_Help SoftEther VPN Server에 현재 등록되어있는 라이센스 목록에서 지정된 라이센스를 제거합니다. \n \n 현재 등록되어있는 라이센스의 목록을 검색하려면 LicenseList 명령을 사용합니다. \n 현재 VPN Server의 라이센스 상태를 표시하려면 LicenseStatus 명령을 사용합니다. \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다.
 CMD_LicenseDel_Args LicenseDel [id]
-CMD_LicenseDel_ [id] 제거 라이센스 번호를 지정합니다.
+CMD_LicenseDel_[id] 제거 라이센스 번호를 지정합니다.
 CMD_LicenseDel_Prompt_ID 제거 라이센스 번호:
 
 
@@ -6199,7 +6181,7 @@ CMD_IPsecGet_PRINT_DEFAULTHUB 기본 가상 HUB 이름
 CMD_EtherIpClientAdd EtherIP/L2TPv3 over IPsec 서버 기능의 클라이언트 장치에서 연결을 받아들이 기위한 연결 설정 추가
 CMD_EtherIpClientAdd_Help EtherIP/L2TPv3 over IPsec 서버 기능의 클라이언트 장치에서 연결을 받아들이 기위한 연결 설정을 추가합니다. \nEtherIP/L2TPv3 over IPsec 서버 기능이 활성화되어있는 경우 라우터 등의 접속을 받아들이는 미리 클라이언트 측이 EtherIP/L2TPv3 over IPsec 대응 라우터가 VPN Server에 연결할 때 IPsec Phase 1 문자 열과 연결된 가상 HUB 정보의 대응표를 정의 해 둘 필요가 있습니다. \nEtherIpClientAdd 명령을 사용하여 정의를 추가함으로써 EtherIP/L2TPv3 over IPsec 클라이언트가 VPN Server에 연결을 시도했을 때 ISAKMP (IKE) Phase 1의 초기 ID 문자열이 정의에 일치하는 경우, 정의 되는 가상 HUB에 연결 설정이 적용됩니다. \n 사용자 이름과 암호는 가상 HUB에 등록되어 있어야합니다. EtherIP/L2TPv3 클라이언트는이 명령에 입력 된 정보에 의해 식별되는 사용자의 권한으로 가상 HUB에 연결 한 것으로 간주됩니다. \n \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_EtherIpClientAdd_Args EtherIpClientAdd [ID] [/HUB:hubname] [/USERNAME:username] [/PASSWORD:password]
-CMD_EtherIpClientAdd_ [ID] ISAKMP Phase 1 ID를 지정합니다. ID는 클라이언트 측 라우터의 연결 설정에서 설정하는 것과 동일한 문자열을 지정하십시오. 문자열 외에도 ID의 종류가 IP 주소의 경우 IP 주소도 지정할 수 있습니다. 또한 '*'(별표)를 지정하면 와일드 카드 지정되고, 다른 명시적인 규칙에 일치하지 않는 모든 연결하는 클라이언트가 대상이됩니다.
+CMD_EtherIpClientAdd_[ID] ISAKMP Phase 1 ID를 지정합니다. ID는 클라이언트 측 라우터의 연결 설정에서 설정하는 것과 동일한 문자열을 지정하십시오. 문자열 외에도 ID의 종류가 IP 주소의 경우 IP 주소도 지정할 수 있습니다. 또한 '*'(별표)를 지정하면 와일드 카드 지정되고, 다른 명시적인 규칙에 일치하지 않는 모든 연결하는 클라이언트가 대상이됩니다.
 CMD_EtherIpClientAdd_HUB 연결된 가상 HUB의 이름을 지정합니다.
 CMD_EtherIpClientAdd_USERNAME 연결된 가상 HUB에 로그인하기위한 사용자 이름을 지정합니다.
 CMD_EtherIpClientAdd_PASSWORD 연결된 가상 HUB에 로그인하기위한 암호를 지정합니다.
@@ -6213,7 +6195,7 @@ CMD_EtherIpClientAdd_Prompt_PASSWORD 가상 HUB 로그인 비밀번호:
 CMD_EtherIpClientDelete EtherIP/L2TPv3 over IPsec 서버 기능의 클라이언트 장치에서 연결을 받아들이 기위한 연결 설정 삭제
 CMD_EtherIpClientDelete_Help EtherIP/L2TPv3 over IPsec 서버 기능의 클라이언트 장치에서 연결을 받아들이 기위한 연결 설정 미리 정의 된 항목을 삭제합니다. \n \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_EtherIpClientDelete_Args EtherIpClientDelete [ID]
-CMD_EtherIpClientDelete_ [ID] ISAKMP Phase 1 ID를 지정합니다.
+CMD_EtherIpClientDelete_[ID] ISAKMP Phase 1 ID를 지정합니다.
 CMD_EtherIpClientDelete_Prompt_ID ISAKMP Phase 1 ID:
 
 
@@ -6227,9 +6209,9 @@ CMD_EtherIpClientList_Args EtherIpClientList
 CMD_OpenVpnEnable OpenVPN 호환 서버 기능을 활성화/비활성화
 CMD_OpenVpnEnable_Help SoftEther VPN Server는 OpenVPN 사의 OpenVPN 소프트웨어 제품과 동일한 VPN 서버 기능이 탑재되어 있습니다. OpenVPN 서버 기능을 활성화하면 OpenVPN 클라이언트에서 OpenVPN 서버에 연결 할 수 있습니다. \n \nOpenVPN 호환 서버 기능으로 가상 HUB에 연결하는 경우 사용자 이름 지정 방법 및 기본 가상 HUB 선택 규칙은 IPsec 서버 기능과 유사합니다. 자세한 내용은 IPsecEnable 명령의 도움말을 참조하십시오. \n \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_OpenVpnEnable_Args OpenVpnEnable [yes|no] [/PORTS:udp_port_list]
-CMD_OpenVpnEnable_ [yes|no] OpenVPN 호환 서버 기능을 활성화하려면 yes, 무효로하는 경우 no를 지정합니다.
+CMD_OpenVpnEnable_[yes|no] OpenVPN 호환 서버 기능을 활성화하려면 yes, 무효로하는 경우 no를 지정합니다.
 CMD_OpenVpnEnable_PORTS OpenVPN 서비스를 제공하는 UDP 포트 목록을 지정하십시오. UDP 포트는 여러 지정할 수 있습니다. 복수 지정하는 경우는 1194, 2001, 2010, 2012와 같이 콤마 (,)로 구분하십시오. OpenVPN은 표준에서 UDP 1194 포트를 사용하지만 다른 임의의 UDP 포트를 지정할 수 있습니다.
-CMD_OpenVpnEnable_Prompt_ [yes|no] OpenVPN 호환 서버 기능을 활성화 (yes/no):
+CMD_OpenVpnEnable_Prompt_[yes|no] OpenVPN 호환 서버 기능을 활성화 (yes/no):
 CMD_OpenVpnEnable_Prompt_PORTS UDP 포트 번호 목록 (표준 1194/복수 지정 가능):
 
 
@@ -6244,7 +6226,7 @@ CMD_OpenVpnGet_PRINT_Ports UDP 포트 번호 목록
 CMD_OpenVpnMakeConfig OpenVPN 호환 서버 기능에 연결 가능한 샘플의 OpenVPN 설정 파일 생성
 CMD_OpenVpnMakeConfig_Help 원래 OpenVPN 클라이언트를 사용하기 위해서는 설정 파일을 수동으로 작성해야하지만, 이것은 난이도가 높은 작업입니다. 그러나이 명령을 사용하면이 VPN Server에 연결할 수있는 기본적인 OpenVPN 클라이언트의 설정 파일을 자동으로 생성 할 수 있습니다. \n \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_OpenVpnMakeConfig_Args OpenVpnMakeConfig [ZIP_FileName]
-CMD_OpenVpnMakeConfig_ [ZIP_FileName]이 명령에 의해 출력되는 설정 파일 (ZIP 압축 형식)을 저장할 파일 이름을 지정합니다. 확장자가 지정되어 있지 않으면 자동으로 ".zip"가 부가됩니다.
+CMD_OpenVpnMakeConfig_[ZIP_FileName] 이 명령에 의해 출력되는 설정 파일 (ZIP 압축 형식)을 저장할 파일 이름을 지정합니다. 확장자가 지정되어 있지 않으면 자동으로 ".zip"가 부가됩니다.
 CMD_OpenVpnMakeConfig_Prompt_ZIP 설정 파일을 저장할 대상 파일 이름 (ZIP 압축 형식):
 CMD_OpenVpnMakeConfig_OK 예제 구성 파일 "%s"파일에 저장했습니다. 이 파일을 unzip 명령 등을 이용하여 전개하고 사용할 수 있습니다. \n
 CMD_OpenVpnMakeConfig_ERROR 예제 구성 파일 "%s"파일에 저장할 수 없습니다. 파일 이름이 잘못되었을 수 있습니다. \n
@@ -6254,8 +6236,8 @@ CMD_OpenVpnMakeConfig_ERROR 예제 구성 파일 "%s"파일에 저장할 수 없
 CMD_SstpEnable Microsoft SSTP VPN 호환 서버 기능을 활성화/비활성화
 CMD_SstpEnable_Help SoftEther VPN Server는 Microsoft 사의 Windows Server 2008/2012 제품에 탑재 된 MS-SSTP VPN 서버 기능과 호환 기능이 탑재되어 있습니다. Microsoft SSTP VPN 호환 서버 기능을 활성화하면 Windows Vista/7/8/RT에 내장 된 MS-SSTP 클라이언트에서이 VPN Server에 연결할 수 있도록합니다. \n \n [주의] \nVPN Server의 SSL 인증서의 CN 값이 클라이언트 측에서 지정하는 호스트 이름과 일치하며 그 인증서를 신뢰할 수 있어야합니다. 자세한 내용은 Microsoft 문서를 참조하십시오. \n 지정된 CN 값을 가지는 새로운 SSL 인증서 (자체 서명 인증서)를 생성하여 VPN Server의 현재 인증서로 대체하기 위해서는 ServerCertRegenerate 명령을 사용하십시오. 이 경우 해당 인증서를 SSTP VPN 클라이언트 컴퓨터의 신뢰할 수있는 루트 인증서로 등록해야합니다. 이러한 번거 로움 않으려면 대신 VeriSign이나 GlobalSign 사 등의 상용 인증서 공급자의 SSL 인증서 취득을 검토하십시오. \n \nMicrosoft SSTP VPN 호환 서버 기능으로 가상 HUB에 연결하는 경우 사용자 이름 지정 방법 및 기본 가상 HUB 선택 규칙은 IPsec 서버 기능과 유사합니다. 자세한 내용은 IPsecEnable 명령의 도움말을 참조하십시오. \n \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_SstpEnable_Args SstpEnable [yes|no]
-CMD_SstpEnable_ [yes|no] Microsoft SSTP VPN 호환 서버 기능을 활성화하려면 yes, 무효로하는 경우 no를 지정합니다.
-CMD_SstpEnable_Prompt_ [yes|no] SSTP VPN 호환 서버 기능을 활성화 (yes/no):
+CMD_SstpEnable_[yes|no] Microsoft SSTP VPN 호환 서버 기능을 활성화하려면 yes, 무효로하는 경우 no를 지정합니다.
+CMD_SstpEnable_Prompt_[yes|no] SSTP VPN 호환 서버 기능을 활성화 (yes/no):
 CMD_SstpEnable_PRINT_Enabled SSTP VPN 호환 서버 기능이 활성화
 
 
@@ -6269,7 +6251,7 @@ CMD_SstpGet_Args SstpGet
 CMD_ServerCertRegenerate 지정된 CN (Common Name)을 가진 자체 서명 인증서를 새로 만든 VPN Server에 등록
 CMD_ServerCertRegenerate_Help SoftEther VPN Server의 SSL-VPN 기능을 제공하는 서버 인증서를 새로 생성하는 인증서로 대체합니다. 새로운 인증서는 자체 서명 인증서로 생성되며, CN (Common Name) 값을 임의의 문자열로 설정할 수 있습니다. \n \n이 명령은 Microsoft SSTP VPN 호환 서버 기능을 사용하고자하는 경우에 유용합니다. 왜냐하면 SSTP VPN 클라이언트 (Windows Vista/7/8/RT에 내장) 연결 대상 VPN Server가 제시하는 SSL 인증서의 CN (Common Name) 값이 연결 대상으로 지정되는 호스트 이름 문자 열과 정확히 일치 여부를 확인하고 만약 일치하지 않을 경우 연결을 취소 할 수 있습니다. \n 자세한 내용은 SstpEnable 명령의 도움말을 참조하십시오. \n \n이 명령은 기존의 VPN Server의 SSL 인증서를 삭제합니다. ServerCertGet 명령 및 ServerKeyGet 명령을 사용하여 현재 인증서와 개인 키를 백업 해 둘 것을 권장합니다. \n \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다.
 CMD_ServerCertRegenerate_Args ServerCertRegenerate [CN]
-CMD_ServerCertRegenerate_ [CN] 새로 생성하는 자체 서명 인증서 Common Name (CN) 값을 지정합니다.
+CMD_ServerCertRegenerate_[CN] 새로 생성하는 자체 서명 인증서 Common Name (CN) 값을 지정합니다.
 CMD_ServerCertRegenerate_Prompt_CN Common Name (CN) 값:
 
 
@@ -6306,7 +6288,7 @@ CMD_DynamicDnsGetStatus_PRINT_IPv6 글로벌 IPv6 주소
 CMD_DynamicDnsSetHostname 동적 DNS 호스트 이름 설정
 CMD_DynamicDnsSetHostname_Help 동적 DNS 기능 VPN Server가 사용하는 호스트 이름을 설정합니다. 현재 할당 된 호스트 이름은 DynamicDnsGetStatus 명령으로 확인할 수 있습니다. \n \n 동적 DNS에 따르면, VPN Server 컴퓨터에 영구적 인 고유의 DNS 호스트 이름이 할당됩니다. 이는 자체로 도메인을 소유하고 있지 않아도, VPN Client와 VPN Bridge 등의 설정 화면이 VPN Server의 IP 주소 대신 DNS 호스트 이름으로 VPN Server를 지정할 수 있습니다. \n 또한 IP 주소가 바뀔 수있는 일반적인 ISP를 사용하여 VPN Server를 인터넷에 연결하는 경우에도 IP 주소가 변경되면 자동으로 DNS 호스트 이름을 IP 주소가 업데이트됩니다 때문에 가변 IP 주소도 VPN Server를 운용 할 수있게됩니다. \n 그러면 비싼 월정액 요금이 필요한 고정 글로벌 IP 주소 서비스를 계약 할 필요가 없습니다. \n \n [주의] \n 동적 DNS 기능을 사용하려면 VPN Server 설정 파일을 편집합니다. \n "declare root"지시문에 "declare DDnsClient"지시문이 있습니다. 이 안에있는 "bool Disable"의 값을 true로 설정하여 VPN Server를 다시 시작하여 동적 DNS 기능이 비활성화됩니다. \n \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다.
 CMD_DynamicDnsSetHostname_Args DynamicDnsSetHostname [hostname]
-CMD_DynamicDnsSetHostname_ [hostname] 새 호스트 이름을 3 자 이상 31 자 이하의 영숫자와 하이픈 '-'로 지정합니다. 변경은 몇 번이라도 가능합니다.
+CMD_DynamicDnsSetHostname_[hostname] 새 호스트 이름을 3 자 이상 31 자 이하의 영숫자와 하이픈 '-'로 지정합니다. 변경은 몇 번이라도 가능합니다.
 CMD_DynamicDnsSetHostname_Prompt_hostname 동적 DNS 호스트 이름 (3 - 31 자):
 
 
@@ -6323,7 +6305,7 @@ CMD_VpnAzureGetStatus_PRINT_HOSTNAME VPN Azure 서비스에서 호스트 이름
 CMD_VpnAzureSetEnable VPN Azure 기능의 활성화/비활성화
 CMD_VpnAzureSetEnable_Help VPN Azure 기능을 활성화하거나 비활성화합니다. \n \nVPN Azure하여 회사의 PC에 가정이나 이동 PC에서 매우 쉽게 VPN 연결 할 수 있습니다. VPN 연결 중에 회사의 컴퓨터를 통해 사내 LAN의 다른 서버에 액세스 할 수 있습니다. \n 회사 컴퓨터 (VPN Server)는 글로벌 IP 주소는 필요하지 않습니다. 방화벽이나 NAT 뒤에라도 작동하고 네트워크 관리자의 설정은 필요하지 않습니다. VPN 클라이언트가 될 자택의 PC에서는 Windows에 표준 부속의 SSTP VPN 클라이언트를 사용할 수 있습니다. \nVPN Azure는 SoftEther VPN Server를 사용하시는 분들은 누구나 무료로 이용할 수 클라우드 VPN 서비스입니다. 소프트 이사 회사에 의해 운영되고 있습니다. 사용법은 http://www.vpnazure.net/에 게재되어 있습니다. \n \nVPN Azure 호스트 이름은 동적 DNS 서비스 호스트 이름의 도메인 부분을 "vpnazure.net"로 변경 한 것이 사용됩니다. 호스트 이름을 변경하려면 DynamicDnsSetHostname 명령을 사용하십시오. \n \n이 명령을 실행하려면 VPN Server 관리자 권한이 있어야합니다. \n이 명령은 VPN Bridge에서는 실행되지 않습니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
 CMD_VpnAzureSetEnable_Args VpnAzureSetEnable [yes|no]
-CMD_VpnAzureSetEnable_ [yes|no] VPN Azure 기능을 활성화하려면 yes 비활성화하려면 no를 지정합니다.
+CMD_VpnAzureSetEnable_[yes|no] VPN Azure 기능을 활성화하려면 yes 비활성화하려면 no를 지정합니다.
 CMD_VpnAzureSetEnable_PROMPT VPN Azure 기능을 활성화 (yes/no):
 
 
@@ -6350,7 +6332,7 @@ CMD_VersionGet_5 OS의 종류
 CMD_PasswordSet VPN Client 서비스에 접속하기위한 비밀번호 설정
 CMD_PasswordSet_Help VPN Client 서비스 명령 줄 관리 유틸리티와 VPN 클라이언트 연결 관리자 등으로 연결된 제어를 할 때 암호 입력을 요청할 수 있습니다. 이 명령을 사용하여 입력을 요청하는 암호를 설정할 수 있습니다. \n 암호는 원격 (localhost가 아닌 컴퓨터)에서 작업을 할 경우에만 입력 할 것을 요구할 수도 있습니다.
 CMD_PasswordSet_Args PasswordSet [password] [/REMOTEONLY:yes|no]
-CMD_PasswordSet_ [password 설정 암호를 지정합니다. "none"을 지정하면 암호 설정을 제거 할 수 있습니다.
+CMD_PasswordSet_[password] 설정 암호를 지정합니다. "none"을 지정하면 암호 설정을 제거 할 수 있습니다.
 CMD_PasswordSet_REMOTEONLY yes를 지정하면 암호는 원격 (localhost가 아닌 컴퓨터)에서 작업을 할 경우에만 요구되며, localhost에서 접속시에는 요구되지 않습니다. 이 매개 변수를 생략 한 경우에는 "no"로 간주합니다.
 
 
@@ -6372,21 +6354,21 @@ CMD_CertList_Args CertList
 CMD_CertAdd 신뢰하는 인증 기관의 인증서 추가
 CMD_CertAdd_Help VPN Client가 신뢰하는 인증 기관의 인증서 목록에 새 인증서를 추가합니다. 등록 된 인증 기관의 인증서 목록은 VPN Server에 연결시 서버 인증서의 유효성 등에 이용됩니다. \n 현재 인증서 목록을 검색하려면 CertList 명령을 사용합니다. \n 인증서를 추가하려면 인증서가 X.509 형식의 파일로 저장되어 있어야합니다.
 CMD_CertAdd_Args CertAdd [path]
-CMD_CertAdd_ [path] 등록 X.509 인증서 파일 이름을 지정합니다.
+CMD_CertAdd_[path] 등록 X.509 인증서 파일 이름을 지정합니다.
 
 
 # CertDelete 명령
 CMD_CertDelete 신뢰하는 인증 기관의 인증서 삭제
 CMD_CertDelete_Help VPN Client가 신뢰하는 인증 기관의 인증서 목록에서 기존 인증서를 삭제합니다. \n 현재 인증서 목록을 검색하려면 CertList 명령을 사용합니다.
 CMD_CertDelete_Args CertDelete [id]
-CMD_CertDelete_ [id] 삭제할 인증서의 ID를 지정합니다.
+CMD_CertDelete_[id] 삭제할 인증서의 ID를 지정합니다.
 
 
 # CertGet 명령
 CMD_CertGet 신뢰하는 인증 기관의 인증서 취득
 CMD_CertGet_Help VPN Client가 신뢰하는 인증 기관의 인증서 목록에서 기존 인증서를 취득하고 X.509 형식의 파일로 저장합니다.
 CMD_CertGet_Args CertGet [id] [/SAVECERT:path]
-CMD_CertGet_ [id] 취득하는 인증서의 ID를 지정합니다.
+CMD_CertGet_[id] 취득하는 인증서의 ID를 지정합니다.
 CMD_CertGet_SAVECERT 취득한 인증서를 저장할 파일 이름을 지정합니다.
 
 
@@ -6400,7 +6382,7 @@ CMD_SecureList_Args SecureList
 CMD_SecureSelect 사용하는 스마트 카드 유형 선택
 CMD_SecureSelect_Help VPN Client에서 사용하는 스마트 카드의 종류를 선택합니다. \n 사용할 수있는 스마트 카드 형식 목록은 SecureList 명령에서 얻을 수 있습니다.
 CMD_SecureSelect_Args SecureSelect [id]
-CMD_SecureSelect_ [id] 스마트 카드 유형의 ID를 지정합니다.
+CMD_SecureSelect_[id] 스마트 카드 유형의 ID를 지정합니다.
 CMD_SecureSelect_PROMPT_ID 사용하는 스마트 카드의 종류 ID:
 
 
@@ -6416,7 +6398,7 @@ CMD_SecureGet_NoPrint 현재 스마트 카드는 선택되지 않습니다.
 CMD_NicCreate 신규 가상 LAN 카드 만들기
 CMD_NicCreate_Help 새로운 가상 LAN 카드를 시스템에 추가합니다. 가상 LAN 카드에 원하는 이름을 지정할 수 있습니다. \n 그러나 가상 LAN 카드 이름에 사용할 수있는 문자는 영숫자 만 Windows 2000 이후의 시스템에서는 31 자까지 Windows 98, 98 SE 및 ME에서는 4자가 될 수 있습니다. \nNicCreate 명령을 호출하면 VPN Client가 실행중인 운영 체제에 새로운 가상 LAN 카드 드라이버를 설치합니다. \n이 경우 운영 체제에서 장치 드라이버를 설치하여도 좋다 있는지 확인하는 대화 상자가 나타날 수 있습니다.
 CMD_NicCreate_Args NicCreate [name]
-CMD_NicCreate_ [name] 가상 LAN 카드의 이름을 지정합니다.
+CMD_NicCreate_[name] 가상 LAN 카드의 이름을 지정합니다.
 CMD_NicCreate_PROMPT_NAME 가상 LAN 카드의 이름:
 
 
@@ -6424,21 +6406,21 @@ CMD_NicCreate_PROMPT_NAME 가상 LAN 카드의 이름:
 CMD_NicDelete 가상 LAN 카드 삭제
 CMD_NicDelete_Help 기존 가상 LAN 카드를 시스템에서 제거합니다. \n 시스템에서 가상 LAN 카드를 제거하면 가상 LAN 카드를 사용하여 연결이 끊어집니다. \n 또한 삭제 된 가상 LAN 카드를 사용하도록 설정되어있는 연결 설정은 다른 가상 LAN 카드를 사용하도록 자동으로 설정 변경됩니다. \n이 명령은 VPN Client는 Windows 2000 이상의 운영 체제에서 작동하는 경우에 사용할 수 있습니다.
 CMD_NicDelete_Args NicDelete [name]
-CMD_NicDelete_ [name] 가상 LAN 카드의 이름을 지정합니다.
+CMD_NicDelete_[name] 가상 LAN 카드의 이름을 지정합니다.
 
 
 # NicUpgrade 명령
 CMD_NicUpgrade 가상 LAN 카드의 장치 드라이버 업그레이드
 CMD_NicUpgrade_Help 기존 가상 LAN 카드의 장치 드라이버의 버전이 오래된 경우 현재 운영하고있는 VPN Client와 함께 제공되는 최신 장치 드라이버로 업그레이드합니다. 업그레이드를하지 않는 경우에도 장치 드라이버를 다시 설치합니다. \n 운영 체제에 따라 장치 드라이버를 설치하여도 좋다 있는지 확인하는 대화 상자가 나타날 수 있습니다. \n이 명령은 VPN Client는 Windows 2000 이상의 운영 체제에서 작동하는 경우에 사용할 수 있습니다.
 CMD_NicUpgrade_Args NicUpgrade [name]
-CMD_NicUpgrade_ [name] 가상 LAN 카드의 이름을 지정합니다.
+CMD_NicUpgrade_[name] 가상 LAN 카드의 이름을 지정합니다.
 
 
 # NicGetSetting 명령
 CMD_NicGetSetting 가상 LAN 카드 설정 검색
 CMD_NicGetSetting_Help 기존 가상 LAN 카드의 MAC 주소 설정을 가져옵니다. \n이 명령은 VPN Client는 Windows 2000 이상의 운영 체제에서 작동하는 경우에 사용할 수 있습니다.
 CMD_NicGetSetting_Args NicGetSetting [name]
-CMD_NicGetSetting_ [name] 가상 LAN 카드의 이름을 지정합니다.
+CMD_NicGetSetting_[name] 가상 LAN 카드의 이름을 지정합니다.
 CMD_NicGetSetting_1 장치 이름
 CMD_NicGetSetting_2 상태
 CMD_NicGetSetting_3 MAC 주소
@@ -6451,7 +6433,7 @@ CMD_NicGetSetting_6 GUID
 CMD_NicSetSetting 가상 LAN 카드 설정 변경
 CMD_NicSetSetting_Help 기존 가상 LAN 카드의 MAC 주소 설정을 변경합니다. 이 명령을 실행하면 현재 실행중인 가상 LAN 카드 장치 드라이버가 다시 시작합니다. \n이 명령은 VPN Client는 Windows 2000 이상의 운영 체제에서 작동하는 경우에 사용할 수 있습니다.
 CMD_NicSetSetting_Args NicSetSetting [name] [/MAC:mac]
-CMD_NicSetSetting_ [name] 가상 LAN 카드의 이름을 지정합니다.
+CMD_NicSetSetting_[name] 가상 LAN 카드의 이름을 지정합니다.
 CMD_NicSetSetting_MAC 설정하는 MAC 주소를 지정합니다. \nMAC 주소는 6 바이트 분의 16 진수 문자열로 지정하십시오. \n 예:00:AC:01:23:45:67 또는 00-AC-01-23-45-67
 CMD_NicSetSetting_PROMPT_MAC 설정 MAC 주소:
 
@@ -6460,14 +6442,14 @@ CMD_NicSetSetting_PROMPT_MAC 설정 MAC 주소:
 CMD_NicEnable 가상 LAN 카드 활성화
 CMD_NicEnable_Help 기존 가상 LAN 카드가 비활성화되어있는 경우 사용합니다. \n이 명령은 VPN Client는 Windows 2000 이상의 운영 체제에서 작동하는 경우에 사용할 수 있습니다.
 CMD_NicEnable_Args NicEnable [name]
-CMD_NicEnable_ [name] 가상 LAN 카드의 이름을 지정합니다.
+CMD_NicEnable_[name] 가상 LAN 카드의 이름을 지정합니다.
 
 
 # NicDisable 명령
 CMD_NicDisable 가상 LAN 카드 비활성화
 CMD_NicDisable_Help 기존 가상 LAN 카드가 활성화되어있는 경우 비활성화합니다. \n이 명령은 VPN Client는 Windows 2000 이상의 운영 체제에서 작동하는 경우에 사용할 수 있습니다.
 CMD_NicDisable_Args NicDisable [name]
-CMD_NicDisable_ [name] 가상 LAN 카드의 이름을 지정합니다.
+CMD_NicDisable_[name] 가상 LAN 카드의 이름을 지정합니다.
 
 
 # NicList 명령
@@ -6486,7 +6468,7 @@ CMD_AccountList_Args AccountList
 CMD_AccountCreate 새 연결 설정 만들기
 CMD_AccountCreate_Help VPN Client에 새 연결 설정을 만듭니다. \n 연결 설정을 만들려면 초기 매개 변수로 연결 설정의 이름과 연결된 서버 및 연결된 가상 HUB 사용자 이름 이외에 사용하는 가상 LAN 카드 이름을 지정해야합니다. 새 연결 설정을 만든 경우 사용자 인증 유형은 익명 인증에 초기 설정된 프록시 서버 설정 및 서버 인증서 유효성 검사 옵션 설정되지 않습니다. 이러한 설정 및 기타 자세한 설정을 변경하려면 연결 설정을 작성한 후 "Account"라는 이름으로 시작하는 다른 명령을 사용합니다.
 CMD_AccountCreate_Args AccountCreate [name] [/SERVER:hostname:port] [/HUB:hubname] [/USERNAME:username] [/NICNAME:nicname]
-CMD_AccountCreate_ [name] 만들 연결 설정의 이름을 지정합니다.
+CMD_AccountCreate_[name] 만들 연결 설정의 이름을 지정합니다.
 CMD_AccountCreate_SERVER 호스트 이름:포트 번호 형식으로 연결된 VPN Server의 호스트 이름과 포트 번호를 지정합니다. IP 주소를 지정할 수도 있습니다.
 CMD_AccountCreate_HUB 연결된 VPN Server의 가상 HUB를 지정합니다.
 CMD_AccountCreate_USERNAME 연결된 VPN Server에 연결할 때 사용자 인증에 사용할 사용자 이름을 지정합니다.
@@ -6502,7 +6484,7 @@ CMD_AccountCreate_Prompt_Nicname 사용하는 가상 LAN 카드 이름:
 CMD_AccountSet 연결 설정 연결 설정
 CMD_AccountSet_Help VPN Client에 등록되어있는 연결 설정 연결할 VPN Server의 호스트 이름과 포트 번호 가상 HUB 이름 및 연결에 사용할 사용자 이름 이외에 사용하는 가상 LAN 카드 이름을 설정합니다.
 CMD_AccountSet_Args AccountSet [name] [/SERVER:hostname:port] [/HUB:hubname]
-CMD_AccountSet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountSet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountSet_SERVER 호스트 이름:포트 번호 형식으로 연결된 VPN Server의 호스트 이름과 포트 번호를 지정합니다. IP 주소를 지정할 수도 있습니다.
 CMD_AccountSet_HUB 연결된 VPN Server의 가상 HUB를 지정합니다.
 
@@ -6511,21 +6493,21 @@ CMD_AccountSet_HUB 연결된 VPN Server의 가상 HUB를 지정합니다.
 CMD_AccountGet 연결 설정 구성 가져 오기
 CMD_AccountGet_Help VPN Client에 등록되어있는 연결 설정 연결 설정을 가져옵니다. \n 또한 연결 설정 연결 설정을 변경하려면 연결 설정을 작성한 후 "Account"라는 이름으로 시작하는 다른 명령을 사용합니다.
 CMD_AccountGet_Args AccountGet [name]
-CMD_AccountGet_ [name] 설정을 가져올 연결 설정의 이름을 지정합니다.
+CMD_AccountGet_[name] 설정을 가져올 연결 설정의 이름을 지정합니다.
 
 
 # AccountDelete 명령
 CMD_AccountDelete 연결 설정 삭제
 CMD_AccountDelete_Help VPN Client에 등록되어있는 연결 설정을 삭제합니다. 지정된 연결 설정이 온라인 상태 인 경우 자동으로 연결을 끊고 삭제합니다.
 CMD_AccountDelete_Args AccountDelete [name]
-CMD_AccountDelete_ [name] 삭제 연결 설정의 이름을 지정합니다.
+CMD_AccountDelete_[name] 삭제 연결 설정의 이름을 지정합니다.
 
 
 # AccountUsernameSet 명령
 CMD_AccountUsernameSet 연결 설정 연결에 사용할 사용자 이름 설정
 CMD_AccountUsernameSet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 사용자 인증에 필요한 사용자 이름을 지정합니다. \n 또한, 사용자 인증 유형을 지정하고 필요한 매개 변수를 지정 할 필요가있을 수 있습니다. 이러한 정보를 변경하려면 AccountAnonymousSet, AccountPasswordSet, AccountCertSet, AccountSecureCertSet 같은 명령을 사용합니다.
 CMD_AccountUsernameSet_Args AccountUsernameSet [name] [/USERNAME:username]
-CMD_AccountUsernameSet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountUsernameSet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountUsernameSet_USERNAME 연결 설정 VPN Server에 연결할 때 사용자 인증에 필요한 사용자 이름을 지정합니다.
 CMD_AccountUsername_Notice 이 연결 설정의 인증 방법은 현재 암호 인증으로 설정되어 있습니다. 사용자 이름을 변경 한 후 AccountPasswordSet 명령에서 암호를 다시 설정해야합니다.
 
@@ -6534,14 +6516,14 @@ CMD_AccountUsername_Notice 이 연결 설정의 인증 방법은 현재 암호 �
 CMD_AccountAnonymousSet 연결 설정의 사용자 인증 유형을 익명 인증으로 설정
 CMD_AccountAnonymousSet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 사용자 인증 방법을 익명 인증으로 설정합니다.
 CMD_AccountAnonymousSet_Args AccountAnonymousSet [name]
-CMD_AccountAnonymousSet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountAnonymousSet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountPasswordSet 명령
 CMD_AccountPasswordSet 연결 설정의 사용자 인증 유형을 암호 인증 설정
 CMD_AccountPasswordSet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 사용자 인증 방법을 암호 인증으로 설정합니다. 암호 인증의 종류에는 표준 암호 인증 및 RADIUS 또는 NT 도메인 인증을 지정합니다.
 CMD_AccountPasswordSet_Args AccountPasswordSet [name] [/PASSWORD:password] [/TYPE:standard|radius]
-CMD_AccountPasswordSet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountPasswordSet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountPasswordSet_PASSWORD 암호 인증에 사용할 암호를 지정합니다. 지정하지 않으면 암호를 입력하라는 메시지가 표시됩니다.
 CMD_AccountPasswordSet_TYPE 암호 인증 유형으로 "standard"(표준 암호 인증) 또는 "radius"(RADIUS 또는 NT 도메인 인증) 중 하나를 지정합니다.
 CMD_AccountPasswordSet_Prompt_Type standard 또는 radius 지정:
@@ -6552,7 +6534,7 @@ CMD_AccountPasswordSet_Type_Invalid standard 또는 radius의 지정이 잘못�
 CMD_AccountCertSet 연결 설정의 사용자 인증 유형을 클라이언트 인증서 인증으로 설정
 CMD_AccountCertSet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 사용자 인증 방법을 클라이언트 인증서 인증으로 설정합니다. 인증서로는 X.509 형식의 인증서 파일과 Base 64로 인코딩 된 해당하는 개인 키 파일을 지정해야합니다.
 CMD_AccountCertSet_Args AccountCertSet [name] [/LOADCERT:cert] [/LOADKEY:key]
-CMD_AccountCertSet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountCertSet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountCertSet_LOADCERT 인증서 인증에서 제시하는 X.509 형식의 인증서 파일 이름을 지정합니다.
 CMD_AccountCertSet_LOADKEY 인증서에 대응 한 Base 64로 인코딩 된 개인 키 파일 이름을 지정합니다.
 
@@ -6561,7 +6543,7 @@ CMD_AccountCertSet_LOADKEY 인증서에 대응 한 Base 64로 인코딩 된 개�
 CMD_AccountCertGet 연결을 설정하기위한 클라이언트 인증서 취득
 CMD_AccountCertGet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정이 클라이언트 인증서 인증을 사용하려면 클라이언트 인증서로 제공하는 인증서를 취득하여 인증서 파일을 X.509 형식으로 저장합니다.
 CMD_AccountCertGet_Args AccountCertGet [name] [/SAVECERT:cert]
-CMD_AccountCertGet_ [name] 설정을 가져올 연결 설정의 이름을 지정합니다.
+CMD_AccountCertGet_[name] 설정을 가져올 연결 설정의 이름을 지정합니다.
 CMD_AccountCertGet_SAVECERT 취득한 인증서를 X.509 형식으로 저장할 파일 이름을 지정합니다.
 
 
@@ -6569,42 +6551,42 @@ CMD_AccountCertGet_SAVECERT 취득한 인증서를 X.509 형식으로 저장할 
 CMD_AccountEncryptEnable 연결 설정의 통신시 암호화 활성화
 CMD_AccountEncryptEnable_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server 사이에서 VPN 연결을 행하고 통신을 할 때 VPN Server 사이의 통신 내용을 SSL로 암호화하도록 로 설정합니다. \n 일반적으로 VPN Server 간의 통신을 SSL로 암호화하여 정보의 도청 및 변조를 방지합니다. 암호화를 비활성화 할 수 있습니다. 암호화를 해제하면 통신 처리량이 향상되지만, 통신 데이터는 일반 텍스트로 네트워크를 통해 흐릅니다.
 CMD_AccountEncryptEnable_Args AccountEncryptEnable [name]
-CMD_AccountEncryptEnable_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountEncryptEnable_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountEncryptDisable 명령
 CMD_AccountEncryptDisable 연결 설정의 통신시 암호화 해제
 CMD_AccountEncryptDisable_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server 사이에서 VPN 연결을 행하고 통신을 할 때 VPN Server 사이의 통신 내용을 암호화하지 않도록 설정 합니다. \n 일반적으로 VPN Server 간의 통신을 SSL로 암호화하여 정보의 도청 및 변조를 방지합니다. 암호화를 비활성화 할 수 있습니다. 암호화를 해제하면 통신 처리량이 향상되지만, 통신 데이터는 일반 텍스트로 네트워크를 통해 흐릅니다.
 CMD_AccountEncryptDisable_Args AccountEncryptDisable [name]
-CMD_AccountEncryptDisable_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountEncryptDisable_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountCompressEnable 명령
 CMD_AccountCompressEnable 연결 설정의 통신시 데이터 압축 사용
-CMD_AccountCompressEnable_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server 사이에서 VPN 연결을 행하고 통신을 할 때 VPN Server 사이의 통신 내용을 압축하도록 설정 합니다. \n 최대 약 80 %정도의 압축을 할 수 있습니다. 그러나 압축하면 클라이언트와 서버 모두에서 CPU 부하가 높아집니다. 회선 속도가 10 Mbps 이상의 경우 압축하면 처리량이 감소하고 역효과가 될 수 있습니다.
+CMD_AccountCompressEnable_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server 사이에서 VPN 연결을 행하고 통신을 할 때 VPN Server 사이의 통신 내용을 압축하도록 설정 합니다. \n 최대 약 80 % 정도의 압축을 할 수 있습니다. 그러나 압축하면 클라이언트와 서버 모두에서 CPU 부하가 높아집니다. 회선 속도가 10 Mbps 이상의 경우 압축하면 처리량이 감소하고 역효과가 될 수 있습니다.
 CMD_AccountCompressEnable_Args AccountCompressEnable [name]
-CMD_AccountCompressEnable_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountCompressEnable_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountCompressDisable 명령
 CMD_AccountCompressDisable 연결 설정의 통신시 데이터 압축 해제
 CMD_AccountCompressDisable_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server 사이에서 VPN 연결을 행하고 통신을 할 때 VPN Server 사이의 통신 내용을 압축하지 않도록 설정 합니다.
 CMD_AccountCompressDisable_Args AccountCompressDisable [name]
-CMD_AccountCompressDisable_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountCompressDisable_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountProxyNone 명령
 CMD_AccountProxyNone 연결 설정의 연결 방법을 직접 TCP/IP 연결 설정
 CMD_AccountProxyNone_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 사용하는 연결 방법을 [직접 TCP/IP 연결을 설정하고 프록시 서버를 경유하지 않도록 합니다.
 CMD_AccountProxyNone_Args AccountProxyNone [name]
-CMD_AccountProxyNone_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountProxyNone_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountProxyHttp 명령
 CMD_AccountProxyHttp 연결 설정의 연결 방법을 HTTP 프록시 서버를 통해 연결 설정
 CMD_AccountProxyHttp_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 사용하는 연결 방법을 HTTP 프록시 서버를 통해 연결을 설정하고 통해 HTTP 프록시 서버의 호스트 이름과 포트 번호, 사용자 이름과 암호 (필요한 경우)을 지정합니다. \n 통해 HTTP 프록시 서버는 HTTPS 통신을하기위한 CONNECT 메소드를 지원해야합니다.
 CMD_AccountProxyHttp_Args AccountProxyHttp [name] [/SERVER:hostname:port] [/USERNAME:username] [/PASSWORD:password]
-CMD_AccountProxyHttp_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountProxyHttp_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountProxyHttp_SERVER 호스트 이름:포트 번호 형식으로 통해 HTTP 프록시 서버의 호스트 이름 또는 IP 주소와 포트 번호를 지정합니다.
 CMD_AccountProxyHttp_USERNAME 통해 HTTP 프록시 서버에 연결하기 위해 사용자 인증이 필요한 경우 사용자 이름을 지정합니다. 또한 동시에/PASSWORD 매개 변수도 지정합니다./USERNAME 및/PASSWORD 매개 변수가 지정되지 않은 경우 사용자 인증 데이터를 설정하지 않습니다.
 CMD_AccountProxyHttp_PASSWORD 통해 HTTP 프록시 서버에 연결하기 위해 사용자 인증이 필요한 경우 암호를 지정합니다./USERNAME 매개 변수와 함께 지정합니다.
@@ -6616,7 +6598,7 @@ CMD_AccountProxyHttp_Prompt_Server 프록시 서버의 호스트 이름과 포�
 CMD_AccountProxySocks 연결 설정의 연결 방법을 SOCKS 프록시 서버를 통해 연결 설정
 CMD_AccountProxySocks_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 사용하는 연결 방법을 [SOCKS 프록시 서버를 통해 연결을 설정하고 통해 SOCKS 프록시 서버 호스트 이름과 포트 번호, 사용자 이름과 암호 (필요한 경우)을 지정합니다. \n 통해 SOCKS 서버는 SOCKS 버전 4를 지원해야합니다.
 CMD_AccountProxySocks_Args AccountProxySocks [name] [/SERVER:hostname:port] [/USERNAME:username] [/PASSWORD:password]
-CMD_AccountProxySocks_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountProxySocks_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountProxySocks_SERVER 호스트 이름:포트 번호 형식으로 통해 SOCKS 프록시 서버의 호스트 이름 또는 IP 주소와 포트 번호를 지정합니다.
 CMD_AccountProxySocks_USERNAME 통해 SOCKS 프록시 서버에 연결하기 위해 사용자 인증이 필요한 경우 사용자 이름을 지정합니다. 또한 동시에/PASSWORD 매개 변수도 지정합니다./USERNAME 및/PASSWORD 매개 변수가 지정되지 않은 경우 사용자 인증 데이터를 설정하지 않습니다.
 CMD_AccountProxySocks_PASSWORD 통해 SOCKS 프록시 서버에 연결하기 위해 사용자 인증이 필요한 경우 암호를 지정합니다./USERNAME 매개 변수와 함께 지정합니다.
@@ -6626,14 +6608,14 @@ CMD_AccountProxySocks_PASSWORD 통해 SOCKS 프록시 서버에 연결하기 위
 CMD_AccountServerCertEnable 연결 설정 서버 인증서 검증 옵션 활성화
 CMD_AccountServerCertEnable_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 연결하려는 VPN Server가 제시하는 SSL 인증서를 신뢰할 수 있는지 검사하는 옵션을 사용하여 합니다. \n이 옵션이 활성화되어있는 경우 연결할 서버의 SSL 인증서를 미리 AccountServerCertSet 명령에서 연결 설정 설정에 저장할하거나 가상 HUB 신뢰하는 인증 기관의 인증서 목록에 서버의 SSL 인증서를 서명 한 루트 인증서를 CertAdd 명령 등으로 등록 할 것을 권장합니다. 등록되어 있지 않은 경우는 처음 연결할 때 확인 메시지가 표시 될 수 있습니다. \n 연결 설정 서버 인증서 검증 옵션이 활성화되어있는 상태에서 연결 한 VPN Server의 인증서를 신뢰할 수없는 경우 즉시 연결을 해제하고 재 시도를 반복합니다.
 CMD_AccountServerCertEnable_Args AccountServerCertEnable [name]
-CMD_AccountServerCertEnable_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountServerCertEnable_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountServerCertDisable 명령
 CMD_AccountServerCertDisable 연결 설정 서버 인증서 검증 옵션 비활성화
 CMD_AccountServerCertDisable_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 연결하려는 VPN Server가 제시하는 SSL 인증서를 신뢰할 수 있는지 검사하는 옵션을 해제 합니다.
 CMD_AccountServerCertDisable_Args AccountServerCertDisable [name]
-CMD_AccountServerCertDisable_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountServerCertDisable_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountRetryOnServerCertEnable command
@@ -6654,7 +6636,7 @@ CMD_AccountRetryOnServerCertDisable_[name]	Specify the name of the VPN Connectio
 CMD_AccountServerCertSet 연결 설정 서버 별 인증서 설정
 CMD_AccountServerCertSet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 연결하려는 VPN Server가 제시하는 SSL 인증서와 동일한 인증서를 미리 등록합니다. \n 연결 설정 서버 인증서 검증 옵션이 활성화되어있는 경우 연결할 서버의 SSL 인증서를 미리이 명령에서 연결 설정 설정에 저장할하거나 가상 HUB 신뢰하는 인증 기관 인증서 목록에 서버의 SSL 인증서를 서명 한 루트 인증서를 CAAdd 명령 등으로 등록되어 있어야합니다. \n 연결 설정 서버 인증서 검증 옵션이 활성화되어있는 상태에서 연결 한 VPN Server의 인증서를 신뢰할 수없는 경우 즉시 연결을 해제하고 재 시도를 반복합니다.
 CMD_AccountServerCertSet_Args AccountServerCertSet [name] [/LOADCERT:cert]
-CMD_AccountServerCertSet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountServerCertSet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountServerCertSet_LOADCERT 설정 서버 별 인증서가 저장되어있는 X.509 형식의 인증서 파일 이름을 지정합니다.
 
 
@@ -6662,14 +6644,14 @@ CMD_AccountServerCertSet_LOADCERT 설정 서버 별 인증서가 저장되어있
 CMD_AccountServerCertDelete 연결 설정 서버 별 인증서 삭제
 CMD_AccountServerCertDelete_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 서버 고유 인증서가 등록되어있는 경우는 그것을 삭제합니다.
 CMD_AccountServerCertDelete_Args AccountServerCertDelete [name]
-CMD_AccountServerCertDelete_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountServerCertDelete_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountServerCertGet 명령
 CMD_AccountServerCertGet 연결 설정 서버 관련 인증서 취득
 CMD_AccountServerCertGet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 서버 고유 인증서가 등록 된 경우 해당 인증서를 취득하여 X.509 형식의 인증서 파일로 저장합니다.
 CMD_AccountServerCertGet_Args AccountServerCertGet [name] [/SAVECERT:path]
-CMD_AccountServerCertGet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountServerCertGet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountServerCertGet_SAVECERT 서버 별 인증서를 X.509 형식으로 저장할 인증서 파일 이름을 지정합니다.
 
 
@@ -6677,7 +6659,7 @@ CMD_AccountServerCertGet_SAVECERT 서버 별 인증서를 X.509 형식으로 저
 CMD_AccountDetailSet 연결 설정의 고급 통신 설정 설정
 CMD_AccountDetailSet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server와 통신하는 데 사용되는 VPN 프로토콜의 통신 설정을 사용자 정의합니다.
 CMD_AccountDetailSet_Args AccountDetailSet [name] [/MAXTCP:max_connection] [/INTERVAL:additional_interval] [/TTL:disconnect_span] [/HALF:yes|no] [/BRIDGE:yes|no] [/MONITOR:yes|no] [/NOTRACK:yes|no] [/NOQOS:yes|no]
-CMD_AccountDetailSet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountDetailSet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountDetailSet_MAXTCP VPN 통신에 사용하는 TCP 연결 수를 1 이상 32 이하의 정수로 지정합니다. VPN Server 사이의 VPN 통신 세션의 데이터 전송에 복수 개의 TCP 연결을 묶어 사용하여 통신 속도를 향상시킬 수 있습니다. \n주의:서버에 연결 회선이 빠른 경우는 8 개 정도를 전화 접속 등의 느린 경우 1 개를 추천합니다.
 CMD_AccountDetailSet_INTERVAL 여러 TCP 연결을 설정하고 VPN 통신을 할 때 각 TCP 연결 설정 간격을 초 단위로 지정합니다. 기본값은 1 초입니다.
 CMD_AccountDetailSet_TTL 각 TCP 연결의 수명을 설정하는 경우, TCP 연결이 설정되고 나서 절단 될 때까지의 수명을 초 단위로 지정합니다. 0을 지정하면 수명은 설정되지 않습니다.
@@ -6696,13 +6678,15 @@ CMD_AccountDetailSet_Prompt_BRIDGE 브리지/라우터 모드를 사용 (yes/no)
 CMD_AccountDetailSet_Prompt_MONITOR 모니터링 모드를 활성화 (yes/no):
 CMD_AccountDetailSet_Prompt_NOTRACK 라우팅 테이블 조정 처리를 비활성화 (yes/no):
 CMD_AccountDetailSet_Prompt_NOQOS QoS 제어 기능을 비활성화 (yes/no):
+CMD_AccountDetailSet_DISABLEUDP Specify "yes" when disabling UDP acceleration function. Normally "no" is specified.
+CMD_AccountDetailSet_Prompt_DISABLEUDP   Disable UDP Acceleration Function (yes/no):
 
 
 # AccountRename 명령
 CMD_AccountRename 연결 설정의 이름 변경
 CMD_AccountRename_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정의 이름을 변경합니다.
 CMD_AccountRename_Args AccountRename [name] [/NEW:new_name]
-CMD_AccountRename_ [name] 이름을 변경하려면 연결 설정의 현재 이름을 지정합니다.
+CMD_AccountRename_[name] 이름을 변경하려면 연결 설정의 현재 이름을 지정합니다.
 CMD_AccountRename_NEW 변경 후 새 이름을 지정합니다.
 CMD_AccountRename_PROMPT_OLD 현재의 이름:
 CMD_AccountRename_PROMPT_NEW 새 이름:
@@ -6712,28 +6696,28 @@ CMD_AccountRename_PROMPT_NEW 새 이름:
 CMD_AccountConnect 연결 설정을 사용하여 VPN Server에 연결을 시작
 CMD_AccountConnect_Help VPN Client에 등록되어있는 연결 설정을 지정하고 해당 연결 설정을 사용하여 VPN Server에 대한 연결을 시작합니다. 연결 처리 중이거나 연결된 상태 연결 설정은 AccountDisconnect 명령으로 종료 될 때까지 VPN Server에 항상 연결하거나 연결을 계속 시도합니다 (그러나 AccountRetrySet 명령 재시도 횟수를 지정하고있는 경우 지정된 횟수만큼 시도를 중단합니다).
 CMD_AccountConnect_Args AccountConnect [name]
-CMD_AccountConnect_ [name] 연결을 시작하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountConnect_[name] 연결을 시작하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountDisconnect 명령
 CMD_AccountDisconnect 연결된 연결 설정 절단
 CMD_AccountDisconnect_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정이 연결 처리 중이거나 연결된 상태이면 즉시 끊습니다.
 CMD_AccountDisconnect_Args AccountDisconnect [name]
-CMD_AccountDisconnect_ [name] 절단 연결 설정의 이름을 지정합니다.
+CMD_AccountDisconnect_[name] 절단 연결 설정의 이름을 지정합니다.
 
 
 # AccountStatusGet 명령
 CMD_AccountStatusGet 연결 설정의 현재 상태의 취득
 CMD_AccountStatusGet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정이 현재 연결되어있는 경우는 그 연결 상태 및 기타 정보를 가져옵니다.
 CMD_AccountStatusGet_Args AccountStatusGet [name]
-CMD_AccountStatusGet_ [name] 정보를 얻을 연결 설정의 이름을 지정합니다.
+CMD_AccountStatusGet_[name] 정보를 얻을 연결 설정의 이름을 지정합니다.
 
 
 # AccountNicSet 명령
 CMD_AccountNicSet 연결 설정에서 사용하는 가상 LAN 카드 설정
 CMD_AccountNicSet_Help VPN Client에 등록되어있는 기존의 연결 설정이 VPN Server에 연결하는 데 사용하는 가상 LAN 카드 이름을 변경합니다.
 CMD_AccountNicSet_Args AccountNicSet [name] [/NICNAME:nicname]
-CMD_AccountNicSet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountNicSet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountNicSet_NICNAME VPN Server에 연결하는 데 사용하는 가상 LAN 카드 이름을 지정합니다.
 
 
@@ -6741,21 +6725,21 @@ CMD_AccountNicSet_NICNAME VPN Server에 연결하는 데 사용하는 가상 LAN
 CMD_AccountStatusShow VPN Server에 연결하는 동안 연결 상태 나 오류 화면을 표시하도록 설정
 CMD_AccountStatusShow_Help VPN Client에 등록되어있는 연결 설정을 지정하고 해당 연결 설정을 사용하여 VPN Server에 연결할 때 연결 상태 나 오류 화면 등을 컴퓨터 화면에 표시하도록 설정합니다.
 CMD_AccountStatusShow_Args AccountStatusShow [name]
-CMD_AccountStatusShow_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountStatusShow_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountStatusHide 명령
 CMD_AccountStatusHide VPN Server에 연결하는 동안 연결 상태 나 오류 화면을 표시하지 않도록 설정
 CMD_AccountStatusHide_Help VPN Client에 등록되어있는 연결 설정을 지정하고 해당 연결 설정을 사용하여 VPN Server에 연결할 때 연결 상태 나 오류 화면 등을 컴퓨터의 디스플레이에 표시하지 않도록 설정합니다.
 CMD_AccountStatusHide_Args AccountStatusHide [name]
-CMD_AccountStatusHide_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountStatusHide_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountSecureCertSet 명령
 CMD_AccountSecureCertSet 연결 설정의 사용자 인증 유형을 스마트 카드 인증으로 설정
 CMD_AccountSecureCertSet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결할 때 사용자 인증 방법을 스마트 카드 인증으로 설정합니다. 또한 스마트 카드에 저장되어있는 인증서 개체와 비밀 열쇠 오브젝트의 이름을 지정해야합니다.
 CMD_AccountSecureCertSet_Args AccountSecureCertSet [name] [/CERTNAME:cert] [/KEYNAME:key]
-CMD_AccountSecureCertSet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountSecureCertSet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountSecureCertSet_CERTNAME 스마트 카드에 저장되어있는 인증서 개체의 이름을 지정합니다.
 CMD_AccountSecureCertSet_KEYNAME 스마트 카드에 저장되어있는 비밀 열쇠 오브젝트의 이름을 지정합니다./CERTNAME에 지정된 인증서에 대응하고있을 필요가 있습니다.
 CMD_AccountSecureCertSet_PROMPT_CERTNAME 스마트 카드에서 인증서 개체의 이름:
@@ -6766,7 +6750,7 @@ CMD_AccountSecureCertSet_PROMPT_KEYNAME 스마트 카드의 비밀 열쇠 오브
 CMD_AccountRetrySet 연결 설정 연결 실패 또는 절단시 다시 시도 횟수 및 간격 설정
 CMD_AccountRetrySet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정 VPN Server에 연결하려고 할 때 또는 연결 중에 VPN Server와 통신이 끊기거나 연결이 실패 할 경우에, 연결을 재 시도하는 횟수와 연결 재시도 간격을 지정합니다. \n 또한, 사용자 인증 유형이 스마트 카드 인증의 경우 연결 시도 횟수 제한 설정에 관계없이 재 시도는하지 않습니다.
 CMD_AccountRetrySet_Args AccountRetrySet [name] [/NUM:num_retry] [/INTERVAL:retry_interval]
-CMD_AccountRetrySet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountRetrySet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 CMD_AccountRetrySet_NUM 계속해서 다시 연결하는 횟수를 지정합니다. "999"로 지정하면 무한 재 연결을 시도합니다 (상시 접속). 0을 지정하면 다시 연결을하지 않습니다.
 CMD_AccountRetrySet_INTERVAL 다시 연결을 할 경우 마지막으로 연결이 끊기거나 연결 실패 후 몇 초 후에 다시 연결 처리를 시작할지 여부를 설정합니다.
 CMD_AccountRetrySet_PROMPT_NUM 다시 연결 횟수 ( "999"무한):
@@ -6778,21 +6762,21 @@ CMD_AccountRetrySet_EVAL_INTERVAL 다시 연결 간격은 5 초 이상이어야�
 CMD_AccountStartupSet 연결 설정을 시작 연결 설정
 CMD_AccountStartupSet_Help VPN Client에 등록되어있는 연결 설정을 지정하고 해당 연결 설정을 시작 연결로 설정합니다. 시작 연결에 설정되어있는 연결 설정은 VPN Client 서비스가 시작하자 마자 자동으로 연결 처리를 시작합니다.
 CMD_AccountStartupSet_Args AccountStartupSet [name]
-CMD_AccountStartupSet_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountStartupSet_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountStartupRemove 명령
 CMD_AccountStartupRemove 연결 설정 시작 연결 해제
 CMD_AccountStartupRemove_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정이 현재 시작 연결로 설정되어있는 경우 시작 연결 설정을 해제합니다.
 CMD_AccountStartupRemove_Args AccountStartupRemove [name]
-CMD_AccountStartupRemove_ [name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
+CMD_AccountStartupRemove_[name] 설정을 변경하려면 연결 설정의 이름을 지정합니다.
 
 
 # AccountExport 명령
 CMD_AccountExport 연결 설정 내보내기
 CMD_AccountExport_Help VPN Client에 등록되어있는 연결 설정을 지정하고 연결 설정의 내용을 텍스트 파일로 내 보냅니다. 내 보낸 연결 설정 파일을 나중에 가져 와서 연결 설정의 내용을 복제 할 수 있습니다. 또한 텍스트 파일로 저장되기 때문에 일반적인 텍스트 편집기에서 편집 할 수 있습니다. \n 대상 파일은 UTF-8 형식의 텍스트 파일로 저장됩니다. 또한, 파일 이름에 .vpn 확장자를 넣으면 Windows 용 VPN 클라이언트 연결 관리자와 연관되므로 편리합니다.
 CMD_AccountExport_Args AccountExport [name] [/SAVEPATH:savepath]
-CMD_AccountExport_ [name] 연결 설정을 내보낼 연결 설정 이름을 지정합니다.
+CMD_AccountExport_[name] 연결 설정을 내보낼 연결 설정 이름을 지정합니다.
 CMD_AccountExport_SAVEPATH 저장할 파일 이름을 지정합니다.
 CMD_AccountExport_PROMPT_SAVEPATH 저장할 파일 이름 (확장자는 .vpn 권장):
 
@@ -6801,7 +6785,7 @@ CMD_AccountExport_PROMPT_SAVEPATH 저장할 파일 이름 (확장자는 .vpn 권
 CMD_AccountImport 연결 설정 가져 오기
 CMD_AccountImport_Help AccountExport 명령에 의해 내 보낸 연결 설정 파일을 가져 와서 VPN Client에 추가합니다.
 CMD_AccountImport_Args AccountImport [path]
-CMD_AccountImport_ [path] 가져올 파일 이름을 지정합니다.
+CMD_AccountImport_[path] 가져올 파일 이름을 지정합니다.
 CMD_AccountImport_PROMPT_PATH 가져 원래 파일 이름:
 CMD_AccountImport_FAILED_PARSE 지정된 파일을 올바르게 해석 할 수 없습니다. 제대로 내 보낸 파일 있는지 확인하십시오.
 CMD_AccountImport_OK 연결 설정 "%s"로 가져 왔습니다.
@@ -6884,7 +6868,7 @@ CMD_MakeCert2048_SAVEKEY 작성한 인증서에 대응하는 비밀 키를 저�
 CMD_TrafficClient 통신 처리량 측정 도구 클라이언트의 실행
 CMD_TrafficClient_Help 통신 처리량 측정 도구의 클라이언트 프로그램을 실행합니다. \n 통신 처리량 측정 도구는 TrafficClient과 TrafficServer 두 명령으로 활용하여 IP 네트워크에서 연결된 두 컴퓨터간에 전송할 수있는 통신 처리량을 측정 할 수 있습니다. 이미 다른 컴퓨터에서 TrafficServer 명령을 사용하여 통신 처리량 측정 도구 서버를 대기시켜두고 TrafficClient 명령에서 서버의 호스트 이름 또는 IP 주소와 포트 번호를 지정하여 연결하고 통신 속도를 측정하는 수 있습니다. \n 통신 속도의 측정은 동시에 복수 개의 TCP 연결을 설정하고 각각의 연결에서 최대한 스트림 데이터를 전송 한 결과, 지정된 시간 내에 실제로 전송할 수있는 데이터의 비트 수 를 계산하고 그것을 바탕으로 통신 처리량 평균 (bps)를 산출하는 방식으로 이루어집니다. 일반적으로 1 개의 TCP 연결을 사용하면 TCP 알고리즘의 한계 때문에 실제 네트워크 처리량보다 느린 속도로 밖에 통신 할 수없는 경우가 많기 때문에, 복수 개의 TCP 연결을 동시에 구축하여 통신 결과 를 측정 할 것을 권장합니다. 이 측정 방법에 따라 측정 된 처리량은 실제로 TCP 스트림으로 수신 측에 닿았 데이터 비트 길이에서 계산되기 때문에 도중에 발생한 패킷 손실이나 데이터 손상된 패킷은 실제로 도착한 패킷은 포함되지 않고, 순수한 네트워크의 최대 통신 가능 대역폭에 가까운 값을 산출 할 수 있습니다. \n 측정 결과로 TCP에서 전송 된 스트림 사이즈에서 실제로 네트워크를 흐르는 데이터의 양의 근사치를 계산하고 그것을 시간으로 나누어 비트 레이트 (bps)를 산출합니다. 물리적 네트워크의 종류는 Ethernet (IEEE802.3)에서 MAC 프레임의 페이로드 크기는 1,500 Bytes (TCP의 MSS는 1,460 Bytes)와 가정하여 계산이 이루어집니다./RAW 옵션을 지정하면 TCP/IP 헤더와 MAC 헤더의 데이터 량을 보정하는 계산되지 않습니다. \n \n ※주의:이 명령은 SoftEther VPN 명령 줄 관리 유틸리티에서 호출 할 수 있습니다. 현재 VPN Server와 VPN Client에서 관리 모드로 접속하는 경우도 실행할 수 있지만 실제로 통신을하고 처리량을 측정하는이 명령을 실행하는 컴퓨터이며 관리 모드로 연결 컴퓨터와도 관계없는 컨텍스트에서 실행됩니다.
 CMD_TrafficClient_Args TrafficClient [host:port] [/NUMTCP:numtcp] [/TYPE:download|upload|full] [/SPAN:span] [/DOUBLE:yes|no] [/RAW:yes|no]
-CMD_TrafficClient_ [host:port] 통신 처리량 측정 도구 서버 (TrafficServer)가 대기하고있는 호스트 이름 또는 IP 주소와 포트 번호를 지정합니다. 포트 번호를 생략했을 경우는 9821이 사용됩니다.
+CMD_TrafficClient_[host:port] 통신 처리량 측정 도구 서버 (TrafficServer)가 대기하고있는 호스트 이름 또는 IP 주소와 포트 번호를 지정합니다. 포트 번호를 생략했을 경우는 9821이 사용됩니다.
 CMD_TrafficClient_NUMTCP 동시에 클라이언트와 서버 사이에 설정된 데이터가 전송되는 TCP 연결 수를 지정합니다. 생략하면 32이 사용됩니다.
 CMD_TrafficClient_TYPE 처리량 측정 할 때의 데이터 흐름 방향을 지정합니다. "download", "upload", "full"중 하나를 지정합니다. download를 지정하면 서버 측에서 클라이언트 측에 데이터가 전송됩니다. upload를 지정하면 클라이언트 측에서 서버 측에 데이터가 전송됩니다. full을 지정하면 양방향으로 데이터가 전송됩니다. full을 지정하는 경우 NUMTCP 값은 2 이상의 짝수로 지정해야합니다 (동시에 연결되는 TCP 연결 중 절반이 다운로드 방향, 나머지 절반은 업로드 방향으로 사용됩니다). 이 매개 변수를 생략하면 full가 사용됩니다.
 CMD_TrafficClient_SPAN 처리량을 측정하기위한 데이터 전송을 할 시간을 초 단위로 지정합니다. 이 매개 변수를 생략하면 15 초가 사용됩니다.
@@ -6900,7 +6884,7 @@ CMD_TrafficClient_ERROR_HOSTPORT 호스트 이름 또는 포트 번호의 지정
 CMD_TrafficServer 통신 처리량 측정 도구 서버의 실행
 CMD_TrafficServer_Help 통신 처리량 측정 도구의 서버 프로그램을 실행합니다. \n 통신 처리량 측정 도구는 TrafficClient과 TrafficServer 두 명령으로 활용하여 IP 네트워크에서 연결된 두 컴퓨터간에 전송할 수있는 통신 처리량을 측정 할 수 있습니다. \n이 컴퓨터의 TCP 포트를 대기 상태로 다른 컴퓨터에서 TrafficClient의 연결을 기다리는에는 TrafficServer 명령에 포트 번호를 지정하여 시작합니다. \n 통신 처리량 측정 도구에 대한 자세한 내용은 "TrafficClient?"라고 입력하면 표시됩니다. \n \n ※주의:이 명령은 SoftEther VPN 명령 줄 관리 유틸리티에서 호출 할 수 있습니다. 현재 VPN Server와 VPN Client에서 관리 모드로 접속하는 경우도 실행할 수 있지만 실제로 통신을하고 처리량을 측정하는이 명령을 실행하는 컴퓨터이며 관리 모드로 연결 컴퓨터와도 관계없는 컨텍스트에서 실행됩니다.
 CMD_TrafficServer_Args TrafficServer [port]
-CMD_TrafficServer_ [port 연결을 기다리는 포트 번호를 정수로 지정합니다. 지정된 포트가 이미 다른 프로그램에서 사용 중이거나 포트를 열 수없는 경우 오류가 발생합니다.
+CMD_TrafficServer_[port] 연결을 기다리는 포트 번호를 정수로 지정합니다. 지정된 포트가 이미 다른 프로그램에서 사용 중이거나 포트를 열 수없는 경우 오류가 발생합니다.
 
 
 # TrafficClient/TrafficServer 계 내부 메시지 문자열
@@ -7192,3 +7176,25 @@ SW_LINK_NAME_LANGUAGE_COMMENT %s의 표시 언어를 변경합니다.
 SW_LINK_NAME_DEBUG 디버깅 정보 수집 도구
 SW_LINK_NAME_DEBUG_COMMENT SoftEther VPN 디버깅 정보를 수집합니다. 지원 담당자의 요청이있을 때만 사용하십시오.
 
+
+HUB_AO_DenyAllRadiusLoginWithNoVlanAssign	If you set this option to non-zero value, then all users, which RADIUS server returns no "Tunnel-Pvt-Group-ID" (ID = 81) value, will be denied to connect to the Virtual Hub. (Only if the values of AssignVLanIdByRadiusAttribute is non-zero value.)
+HUB_AO_UseHubNameAsDhcpUserClassOption		If you set this option to non-zero value, then the Virtual Hub Name will be added to a DHCP request to an external DHCP server as the "User-Class" option. This allows to use separate pools of IP addresses for each Virtual Hub. (For only L2TP/IPsec and OpenVPN sessions.)
+CM_VLAN_REINSTALL_MSG	After reinstalling the Virtual Network Adapter driver, the current Virtual Network Adapter's MAC address will change. Also, all TCP/IP settings within the Virtual Network Adapter will reset.\r\n\r\nIn case the reinstalled Virtual Network Adapter fails to work, delete it and create a new one. If it still doesn't work properly, please create a new Virtual Network Adapter with a different name.
+SVC_SEVPNCLIENTDEV_NAME		sevpnclientdev
+SVC_SEVPNCLIENTDEV_TITLE	SoftEther VPN Client Developer Edition
+SVC_SEVPNCLIENTDEV_DESCRIPT	This manages the Virtual Network Adapter device driver and connection service for the SoftEther VPN Client. When this service is stopped, it will not be possible to use SoftEther VPN Client on this computer to connect to a SoftEther VPN Server.
+SVC_SEVPNSERVERDEV_NAME		sevpnserverdev
+SVC_SEVPNSERVERDEV_TITLE	SoftEther VPN Server Developer Edition
+SVC_SEVPNSERVERDEV_DESCRIPT	This manages the server processes of SoftEther VPN Server. SoftEther VPN Server provides high-performance SoftEther VPN Server functions via TCP/IP protocol. When this service is stopped, SoftEther VPN Server on this computer will stop and SoftEther VPN Client will be unable to establish a VPN connection with this computer.
+SVC_SEVPNBRIDGEDEV_NAME		sevpnbridgedev
+SVC_SEVPNBRIDGEDEV_TITLE	SoftEther VPN Bridge Developer Edition
+HUB_AO_UseHubNameAsRadiusNasId		If you set this option to non-zero value, then the NAS-Identifier RADIUS attribute will be set to a name of the Virtual Hub. This allows to determine on RADIUS server whether access to the Virtual Hub should be granted or denied.
+SVC_SEVPNBRIDGEDEV_DESCRIPT	This manages the processes of SoftEther VPN Bridge. SoftEther VPN Bridge provides a bridging connection between the network this computer is connected to and a SoftEther VPN Server that is remotely located. When this service is stopped, SoftEther VPN Bridge on this computer will stop and it will no longer be possible to communicate via the bridge connection.
+SM_SNAT_IS_RAW		Raw IP mode NAT is Active
+LO_CLIENT_CERT		Client certificate received (subject: CN="%s"), will use certificate authentication.
+LO_CLIENT_UNVERIFIED_CERT	Client certificate was provided but did not pass verification (error="%S"), will use password authentication.
+LO_CLIENT_NO_CERT	Client certificate is not provided, will use password authentication.
+LH_AUTH_OPENVPN_CERT	OpenVPN certificate authentication
+CMD_AccessAddEx_REDIRECTURL	The specified URL will be mandatory replied to the client as a response for TCP connecting request packets which matches the conditions of this access list entry via this Virtual Hub. To use this setting, you can enforce the web browser of the VPN Client computer to show the specified web site when that web browser tries to access the specific IP address.
+CMD_AccessAddEx6_REDIRECTURL	The specified URL will be mandatory replied to the client as a response for TCP connecting request packets which matches the conditions of this access list entry via this Virtual Hub. To use this setting, you can enforce the web browser of the VPN Client computer to show the specified web site when that web browser tries to access the specific IP address.
+CMD_TrafficServer_NOHUP		When "yes" is specified, the server process never stops without regard to any input from the console. It is convenient when you want to run the TrafficServer endlessly.

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -2312,7 +2312,6 @@ S_RETRY_NUM_2			times
 S_RETRY_SPAN_1			Reconnect Interval:
 S_RETRY_SPAN_2			seconds
 R_INFINITE				&Infinite Reconnects (Keep VPN Always Online)
-R_NOTLS1				Do not use TLS &1.0
 B_DETAIL				A&dvanced Settings...
 IDOK					&OK
 IDCANCEL				Cancel
@@ -6669,7 +6668,7 @@ CMD_AccountDetailSet_Prompt_BRIDGE	Enable Bridge / Router Mode (yes/no):
 CMD_AccountDetailSet_Prompt_MONITOR	Enable Monitoring Mode (yes/no): 
 CMD_AccountDetailSet_Prompt_NOTRACK	Disable Adjustment of Routing Table (yes/no): 
 CMD_AccountDetailSet_Prompt_NOQOS	 Disable QoS Control Function (yes/no): 
-CMD_AccountDetailSet_Prompt_DISABLEUDP	 Disable UDP Acceleration Function (yes/no): 
+CMD_AccountDetailSet_Prompt_DISABLEUDP	Disable UDP Acceleration Function (yes/no): 
 
 
 # AccountRename command
@@ -7172,3 +7171,24 @@ SW_LINK_NAME_LANGUAGE_COMMENT				Change the display language setting of %s.
 
 SW_LINK_NAME_DEBUG							Debugging Information Collecting Tool
 SW_LINK_NAME_DEBUG_COMMENT					Collects debugging information of SoftEther VPN. Use this tool only if your support staff asks you to do so.
+
+CMD_ACCOUNT_COLUMN_RETRY_ON_SERVER_CERT	Retry on Untrusted Server Certificate
+CMD_TUNDownOnDisconnectEnable	Enable the Turn TUN Interface Down on Client Disconnect Function.
+CMD_TUNDownOnDisconnectEnable_Help	This allows you to enable Turn TUN Interface Down on Client Disconnect Function.
+CMD_TUNDownOnDisconnectEnable_Args	TUNDownOnDisconnectEnable
+CMD_TUNDownOnDisconnectDisable	Disable the Turn TUN Interface Down on Client Disconnect Function.
+CMD_TUNDownOnDisconnectDisable_Help	This allows you to disable Turn TUN Interface Down on Client Disconnect Function.
+CMD_TUNDownOnDisconnectDisable_Args	TUNDownOnDisconnectDisable
+CMD_TUNDownOnDisconnectGet		Get status of the Turn TUN Interface Down on Client Disconnect Function.
+CMD_TUNDownOnDisconnectGet_Help	This allows you to get status of the Turn TUN Interface Down on Client Disconnect Function.
+CMD_TUNDownOnDisconnectGet_Args	TUNDownOnDisconnectGet
+CMD_TUNDownOnDisconnectGet_COLUMN1	Put TUN down on disconnect
+CMD_AccountRetryOnServerCertEnable	Enable VPN connection retry if server certificate is invalid
+CMD_AccountRetryOnServerCertEnable_Help	When a VPN Connection Setting registered on the VPN Client is specified and that VPN Connection Setting connects to a VPN Server, use this to enable the option to retry connection if Server certificate cannot be trusted.
+CMD_AccountRetryOnServerCertEnable_Args	AccountRetryOnServerCertEnable [name]
+CMD_AccountRetryOnServerCertEnable_[name]	Specify the name of the VPN Connection Setting whose setting you want to change.
+CMD_AccountRetryOnServerCertDisable	Enable VPN connection retry if server certificate is invalid
+CMD_AccountRetryOnServerCertDisable_Help	When a VPN Connection Setting registered on the VPN Client is specified and that VPN Connection Setting connects to a VPN Server, use this to disable the option to retry connection if Server certificate cannot be trusted.
+CMD_AccountRetryOnServerCertDisable_Args	AccountRetryOnServerCertEnable [name]
+CMD_AccountRetryOnServerCertDisable_[name]	Specify the name of the VPN Connection Setting whose setting you want to change.
+

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -955,7 +955,7 @@ CM_ACCOUNT_FILE_BANNER	# VPN Client 連接設置檔案\r\n# \r\n# 此檔案是�
 CM_FAILED_TO_OPEN_FILE	無法打開檔案。
 CM_FAILED_TO_SAVE_FILE	無法保存檔案。
 CM_ACCOUNT_PARSE_FAILED	無法從指定檔案裝載 VPN 連接設置。\r\n請檢查檔案內容。
-CM_ACCOUNT_MSG_SENSITIVE此 VPN 連接設置有用戶名和密碼。\r\n您想從匯出的設置檔中刪除這些敏感資訊嗎？\r\n\r\n按一下“是”以刪除敏感資訊。\r\n在這種情況下，當他正試圖連接到 VPN Server 時，使用者需要輸入用戶名和密碼。\r\n\r\n按一下“否”將敏感資訊留在檔內。
+CM_ACCOUNT_MSG_SENSITIVE	此 VPN 連接設置有用戶名和密碼。\r\n您想從匯出的設置檔中刪除這些敏感資訊嗎？\r\n\r\n按一下“是”以刪除敏感資訊。\r\n在這種情況下，當他正試圖連接到 VPN Server 時，使用者需要輸入用戶名和密碼。\r\n\r\n按一下“否”將敏感資訊留在檔內。
 CM_SHORTCUT_FILE		快捷方式檔案|*.lnk
 CM_SHORTCUT_SAVE_TITLE	輸入快捷方式檔案名。
 CM_SHORTCUT_UNSUPPORTED	該連接的快捷方式的功能不支援此 VPN Client 的版本。\r\n更新到新版本。
@@ -6712,6 +6712,8 @@ CMD_AccountDetailSet_Prompt_BRIDGE	啟用橋/路由器模式 (yes/no):
 CMD_AccountDetailSet_Prompt_MONITOR	啟用監控模式 (yes/no): 
 CMD_AccountDetailSet_Prompt_NOTRACK	禁用路由表項調節器 (yes/no): 
 CMD_AccountDetailSet_Prompt_NOQOS	禁用 QoS 控制功能 (yes/no): 
+CMD_AccountDetailSet_DISABLEUDP Specify "yes" when disabling UDP acceleration function. Normally "no" is specified.
+CMD_AccountDetailSet_Prompt_DISABLEUDP   Disable UDP Acceleration Function (yes/no):
 
 
 # AccountRename 命令


### PR DESCRIPTION
Changes proposed in this pull request:
 -  sync localization files before merging PR#712


Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

