### PR TITLE
docs(BUILD_UNIX): add macOS specifics

### DIFF
--- a/src/BUILD_UNIX.md
+++ b/src/BUILD_UNIX.md
@@ -3,6 +3,7 @@ This document describes how to build SoftEtherVPN for Unix based Operating syste
 - [Requirements](#requirements)
   * [Install requirements on Centos/RedHat](#install-requirements-on-centosredhat)
   * [Install Requirements on Debian/Ubuntu](#install-requirements-on-debianubuntu)
+  * [Install Requirements on macOS](#install-requirements-on-macos)
 - [Build from source code and install](#build-from-source-code-and-install)
 - [How to Run SoftEther](#how-to-run-softether)
   * [Start/Stop SoftEther VPN Server](#startstop-softether-vpn-server)
@@ -34,11 +35,16 @@ sudo yum -y groupinstall "Development Tools"
 sudo yum -y install cmake ncurses-devel openssl-devel readline-devel zlib-devel
 ```
 
-## Install Requirements on Debian/Ubuntu
+## Install requirements on Debian/Ubuntu
 ```bash
 sudo apt -y install cmake gcc g++ libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev
 ```
 
+## Install requirements on macOS
+```bash
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+brew install cmake openssl readline
+```
 
 # Build from source code and install
 


### PR DESCRIPTION
Changes proposed in this pull request:
Provide required preparation on macOS to build SoftEtherVPN (development repo) from source.

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

-

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

