### PR TITLE
AUTHORS.TXT: update contributors list using "git log --format='%aN <%aE>' | sort -f | uniq"

### DIFF
--- a/AUTHORS.TXT
+++ b/AUTHORS.TXT
@@ -53,150 +53,81 @@ DEVELOPMENT BOARD MEMBERS:
     https://github.com/chipitsine
 
 
-CONTRIBUTORS on GitHub:
-
-  - Melvyn
-    https://github.com/yaurthek
-
-  - nattoheaven
-    https://github.com/nattoheaven
-
-  - ELIN
-    https://github.com/el1n
-
-  - Dmitry Orlov
-    https://github.com/mosquito
-
-  - Renaud Allard
-    https://github.com/renaudallard
-
-  - Hideki Saito
-    https://github.com/hsaito
-
-  - Dexter Ang
-    https://github.com/thepoch
-
-  - YF
-    https://github.com/yfdyh000
-
-  - Sahal Ansari
-    https://github.com/sahal
-
-  - ygrek
-    https://github.com/ygrek
-
-  - ajee cai
-    https://github.com/ajeecai
-
-  - NOKUBI Takatsugu
-    https://github.com/knok
-
-  - Den Lesnov
-    https://github.com/Leden
-
-  - Matt Lewandowsky
-    https://github.com/lewellyn
-
-  - Raymond Tau
-    https://github.com/rtau
-
-  - Luiz Eduardo Gava
-    https://github.com/LegDog
-
-  - Charles Surett
-    https://github.com/scj643
-
-  - Jeff Tang
-    https://github.com/mrjefftang
-
-  - Victor Salgado
-    https://github.com/mcsalgado
-
-  - micsell
-    https://github.com/micsell
-
-  - yehorov
-    https://github.com/yehorov
-
-  - dglushenok
-    https://github.com/dglushenok
-
-  - NoNameA 774
-    https://github.com/nna774
-
-  - Alexandre De Oliveira
-    https://github.com/yodresh
-
-  - Bernhard Rosenkraenzer
-    https://github.com/berolinux
-
-  - Sacha Bernstein
-    https://github.com/sacha
-
-  - cm0x4D
-    https://github.com/cm0x4D
-
-  - DDGo
-    https://github.com/DDGo
-
-  - Noah O'Donoghue
-    https://github.com/NoahO
-
-  - rel22
-    https://github.com/rel22
-
-  - Guanzhong Chen
-    https://github.com/quantum5
-
-  - Nguyễn Hồng Quân
-    https://github.com/hongquan
-
-  - macvk
-    https://github.com/macvk
+SPECIAL CONTRIBUTORS:
 
   - Guido Vranken
     https://github.com/guidovranken
 
-  - Maks Naumov
-    https://github.com/maksqwe
-    
-  - nvsofts
-    https://github.com/nvsofts
 
-  - Quintin Beukes
-    https://github.com/qbeukes 
+CONTRIBUTORS:
 
