### PR TITLE
cmake: compare PROJECT_VERSION against src/CurrentBuild.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,20 @@ if(EXISTS "${SoftEtherVPN_SOURCE_DIR}/.git" AND NOT EXISTS "${SoftEtherVPN_SOURC
     message (FATAL_ERROR "Submodules are not initialized. Run\n\tgit submodule update --init --recursive")
 endif()
 
+# Compare ${PROJECT_VERSION} and src/CurrentBuild.txt
+file(READ ${SoftEtherVPN_SOURCE_DIR}/src/CurrentBuild.txt CurrentBuild)
+
+string(REGEX MATCH "VERSION_MAJOR ([0-9]+)" temp ${CurrentBuild})
+string(REGEX REPLACE "VERSION_MAJOR ([0-9]+)" "\\1" CurrentBuild_MAJOR ${temp})
+string(REGEX MATCH "VERSION_MINOR ([0-9]+)" temp ${CurrentBuild})
+string(REGEX REPLACE "VERSION_MINOR ([0-9]+)" "\\1" CurrentBuild_MINOR ${temp})
+string(REGEX MATCH "VERSION_BUILD ([0-9]+)" temp ${CurrentBuild})
+string(REGEX REPLACE "VERSION_BUILD ([0-9]+)" "\\1" CurrentBuild_BUILD ${temp})
+
+if (NOT ${PROJECT_VERSION} VERSION_EQUAL "${CurrentBuild_MAJOR}.${CurrentBuild_MINOR}.${CurrentBuild_BUILD}")
+  message (FATAL_ERROR "PROJECT_VERSION does not match to src/CurrentBuild.txt")
+endif()
+
 set(BUILD_DIRECTORY ${SoftEtherVPN_SOURCE_DIR}/build)
 
 add_subdirectory(src)


### PR DESCRIPTION
SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

