### PR TITLE
CMake: build all targets in the same directory, so that "hamcore.se2" doesn't have to be copied for each of them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
       script:
         - ./configure
         - make -C tmp
-        - otool -L build/vpnserver/vpnserver
+        - otool -L build/vpnserver
         - sudo make -C tmp install
 
 addons:
@@ -83,6 +83,6 @@ script:
   - export LDFLAGS="-L${HOME}/opt/lib"
   - ./configure
   - make -C tmp
-  - ldd build/vpnserver/vpnserver
+  - ldd build/vpnserver
   - sudo LD_LIBRARY_PATH="${HOME}/opt/lib:${LD_LIBRARY_PATH:-}" make -C tmp install
   - if [ "${BUILD_DEB}" = "1" ]; then make package -C tmp; fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,105 +101,27 @@ add_subdirectory(hamcorebuilder)
 
 # vpnserver
 add_subdirectory(vpnserver)
-get_target_property(VPNSERVER_RUNTIME_OUTPUT_DIRECTORY vpnserver RUNTIME_OUTPUT_DIRECTORY)
 
 # vpnclient
 add_subdirectory(vpnclient)
-get_target_property(VPNCLIENT_RUNTIME_OUTPUT_DIRECTORY vpnclient RUNTIME_OUTPUT_DIRECTORY)
 
 # vpnbridge
 add_subdirectory(vpnbridge)
-get_target_property(VPNBRIDGE_RUNTIME_OUTPUT_DIRECTORY vpnbridge RUNTIME_OUTPUT_DIRECTORY)
 
 # vpncmd
 add_subdirectory(vpncmd)
-get_target_property(VPNCMD_RUNTIME_OUTPUT_DIRECTORY vpncmd RUNTIME_OUTPUT_DIRECTORY)
 
 # vpntest
 add_subdirectory(vpntest)
-get_target_property(VPNTEST_RUNTIME_OUTPUT_DIRECTORY vpntest RUNTIME_OUTPUT_DIRECTORY)
 
 # hamcore.se2 archive file
 add_custom_target(hamcore-archive-build
   ALL
-  COMMAND hamcorebuilder ${CMAKE_SOURCE_DIR}/src/bin/hamcore/ ${CMAKE_SOURCE_DIR}/tmp/hamcore.se2
+  COMMAND hamcorebuilder "${CMAKE_SOURCE_DIR}/src/bin/hamcore/" "${BUILD_DIRECTORY}/hamcore.se2"
   DEPENDS hamcorebuilder
   COMMENT "Building hamcore.se2 archive file..."
   VERBATIM
 )
