### PR TITLE
adjust systemd paths according to installation path

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,8 @@ build_script:
       exit %errorlevel%
   - sh: >-
       ./configure && make package -C tmp
+      dpkg -i build/softether-vpn*.deb
+      systemctl restart softether-vpnserver
 
 artifacts:
   - path: output\pkg\*\*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@
   script:
     - ./configure
     - make package -C tmp
+    - dpkg -i build/softether-vpn*.deb
 
 bionic: 
   <<: *ubuntu_def

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ Check_Include_File(sys/auxv.h HAVE_SYS_AUXV)
 configure_file("${SoftEtherVPN_SOURCE_DIR}/AUTHORS.TXT" "${SoftEtherVPN_SOURCE_DIR}/src/bin/hamcore/authors.txt" COPYONLY)
 
 set(BUILD_DIRECTORY ${SoftEtherVPN_SOURCE_DIR}/build)
+set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 
 add_subdirectory(src)
 
@@ -45,6 +46,8 @@ set(CPACK_PACKAGE_DESCRIPTION_FILE "${SoftEtherVPN_SOURCE_DIR}/description")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SoftEther VPN is an open-source cross-platform multi-protocol VPN program, created as an academic project in the University of Tsukuba.")
 
 # DEB
+file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/postinst" "#!/bin/sh\nldconfig")
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_SOURCE_DIR}/postinst")
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,24 +16,6 @@ macro(install_wrapper_script component target)
   )
 endmacro(install_wrapper_script)
 
-macro(install_systemd_service component file_path binary_path)
-    get_filename_component(file_name ${file_path} NAME)
-    get_filename_component(binary_directory ${binary_path} DIRECTORY)
-
-    file(READ ${file_path} FILE_CONTENT)
-    string(REPLACE "[DIRECTORY]" ${binary_directory} FILE_CONTENT ${FILE_CONTENT})
-    string(REPLACE "[BINARY]" ${binary_path} FILE_CONTENT ${FILE_CONTENT})
-    file(WRITE ${CMAKE_SOURCE_DIR}/tmp/systemd/${file_name} ${FILE_CONTENT})
-
-  if(EXISTS "/lib/systemd/system")
-    install(FILES ${CMAKE_SOURCE_DIR}/tmp/systemd/${file_name}
-      COMPONENT ${component}
-      DESTINATION "/lib/systemd/system"
-      PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-    )
-  endif()
-endmacro(install_systemd_service)
-
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(-D_DEBUG -DDEBUG)
 endif()

