### PR TITLE
BridgeUnix.c: enable local bridge function on all BSD systems

### DIFF
--- a/src/Cedar/BridgeUnix.c
+++ b/src/Cedar/BridgeUnix.c
@@ -270,12 +270,10 @@ bool IsEthSupported()
 
 #if	defined(UNIX_LINUX)
 	return IsEthSupportedLinux();
+#elif	defined(UNIX_BSD)
+	return true;
 #elif	defined(UNIX_SOLARIS)
 	return IsEthSupportedSolaris();
-#elif	defined(BRIDGE_PCAP)
-	return true;
-#elif	defined(BRIDGE_BPF)
-	return true;
 #else
 	return false;
 #endif


### PR DESCRIPTION
Fixes #723.

Local bridge support for BSD systems was added in #670 and #706.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.