### PR TITLE
src/Cedar: resolve possible null pointer dereference and silence dead code warning

### DIFF
--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -1869,6 +1869,7 @@ BEGIN_LISTENER:
 			// If the port cannot be opened
 			if (cn_next_allow <= Tick64())
 			{
+#ifdef  OS_WIN32
 				if (cursor_changed)
 				{
 					// It can be judged to have the rights to open the port
@@ -1876,6 +1877,7 @@ BEGIN_LISTENER:
 					// So, take over the port which is owned by other process forcibly
 					CncReleaseSocket();
 				}
+#endif  // OS_WIN32
 
 				if (cn_listener->Halt)
 				{

--- a/src/Cedar/Hub.c
+++ b/src/Cedar/Hub.c
@@ -3782,7 +3782,7 @@ LABEL_TRY_AGAIN:
 
 	if (no_parse_dhcp == false && packet != NULL)
 	{
-		if (hub->Option != NULL && hub->Option->RemoveDefGwOnDhcpForLocalhost)
+		if (hub != NULL && hub->Option != NULL && hub->Option->RemoveDefGwOnDhcpForLocalhost)
 		{
 			// Remove the designation of the DHCP server from the DHCP response packet addressed to localhost
 			if (packet->TypeL7 == L7_DHCPV4)


### PR DESCRIPTION
SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

