### PR TITLE
travis-ci: add "vpntest" memory checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         - ./configure
         - make -C tmp
         - otool -L build/vpnserver
-        - sudo make -C tmp install
+        - .ci/memory-leak-test.sh
 
 cache:
   directories:
@@ -80,5 +80,5 @@ script:
   - ./configure
   - make -C tmp
   - ldd build/vpnserver
-  - sudo LD_LIBRARY_PATH="${HOME}/opt/lib:${LD_LIBRARY_PATH:-}" make -C tmp install
   - if [ "${BUILD_DEB}" = "1" ]; then make package -C tmp; fi
+  - .ci/memory-leak-test.sh


### PR DESCRIPTION
Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one