### PR TITLE
Debug flag and test mode improvements

### DIFF
--- a/src/Cedar/SW.c
+++ b/src/Cedar/SW.c
@@ -783,8 +783,11 @@ UINT SWExec()
 		MayaquaMinimalMode();
 	}
 
-#ifdef DEBUG
-	InitMayaqua(true, true, 0, NULL);
+#if defined(_DEBUG) || defined(DEBUG)	// In VC++ compilers, the macro is "_DEBUG", not "DEBUG".
+	// If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
+	// For normal debug we set memcheck = false.
+	// Please set memcheck = true if you want to test the cause of memory leaks.
+	InitMayaqua(false, true, 0, NULL);
 #else
 	InitMayaqua(false, false, 0, NULL);
 #endif

--- a/src/Mayaqua/Microsoft.c
+++ b/src/Mayaqua/Microsoft.c
@@ -4569,8 +4569,11 @@ void CALLBACK MsServiceDispatcher(DWORD argc, LPTSTR *argv)
 
 	//// Initialization
 	// Start of the Mayaqua
-#ifdef DEBUG
-	InitMayaqua(true, true, 0, NULL);
+#if defined(_DEBUG) || defined(DEBUG)	// In VC++ compilers, the macro is "_DEBUG", not "DEBUG".
+	// If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
+	// For normal debug we set memcheck = false.
+	// Please set memcheck = true if you want to test the cause of memory leaks.
+	InitMayaqua(false, true, 0, NULL);
 #else
 	InitMayaqua(false, false, 0, NULL);
 #endif
@@ -4748,8 +4751,11 @@ UINT MsService(char *name, SERVICE_FUNCTION *start, SERVICE_FUNCTION *stop, UINT
 	}
 
 	// Start of the Mayaqua
-#ifdef DEBUG
-	InitMayaqua(true, true, 0, NULL);
+#if defined(_DEBUG) || defined(DEBUG)	// In VC++ compilers, the macro is "_DEBUG", not "DEBUG".
+	// If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
+	// For normal debug we set memcheck = false.
+	// Please set memcheck = true if you want to test the cause of memory leaks.
+	InitMayaqua(false, true, 0, NULL);
 #else
 	InitMayaqua(false, false, 0, NULL);
 #endif

--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -2766,7 +2766,10 @@ RESTART_PROCESS:
 	else if (argc >= 3 && StrCmpi(argv[1], UNIX_SVC_ARG_START) == 0 && StrCmpi(argv[2], UNIX_SVC_ARG_FOREGROUND) == 0)
 	{
 #ifdef DEBUG
-		InitMayaqua(true, true, argc, argv);
+		// If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
+		// For normal debug we set memcheck = false.
+		// Please set memcheck = true if you want to test the cause of memory leaks.
+		InitMayaqua(false, true, argc, argv);
 #else
 		InitMayaqua(false, false, argc, argv);
 #endif
@@ -2786,7 +2789,10 @@ void UnixServiceMain(int argc, char *argv[], char *name, SERVICE_FUNCTION *start
 	UINT mode = 0;
 	// Start of the Mayaqua
 #ifdef DEBUG
-	InitMayaqua(true, true, argc, argv);
+	// If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
+	// For normal debug we set memcheck = false.
+	// Please set memcheck = true if you want to test the cause of memory leaks.
+	InitMayaqua(false, true, argc, argv);
 #else
 	InitMayaqua(false, false, argc, argv);
 #endif

--- a/src/vpncmd/vpncmd.c
+++ b/src/vpncmd/vpncmd.c
@@ -143,8 +143,11 @@ int main(int argc, char *argv[])
 	SetConsoleTitleA(CEDAR_PRODUCT_STR " VPN Command Line Utility");
 #endif	// OS_WIN32
 
-#ifdef DEBUG
-	InitMayaqua(true, true, argc, argv);
+#if defined(_DEBUG) || defined(DEBUG)	// In VC++ compilers, the macro is "_DEBUG", not "DEBUG".
+	// If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
+	// For normal debug we set memcheck = false.
+	// Please set memcheck = true if you want to test the cause of memory leaks.
+	InitMayaqua(false, true, argc, argv);
 #else
 	InitMayaqua(false, false, argc, argv);
 #endif

--- a/src/vpncmgr/vpncmgr.c
+++ b/src/vpncmgr/vpncmgr.c
@@ -136,8 +136,11 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	InitProcessCallOnce();
 
-#ifdef DEBUG
-	InitMayaqua(true, true, 0, NULL);
+#if defined(_DEBUG) || defined(DEBUG)	// In VC++ compilers, the macro is "_DEBUG", not "DEBUG".
+	// If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
+	// For normal debug we set memcheck = false.
+	// Please set memcheck = true if you want to test the cause of memory leaks.
+	InitMayaqua(false, true, 0, NULL);
 #else
 	InitMayaqua(false, false, 0, NULL);
 #endif

--- a/src/vpndrvinst/vpndrvinst.c
+++ b/src/vpndrvinst/vpndrvinst.c
@@ -355,8 +355,11 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	InitProcessCallOnce();
 
-#ifdef DEBUG
-	InitMayaqua(true, true, 0, NULL);
+#if defined(_DEBUG) || defined(DEBUG)	// In VC++ compilers, the macro is "_DEBUG", not "DEBUG".
+	// If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
+	// For normal debug we set memcheck = false.
+	// Please set memcheck = true if you want to test the cause of memory leaks.
+	InitMayaqua(false, true, 0, NULL);
 #else
 	InitMayaqua(false, false, 0, NULL);
 #endif

--- a/src/vpninstall/vpninstall.c
+++ b/src/vpninstall/vpninstall.c
@@ -1635,13 +1635,16 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	INSTANCE *instance;
 	InitProcessCallOnce();
-#ifdef DEBUG
+#if defined(_DEBUG) || defined(DEBUG)	// In VC++ compilers, the macro is "_DEBUG", not "DEBUG".
 	is_debug = true;
 #else
 	is_debug = false;
 #endif
 	MayaquaMinimalMode();
-	InitMayaqua(is_debug, is_debug, 0, NULL);
+	// If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
+	// For normal debug we set memcheck = false.
+	// Please set memcheck = true if you want to test the cause of memory leaks.
+	InitMayaqua(false, is_debug, 0, NULL);
 	InitCedar();
 	ViSetSkip();
 	ViLoadStringTables();

--- a/src/vpnsmgr/vpnsmgr.c
+++ b/src/vpnsmgr/vpnsmgr.c
@@ -134,8 +134,11 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 {
 	InitProcessCallOnce();
 
-#ifdef DEBUG
-	InitMayaqua(true, true, 0, NULL);
+#if defined(_DEBUG) || defined(DEBUG)	// In VC++ compilers, the macro is "_DEBUG", not "DEBUG".
+	// If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
+	// For normal debug we set memcheck = false.
+	// Please set memcheck = true if you want to test the cause of memory leaks.
+	InitMayaqua(false, true, 0, NULL);
 #else
 	InitMayaqua(false, false, 0, NULL);
 #endif


### PR DESCRIPTION
1. ifdef DEBUG -> defined(_DEBUG) || defined(DEBUG)
In VC++ compilers, the macro is "_DEBUG", not "DEBUG".

2. If set memcheck = true, the program will be vitally slow since it will log all malloc() / realloc() / free() calls to find the cause of memory leak.
For normal debug we set memcheck = false.
Please set memcheck = true if you want to test the cause of memory leaks.



Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

-

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

