### PR TITLE
Add string for "IF_TYPE_PROP_VIRTUAL" network interface type

### DIFF
--- a/src/Mayaqua/Microsoft.c
+++ b/src/Mayaqua/Microsoft.c
@@ -3119,6 +3119,10 @@ wchar_t *MsGetAdapterTypeStr(UINT type)
 
 	switch (type)
 	{
+	case IF_TYPE_PROP_VIRTUAL:
+		ret = _UU("MS_VIRTUAL");
+		break;
+
 	case MIB_IF_TYPE_ETHERNET:
 		ret = _UU("MS_ETHERNET");
 		break;

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -2102,6 +2102,7 @@ L3_SWITCH_STOP				虚拟 3 层交换机 "%S" 终止。
 
 
 #关于Microsoft.c
+MS_VIRTUAL					专有的虚拟/内部接口
 MS_ETHERNET					以太网接口
 MS_TOKENRING				令牌环接口
 MS_FDDI						FDDI 接口

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -2082,6 +2082,7 @@ L3_SWITCH_STOP			The Virtual Layer 3 Switch "%S" terminated.
 
 
 # Concerning Microsoft.c
+MS_VIRTUAL				Proprietary Virtual/Internal Interface
 MS_ETHERNET				Ethernet Interface
 MS_TOKENRING			Token Ring Interface
 MS_FDDI					FDDI Interface

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -2086,6 +2086,7 @@ L3_SWITCH_STOP			仮想レイヤ 3 スイッチ "%S" が終了しました。
 
 
 # Microsoft.c 関係
+MS_VIRTUAL				独自の仮想/内部インタフェース
 MS_ETHERNET				Ethernet インターフェイス
 MS_TOKENRING			トークンリングインターフェイス
 MS_FDDI					FDDI インターフェイス

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -2063,6 +2063,7 @@ L3_SWITCH_STOP 가상 레이어 3 스위치 "%S"가 종료되었습니다.
 
 
 # Microsoft.c 관계
+MS_VIRTUAL 독점적 인 가상 / 내부 인터페이스
 MS_ETHERNET Ethernet 인터페이스
 MS_TOKENRING 토큰 링 인터페이스
 MS_FDDI FDDI 인터페이스

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -2082,6 +2082,7 @@ L3_SWITCH_STOP			The Virtual Layer 3 Switch "%S" terminated.
 
 
 # Concerning Microsoft.c
+MS_VIRTUAL				Proprietary Virtual/Internal Interface
 MS_ETHERNET				Ethernet Interface
 MS_TOKENRING			Token Ring Interface
 MS_FDDI					FDDI Interface

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -2103,6 +2103,7 @@ L3_SWITCH_STOP			虛擬 3 層交換機 "%S" 終止。
 
 
 #關於Microsoft.c
+MS_VIRTUAL				专有的虚拟/内部接口
 MS_ETHERNET				網路介面
 MS_TOKENRING			標記環介面
 MS_FDDI					FDDI 介面


### PR DESCRIPTION
The network interface adapter's type has been set to `IF_TYPE_PROP_VIRTUAL` in #508.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.