### PR TITLE
CMake: change ${CMAKE_SOURCE_DIR}/tmp with ${CMAKE_BINARY_DIR}

### DIFF
--- a/src/vpnbridge/CMakeLists.txt
+++ b/src/vpnbridge/CMakeLists.txt
@@ -24,8 +24,8 @@ install(FILES "${BUILD_DIRECTORY}/hamcore.se2"
 
 install_wrapper_script("vpnbridge" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnbridge/vpnbridge")
 if(EXISTS "/lib/systemd/system")
-  configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnbridge.service ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnbridge.service)
-  install(FILES ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnbridge.service
+  configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnbridge.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnbridge.service)
+  install(FILES ${CMAKE_BINARY_DIR}/systemd/softether-vpnbridge.service
     COMPONENT "vpnbridge"
     DESTINATION "/lib/systemd/system"
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ

--- a/src/vpnclient/CMakeLists.txt
+++ b/src/vpnclient/CMakeLists.txt
@@ -24,8 +24,8 @@ install(FILES "${BUILD_DIRECTORY}/hamcore.se2"
 
 install_wrapper_script("vpnclient" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnclient/vpnclient")
 if(EXISTS "/lib/systemd/system")
-  configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnclient.service ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnclient.service)
-  install(FILES ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnclient.service
+  configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnclient.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnclient.service)
+  install(FILES ${CMAKE_BINARY_DIR}/systemd/softether-vpnclient.service
     COMPONENT "vpnclient"
     DESTINATION "/lib/systemd/system"
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ

--- a/src/vpnserver/CMakeLists.txt
+++ b/src/vpnserver/CMakeLists.txt
@@ -24,8 +24,8 @@ install(FILES "${BUILD_DIRECTORY}/hamcore.se2"
 
 install_wrapper_script("vpnserver" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnserver/vpnserver")
 if(EXISTS "/lib/systemd/system")
-  configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnserver.service ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnserver.service)
-  install(FILES ${CMAKE_SOURCE_DIR}/tmp/systemd/softether-vpnserver.service
+  configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnserver.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnserver.service)
+  install(FILES ${CMAKE_BINARY_DIR}/systemd/softether-vpnserver.service
     COMPONENT "vpnserver"
     DESTINATION "/lib/systemd/system"
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ


### PR DESCRIPTION
Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one