### PR TITLE
travis-ci: fix osx build, remove unneeded "apt" plugin (it is unused since CPack)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,16 +54,12 @@ matrix:
         directories:
         - ${HOME}/Library/Caches/Homebrew
       before_install:
-        - brew update && brew upgrade
+        - brew update
       script:
         - ./configure
         - make -C tmp
         - otool -L build/vpnserver
         - sudo make -C tmp install
-
-addons:
-  apt:
-    packages: [ debhelper, devscripts, fakeroot, cmake3, dh-exec ]
 
 cache:
   directories:


### PR DESCRIPTION
Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one
