### PR TITLE
Fix a single memory leak in loading the string table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ x64_Debug
 *.user
 *.ncb
 *.opt
+*.suo
 !/src/BuildFiles/**/*
 
 # Applied for 'developer_tools/stbchecker/'
@@ -204,3 +205,4 @@ developer_tools/stbchecker/**/ASALocalRun/
 developer_tools/stbchecker/**/*.binlog
 developer_tools/stbchecker/**/*.nvuser
 developer_tools/stbchecker/**/.mfractor/
+

--- a/src/Mayaqua/Table.c
+++ b/src/Mayaqua/Table.c
@@ -945,6 +945,8 @@ TABLE *ParseTableLine(char *line, char *prefix, UINT prefix_size, LIST *replace_
 			UniReplaceStrEx(tmp, tmp_size, tmp, (wchar_t *)r->name, r->unistr, false);
 		}
 
+		Free(unistr);
+
 		unistr = CopyUniStr(tmp);
 
 		Free(tmp);


### PR DESCRIPTION
Changes proposed in this pull request:
 - Fix a single memory leak in loading the string table.
 - Add .suo (Visual Studio user setting) file to the .gitignore file.

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

-

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