--- a/src/vpnbridge/CMakeLists.txt
+++ b/src/vpnbridge/CMakeLists.txt
@@ -23,4 +23,11 @@ install(FILES "${BUILD_DIRECTORY}/hamcore.se2"
 )
 
 install_wrapper_script("vpnbridge" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnbridge/vpnbridge")
-install_systemd_service("vpnbridge" "${CMAKE_SOURCE_DIR}/systemd/softether-vpnbridge.service" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnbridge/vpnbridge")
+if(EXISTS "/lib/systemd/system")
+  configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnbridge.service ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnbridge.service)
+  install(FILES ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnbridge.service
+    COMPONENT "vpnbridge"
+    DESTINATION "/lib/systemd/system"
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+  )
+endif()

--- a/src/vpnclient/CMakeLists.txt
+++ b/src/vpnclient/CMakeLists.txt
@@ -23,4 +23,11 @@ install(FILES "${BUILD_DIRECTORY}/hamcore.se2"
 )
 
 install_wrapper_script("vpnclient" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnclient/vpnclient")
-install_systemd_service("vpnclient" "${CMAKE_SOURCE_DIR}/systemd/softether-vpnclient.service" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnclient/vpnclient")
+if(EXISTS "/lib/systemd/system")
+  configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnclient.service ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnclient.service)
+  install(FILES ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnclient.service
+    COMPONENT "vpnclient"
+    DESTINATION "/lib/systemd/system"
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+  )
+endif()

--- a/src/vpnserver/CMakeLists.txt
+++ b/src/vpnserver/CMakeLists.txt
@@ -23,4 +23,11 @@ install(FILES "${BUILD_DIRECTORY}/hamcore.se2"
 )
 
 install_wrapper_script("vpnserver" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnserver/vpnserver")
-install_systemd_service("vpnserver" "${CMAKE_SOURCE_DIR}/systemd/softether-vpnserver.service" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnserver/vpnserver")
+if(EXISTS "/lib/systemd/system")
+  configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnserver.service ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnserver.service)
+  install(FILES ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnserver.service
+    COMPONENT "vpnserver"
+    DESTINATION "/lib/systemd/system"
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+  )
+endif()

--- a/systemd/softether-vpnbridge.service
+++ b/systemd/softether-vpnbridge.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=SoftEther VPN Bridge
 After=network.target auditd.service
-ConditionPathExists=![DIRECTORY]/do_not_run
+ConditionPathExists=!${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnbridge/do_not_run
 
 [Service]
 Type=forking
-EnvironmentFile=-[DIRECTORY]
-ExecStart=[BINARY] start
-ExecStop=[BINARY] stop
+EnvironmentFile=-${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnbridge
+ExecStart=${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnbridge/vpnbridge start
+ExecStop=${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnbridge/vpnbridge stop
 KillMode=process
 Restart=on-failure
 
@@ -16,7 +16,7 @@ PrivateTmp=yes
 ProtectHome=yes
 ProtectSystem=full
 ReadOnlyDirectories=/
-ReadWriteDirectories=-[DIRECTORY]
+ReadWriteDirectories=-${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnbridge
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SYS_NICE CAP_SYS_ADMIN CAP_SETUID
 
 [Install]

--- a/systemd/softether-vpnclient.service
+++ b/systemd/softether-vpnclient.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=SoftEther VPN Client
 After=network.target auditd.service
-ConditionPathExists=![DIRECTORY]/do_not_run
+ConditionPathExists=!${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnclient/do_not_run
 
 [Service]
 Type=forking
-EnvironmentFile=-[DIRECTORY]
-ExecStart=[BINARY] start
-ExecStop=[BINARY] stop
+EnvironmentFile=-${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnclient
+ExecStart=${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnclient/vpnclient start
+ExecStop=${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnclient/vpnclient stop
 KillMode=process
 Restart=on-failure
 
@@ -16,7 +16,7 @@ PrivateTmp=yes
 ProtectHome=yes
 ProtectSystem=full
 ReadOnlyDirectories=/
-ReadWriteDirectories=-[DIRECTORY]
+ReadWriteDirectories=-${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnclient
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SYS_NICE CAP_SYS_ADMIN CAP_SETUID
 
 [Install]

--- a/systemd/softether-vpnserver.service
+++ b/systemd/softether-vpnserver.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=SoftEther VPN Server
 After=network.target auditd.service
-ConditionPathExists=![DIRECTORY]/do_not_run
+ConditionPathExists=!${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnserver/do_not_run
 
 [Service]
 Type=forking
-EnvironmentFile=-[DIRECTORY]
-ExecStart=[BINARY] start
-ExecStop=[BINARY] stop
+EnvironmentFile=-${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnserver
+ExecStart=${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnserver/vpnserver start
+ExecStop=${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnserver/vpnserver stop
 KillMode=process
 Restart=on-failure
 
@@ -16,7 +16,7 @@ PrivateTmp=yes
 ProtectHome=yes
 ProtectSystem=full
 ReadOnlyDirectories=/
-ReadWriteDirectories=-[DIRECTORY]
+ReadWriteDirectories=-${CPACK_PACKAGING_INSTALL_PREFIX}/libexec/softether/vpnserver
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SYS_NICE CAP_SYS_ADMIN CAP_SETUID
 
 [Install]


### PR DESCRIPTION
Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one