### PR TITLE
Protocol.c: fix crash with OpenVPN when the certificate's common name is empty

### DIFF
--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -7094,8 +7094,7 @@ PACK *PackLoginWithOpenVPNCertificate(char *hubname, char *username, X *x)
 		{
 			return NULL;
 		}
-		wcstombs(cn_username, x->subject_name->CommonName, 127);
-		cn_username[127] = '\0';
+		UniToStr(cn_username, sizeof(cn_username), x->subject_name->CommonName);
 		PackAddStr(p, "username", cn_username);
 	}
 	else


### PR DESCRIPTION
Fixes #758.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.