-
-# Copy hamcore.se2 to vpnserver's directory
-add_custom_command(TARGET hamcore-archive-build
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/tmp/hamcore.se2 ${VPNSERVER_RUNTIME_OUTPUT_DIRECTORY}
-)
-
-# Copy hamcore.se2 to vpnclient's directory
-add_custom_command(TARGET hamcore-archive-build
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/tmp/hamcore.se2 ${VPNCLIENT_RUNTIME_OUTPUT_DIRECTORY}
-)
-
-# Copy hamcore.se2 to vpnbridge's directory
-add_custom_command(TARGET hamcore-archive-build
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/tmp/hamcore.se2 ${VPNBRIDGE_RUNTIME_OUTPUT_DIRECTORY}
-)
-
-# Copy hamcore.se2 to vpncmd's directory
-add_custom_command(TARGET hamcore-archive-build
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/tmp/hamcore.se2 ${VPNCMD_RUNTIME_OUTPUT_DIRECTORY}
-)
-
-# Copy hamcore.se2 to vpntest's directory
-add_custom_command(TARGET hamcore-archive-build
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/tmp/hamcore.se2 ${VPNTEST_RUNTIME_OUTPUT_DIRECTORY}
-)
-
-# Copy "vpnserver" directory to /usr/lib(exec)/softether/, install launch script and systemd service
-install(DIRECTORY ${VPNSERVER_RUNTIME_OUTPUT_DIRECTORY}
-  COMPONENT "vpnserver"
-  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether"
-  PATTERN "*"
-  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-)
-
-install_wrapper_script("vpnserver" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnserver/vpnserver")
-install_systemd_service("vpnserver" "${CMAKE_SOURCE_DIR}/systemd/softether-vpnserver.service" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnserver/vpnserver")
-
-# Copy "vpnclient" directory to /usr/lib(exec)/softether/, install launch script and systemd service
-install(DIRECTORY ${VPNCLIENT_RUNTIME_OUTPUT_DIRECTORY}
-  COMPONENT "vpnclient"
-  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether"
-  PATTERN "*"
-  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-)
-
-install_wrapper_script("vpnclient" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnclient/vpnclient")
-install_systemd_service("vpnclient" "${CMAKE_SOURCE_DIR}/systemd/softether-vpnclient.service" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnclient/vpnclient")
-
-# Copy "vpnbridge" directory to /usr/lib(exec)/softether/, install launch script and systemd service
-install(DIRECTORY ${VPNBRIDGE_RUNTIME_OUTPUT_DIRECTORY}
-  COMPONENT "vpnbridge"
-  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether"
-  PATTERN "*"
-  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-)
-
-install_wrapper_script("vpnbridge" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnbridge/vpnbridge")
-install_systemd_service("vpnbridge" "${CMAKE_SOURCE_DIR}/systemd/softether-vpnbridge.service" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnbridge/vpnbridge")
-
-# Copy "vpncmd" directory to /usr/lib(exec)/softether/, install launch script and systemd service
-install(DIRECTORY ${VPNCMD_RUNTIME_OUTPUT_DIRECTORY}
-  COMPONENT "vpncmd"
-  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether"
-  PATTERN "*"
-  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-)
-
-install_wrapper_script("vpncmd" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpncmd/vpncmd")
 
 # Print message after installing the targets
 install(CODE "message(\"\n----------------------------------------------------------------------------------------------------------------------------\")")

--- a/src/vpnbridge/CMakeLists.txt
+++ b/src/vpnbridge/CMakeLists.txt
@@ -2,9 +2,25 @@ add_executable(vpnbridge vpnbridge.c)
 
 set_target_properties(vpnbridge
   PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpnbridge"
-  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpnbridge"
-  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpnbridge"
+  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
 target_link_libraries(vpnbridge cedar mayaqua)
+
+# Copy binary and "hamcore.se2" to /usr/lib(exec)/softether/, install launch script and systemd service
+install(TARGETS vpnbridge
+  COMPONENT "vpnbridge"
+  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether/vpnbridge"
+  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)
+
+install(FILES "${BUILD_DIRECTORY}/hamcore.se2"
+  COMPONENT "vpnbridge"
+  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether/vpnbridge"
+  PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+)
+
+install_wrapper_script("vpnbridge" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnbridge/vpnbridge")
+install_systemd_service("vpnbridge" "${CMAKE_SOURCE_DIR}/systemd/softether-vpnbridge.service" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnbridge/vpnbridge")

--- a/src/vpnclient/CMakeLists.txt
+++ b/src/vpnclient/CMakeLists.txt
@@ -2,9 +2,25 @@ add_executable(vpnclient vpncsvc.c)
 
 set_target_properties(vpnclient
   PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpnclient"
-  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpnclient"
-  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpnclient"
+  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
 target_link_libraries(vpnclient cedar mayaqua)
+
+# Copy binary and "hamcore.se2" to /usr/lib(exec)/softether/, install launch script and systemd service
+install(TARGETS vpnclient
+  COMPONENT "vpnclient"
+  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether/vpnclient"
+  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)
+
+install(FILES "${BUILD_DIRECTORY}/hamcore.se2"
+  COMPONENT "vpnclient"
+  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether/vpnclient"
+  PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+)
+
+install_wrapper_script("vpnclient" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnclient/vpnclient")
+install_systemd_service("vpnclient" "${CMAKE_SOURCE_DIR}/systemd/softether-vpnclient.service" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnclient/vpnclient")

--- a/src/vpncmd/CMakeLists.txt
+++ b/src/vpncmd/CMakeLists.txt
@@ -2,9 +2,24 @@ add_executable(vpncmd vpncmd.c)
 
 set_target_properties(vpncmd
   PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpncmd"
-  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpncmd"
-  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpncmd"
+  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
 target_link_libraries(vpncmd cedar mayaqua)
+
+# Copy binary and "hamcore.se2" to /usr/lib(exec)/softether/, install launch script
+install(TARGETS vpncmd
+  COMPONENT "vpncmd"
+  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether/vpncmd"
+  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)
+
+install(FILES "${BUILD_DIRECTORY}/hamcore.se2"
+  COMPONENT "vpncmd"
+  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether/vpncmd"
+  PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+)
+
+install_wrapper_script("vpncmd" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpncmd/vpncmd")

--- a/src/vpnserver/CMakeLists.txt
+++ b/src/vpnserver/CMakeLists.txt
@@ -2,9 +2,25 @@ add_executable(vpnserver vpnserver.c)
 
 set_target_properties(vpnserver
   PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpnserver"
-  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpnserver"
-  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpnserver"
+  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
 target_link_libraries(vpnserver cedar mayaqua)
+
+# Copy binary and "hamcore.se2" to /usr/lib(exec)/softether/, install launch script and systemd service
+install(TARGETS vpnserver
+  COMPONENT "vpnserver"
+  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether/vpnserver"
+  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)
+
+install(FILES "${BUILD_DIRECTORY}/hamcore.se2"
+  COMPONENT "vpnserver"
+  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/softether/vpnserver"
+  PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+)
+
+install_wrapper_script("vpnserver" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnserver/vpnserver")
+install_systemd_service("vpnserver" "${CMAKE_SOURCE_DIR}/systemd/softether-vpnserver.service" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnserver/vpnserver")

--- a/src/vpntest/CMakeLists.txt
+++ b/src/vpntest/CMakeLists.txt
@@ -2,9 +2,9 @@ add_executable(vpntest vpntest.c vpntest.h)
 
 set_target_properties(vpntest
   PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpntest"
-  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpntest"
-  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}/vpntest"
+  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
 target_link_libraries(vpntest cedar mayaqua)


### PR DESCRIPTION
This results in a faster build and less space required.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.