### PR TITLE
gitlab-ci: add "vpntest" memory tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@
     - ./configure
     - make package -C tmp
     - dpkg -i build/softether-vpn*.deb
+    - .ci/memory-leak-test.sh
 
 trusty:      
   <<: *ubuntu_def


### PR DESCRIPTION
Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one