### PR TITLE
CMake: build Cedar and Mayaqua as shared libraries, create "common" package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(BUILD_DIRECTORY ${SoftEtherVPN_SOURCE_DIR}/build)
 add_subdirectory(src)
 
 # Packaging
-set(CPACK_COMPONENTS_ALL vpnserver vpnclient vpnbridge vpncmd)
+set(CPACK_COMPONENTS_ALL common vpnserver vpnclient vpnbridge vpncmd)
 set(CPACK_PACKAGE_DIRECTORY ${BUILD_DIRECTORY})
 set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
 set(CPACK_PACKAGE_VENDOR "SoftEther")

--- a/src/Cedar/CMakeLists.txt
+++ b/src/Cedar/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(Curses REQUIRED)
 target_link_libraries(cedar PRIVATE ${LIB_READLINE} ${CURSES_LIBRARIES})
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-  target_link_libraries(cedar PRIVATE pcap)
+  target_link_libraries(cedar PRIVATE mayaqua pcap)
 endif()
 
 # Version

--- a/src/Cedar/CMakeLists.txt
+++ b/src/Cedar/CMakeLists.txt
@@ -1,22 +1,22 @@
 file(GLOB SOURCES_CEDAR "*.c")
 file(GLOB HEADERS_CEDAR "*.h")
 
-add_library(cedar STATIC ${SOURCES_CEDAR} ${HEADERS_CEDAR})
+add_library(cedar SHARED ${SOURCES_CEDAR} ${HEADERS_CEDAR})
 
 set_target_properties(cedar
   PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp/Cedar"
-  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp/Cedar"
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp/Cedar"
+  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
 find_library(LIB_READLINE readline)
 find_package(Curses REQUIRED)
 
-target_link_libraries(cedar ${LIB_READLINE} ${CURSES_LIBRARIES})
+target_link_libraries(cedar PRIVATE ${LIB_READLINE} ${CURSES_LIBRARIES})
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-  target_link_libraries(cedar pcap)
+  target_link_libraries(cedar PRIVATE pcap)
 endif()
 
 # Version
@@ -54,3 +54,9 @@ message(STATUS "Build time: ${BUILD_HOUR}:${BUILD_MINUTE}:${BUILD_SECOND}")
 
 add_definitions(-DBUILD_DATE_D=${BUILD_DAY} -DBUILD_DATE_M=${BUILD_MONTH} -DBUILD_DATE_Y=${BUILD_YEAR})
 add_definitions(-DBUILD_DATE_HO=${BUILD_HOUR} -DBUILD_DATE_MI=${BUILD_MINUTE} -DBUILD_DATE_SE=${BUILD_SECOND})
+
+install(TARGETS cedar
+  COMPONENT "common"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+)

--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -1,15 +1,15 @@
 file(GLOB SOURCES_MAYAQUA "*.c")
 file(GLOB HEADERS_MAYAQUA "*.h")
 
-add_library(mayaqua STATIC ${SOURCES_MAYAQUA} ${HEADERS_MAYAQUA})
+add_library(mayaqua SHARED ${SOURCES_MAYAQUA} ${HEADERS_MAYAQUA})
 
 target_include_directories(mayaqua PUBLIC .)
 
 set_target_properties(mayaqua
   PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp/Mayaqua"
-  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp/Mayaqua"
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp/Mayaqua"
+  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
 find_package(OpenSSL REQUIRED)
@@ -21,27 +21,34 @@ find_library(LIB_ICONV iconv)
 
 if(HAVE_SYS_AUXV)
   add_subdirectory(cpu_features)
+  set_property(TARGET cpu_features PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
 target_include_directories(mayaqua PRIVATE cpu_features/include)
 
-target_link_libraries(mayaqua OpenSSL::SSL OpenSSL::Crypto Threads::Threads ZLIB::ZLIB)
+target_link_libraries(mayaqua PRIVATE OpenSSL::SSL OpenSSL::Crypto Threads::Threads ZLIB::ZLIB)
 
 if(HAVE_SYS_AUXV)
-  target_link_libraries(mayaqua cpu_features)
+  target_link_libraries(mayaqua PRIVATE cpu_features)
 else()
   add_definitions(-DSKIP_CPU_FEATURES)
 endif()
 
 find_library(LIB_RT rt)
 if(LIB_RT)
-  target_link_libraries(mayaqua rt)
+  target_link_libraries(mayaqua PRIVATE ${LIB_RT})
 endif()
 
 if(LIB_ICONV)
-  target_link_libraries(mayaqua ${LIB_ICONV})
+  target_link_libraries(mayaqua PRIVATE ${LIB_ICONV})
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
-  target_link_libraries(mayaqua nsl socket)
+  target_link_libraries(mayaqua PRIVATE nsl socket)
 endif()
+
+install(TARGETS mayaqua
+  COMPONENT "common"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)


### PR DESCRIPTION
The binaries can still be run directly from the build directory.

A new package containing the shared libraries is built, but they are not marked as dependencies by CMake. It's something we should fix as soon as possible.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.