-  - Diego Schulz
-    https://github.com/dschulz
+  - ajeecai <ajee.cai@gmail.com>
+  - Alexandre De Oliveira <yodresh@gmail.com>
+  - Alexey Kryuchkov <alexey.kruchkov@gmail.com>
+  - Allen Cui <allen_st_clair@msn.com>
+  - Andy Walsh <andy.walsh44+github@gmail.com>
+  - Bernhard Rosenkränzer <bero@lindev.ch>
+  - Bill Welliver <bill@welliver.org>
+  - Charles Surett <surettcharles@gmail.com>
+  - cm0x4d <cm0x4d@codemonkey.ch>
+  - DDGo <Wiki13@hotmail.nl>
+  - Denis Lesnov <den.lesnov@gmail.com>
+  - Den Lesnov <https://github.com/Leden>
+  - Dexter Ang <thepoch@gmail.com>
+  - Dmitry Glushenok <dglushenok@yandex.ru>
+  - Dmitry Orlov <dorlov@undev.ru>
+  - ELIN <elin@mikomoe.jp>
+  - Guanzhong Chen <quantum2048@gmail.com>
+  - Hideki Saito <hideki@hidekisaito.com>
+  - holoreimu <michael3707@gmail.com>
+  - Holoreimu <michael3707@gmail.com>
+  - hoppler <https://github.com/hoppler>
+  - Igor Pikovets <igor@ahrefs.com>
+  - James Brink <brink.james@gmail.com>
+  - Jeff Tang <https://github.com/mrjefftang>
+  - Jioh L. Jung <ziozzang@gmail.com>
+  - Johan de Vries <devries@wivion.nl>
+  - Josh Soref <https://github.com/jsoref>
+  - Joshua Perry <josh@6bit.com>
+  - Luiz Eduardo Gava <luiz.gava@procempa.com.br>
+  - macvk <tutumbul@gmail.com>
+  - Maks Naumov <maksqwe1@ukr.net>
+  - Matt Lewandowsky <lewellyn@foxmail.com>
+  - Max Miroshnikov <mogikanin.tir@gmail.com>
+  - Melvyn <yaurthek@gmail.com>
+  - Michael B <https://github.com/DownWithUp>
+  - Michael Clausen <cm0x4d@codemonkey.ch>
+  - Michael Clausen <michael.clausen@hevs.ch>
+  - Mike Selivanov <mikes777@gmail.com>
+  - Mikhail Pridushchenko <mikhail.pridushchenko@dsr-company.com>
+  - mogikanin <mogikanin.tir@gmail.com>
+  - Mykhaylo Yehorov <yehorov@gmail.com>
+  - nattoheaven <nattoheaven@gmail.com>
+  - Nguyễn Hồng Quân <ng.hong.quan@gmail.com>
+  - Noah O'Donoghue <https://github.com/NoahO>
+  - NOKUBI Takatsugu <knok@daionet.gr.jp>
+  - NoNameA 774 <nonamea774@gmail.com>
+  - Norbert Preining <norbert@preining.info>
+  - NV <nvsofts@gmail.com>
+  - Olimjon <olim98@bk.ru>
+  - parly <https://github.com/parly>
+  - Quantum <quantum2048@gmail.com>
+  - Quintin <quintin@last.za.net>
+  - Raymond Tau <raymondtau@gmail.com>
+  - rel22 <rel22@inbox.ru>
+  - Renaud Allard <renaud@allard.it>
+  - root <root@vpn.sjbcom.com>
+  - Sacha J Bernstein <sacha@sjbcom.com>
+  - Sahal Ansari <github@sahal.info>
+  - Shadus Black <blackholefoxdev@gmail.com>
+  - thepyper <thepyper@gmail.com>
+  - Tim Schneider <schneider0tim@gmail.com>
+  - tonychung00 <tonychung00@gmail.com>
+  - Victor Salgado <vms@pinhaotec.com.br>
+  - William Welliver <william@welliver.org>
+  - YF <yfdyh000@gmail.com>
 
-  - Holoreimu
-    https://github.com/holoreimu
 
-  - Ryoga
-    https://github.com/proelbtn
-
-  - parly
-    https://github.com/parly
-
-  - Alexey Kryuchkov
-    https://github.com/a-kr
-
-  - tidatida
-    https://github.com/tidatida
-
-  - Tim Schneider
-    https://github.com/timschneider
-
-  - Max Miroshnikov
-    https://github.com/mogikanin
-
-  - Josh Soref
-    https://github.com/jsoref
-
-  - Norbert Preining
-    https://github.com/norbusan
-
-       
 JOIN THE SOFTETHER VPN DEVELOPMENT
 ----------------------------------
 


### PR DESCRIPTION
This pull request updates the contributors list and changes the format to the one used by Git, with the output of the command `git log --format='%aN <%aE>' | sort -f | uniq`.

Email addresses ending with `@users.noreply.github.com` are replaced with the GitHub profile links.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.