### PR TITLE
Memory.c: fix pointer cast in TrackChangeObjSize() call

### DIFF
--- a/src/Mayaqua/Memory.c
+++ b/src/Mayaqua/Memory.c
@@ -3915,7 +3915,7 @@ void *InternalReAlloc(void *addr, UINT size)
 	}
 
 #ifndef	DONT_USE_KERNEL_STATUS
-	TrackChangeObjSize((DWORD)addr, size, (DWORD)new_addr);
+	TrackChangeObjSize(POINTER_TO_UINT64(addr), size, POINTER_TO_UINT64(new_addr));
 #endif	// DONT_USE_KERNEL_STATUS
 
 	return new_addr;


### PR DESCRIPTION
This pull request fixes the `TrackDeleteObj: 0x12345678 is not Object!!` (where `0x12345678` is the actual address) errors with `memcheck` enabled .

It also fixes the following related warnings:
```
warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  TrackChangeObjSize((DWORD)addr, size, (DWORD)new_addr);
                     ^
warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  TrackChangeObjSize((DWORD)addr, size, (DWORD)new_addr);
                                        ^
```

---
SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.