### PR TITLE
Cedar/Proto_OpenVPN: add support for GCM ciphers

### DIFF
--- a/src/Cedar/Proto_OpenVPN.h
+++ b/src/Cedar/Proto_OpenVPN.h
@@ -127,6 +127,7 @@
 #define	OPENVPN_MAX_SSL_RECV_BUF_SIZE			(256 * 1024)	// SSL receive buffer maximum length
 
 #define	OPENVPN_MAX_KEY_SIZE					64		// Maximum key size
+#define	OPENVPN_TAG_SIZE						16		// Tag size (for packet authentication in AEAD mode)
 
 #define	OPENVPN_TMP_BUFFER_SIZE					(65536 + 256)	// Temporary buffer size
 
@@ -241,9 +242,10 @@ struct OPENVPN_CHANNEL
 	CIPHER *CipherDecrypt;								// Decryption algorithm
 	MD *MdSend;											// Transmission MD algorithm
 	MD *MdRecv;											// Reception MD algorithm
+	UCHAR IvSend[64];									// Transmission IV
+	UCHAR IvRecv[64];									// Reception IV
 	UCHAR MasterSecret[48];								// Master Secret
 	UCHAR ExpansionKey[256];							// Expansion Key
-	UCHAR NextIv[64];									// Next IV
 	UINT LastDataPacketId;								// Previous Data Packet ID
 	UINT64 EstablishedTick;								// Established time
 	UCHAR KeyId;										// KEY ID

--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -570,6 +570,7 @@ CIPHER *NewCipher(char *name)
 	EVP_CIPHER_CTX_init(c->Ctx);
 #endif
 
+	c->IsAeadCipher = EVP_CIPHER_flags(c->Cipher) & EVP_CIPH_FLAG_AEAD_CIPHER;
 	c->BlockSize = EVP_CIPHER_block_size(c->Cipher);
 	c->KeySize = EVP_CIPHER_key_length(c->Cipher);
 	c->IvSize = EVP_CIPHER_iv_length(c->Cipher);
@@ -629,6 +630,74 @@ UINT CipherProcess(CIPHER *c, void *iv, void *dest, void *src, UINT size)
 	if (EVP_CipherFinal(c->Ctx, ((UCHAR *)dest) + (UINT)r, &r2) == 0)
 	{
 		return 0;
+	}
+
+	return r + r2;
+}
+
+// Process encryption / decryption (AEAD)
+UINT CipherProcessAead(CIPHER *c, void *iv, void *tag, UINT tag_size, void *dest, void *src, UINT src_size, void *aad, UINT aad_size)
+{
+	int r = src_size;
+	int r2 = 0;
+	// Validate arguments
+	if (c == NULL)
+	{
+		return 0;
+	}
+	else if (c->IsNullCipher)
+	{
+		Copy(dest, src, src_size);
+		return src_size;
+	}
+	else if (c->IsAeadCipher == false || iv == NULL || tag == NULL || tag_size == 0 || dest == NULL || src == NULL || src_size == 0)
+	{
+		return 0;
+	}
+
+	if (EVP_CipherInit_ex(c->Ctx, NULL, NULL, NULL, iv, c->Encrypt) == false)
+	{
+		Debug("CipherProcessAead(): EVP_CipherInit_ex() failed with error: %s\n", OpenSSL_Error());
+		return 0;
+	}
+
+	if (c->Encrypt == false)
+	{
+		if (EVP_CIPHER_CTX_ctrl(c->Ctx, EVP_CTRL_AEAD_SET_TAG, tag_size, tag) == false)
+		{
+			Debug("CipherProcessAead(): EVP_CIPHER_CTX_ctrl() failed to set the tag!\n");
+			return 0;
+		}
+	}
+
+	if (aad != NULL && aad_size != 0)
+	{
+		if (EVP_CipherUpdate(c->Ctx, NULL, &r, aad, aad_size) == false)
+		{
+			Debug("CipherProcessAead(): EVP_CipherUpdate() failed with error: %s\n", OpenSSL_Error());
+			return 0;
+		}
+	}
+
+	if (EVP_CipherUpdate(c->Ctx, dest, &r, src, src_size) == false)
+	{
+		Debug("CipherProcessAead(): EVP_CipherUpdate() failed with error: %s\n", OpenSSL_Error());
+		return 0;
+	}
+
+	if (EVP_CipherFinal_ex(c->Ctx, ((UCHAR *)dest) + (UINT)r, &r2) == false)
+	{
+		Debug("CipherProcessAead(): EVP_CipherFinal_ex() failed with error: %s\n", OpenSSL_Error());
+		return 0;
+	}
+
+	if (c->Encrypt)
+	{
+		if (EVP_CIPHER_CTX_ctrl(c->Ctx, EVP_CTRL_AEAD_GET_TAG, tag_size, tag) == false)
+		{
+			Debug("CipherProcessAead(): EVP_CIPHER_CTX_ctrl() failed to get the tag!\n");
+			return 0;
+		}
 	}
 
 	return r + r2;

--- a/src/Mayaqua/Encrypt.h
+++ b/src/Mayaqua/Encrypt.h
@@ -239,6 +239,8 @@ void RAND_Free_For_SoftEther();
 
 // OpenSSL <1.1 Shims
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
+#	define EVP_CTRL_AEAD_GET_TAG EVP_CTRL_GCM_GET_TAG
+#	define EVP_CTRL_AEAD_SET_TAG EVP_CTRL_GCM_SET_TAG
 #	define EVP_PKEY_get0_RSA(obj) ((obj)->pkey.rsa)
 #	define EVP_PKEY_base_id(pkey) ((pkey)->type)
 #	define X509_get0_notBefore(x509) ((x509)->cert_info->validity->notBefore)
@@ -348,7 +350,7 @@ struct DH_CTX
 struct CIPHER
 {
 	char Name[MAX_PATH];
-	bool IsNullCipher;
+	bool IsNullCipher, IsAeadCipher;
 	const struct evp_cipher_st *Cipher;
 	struct evp_cipher_ctx_st *Ctx;
 	bool Encrypt;
@@ -523,6 +525,7 @@ CIPHER *NewCipher(char *name);
 void FreeCipher(CIPHER *c);
 void SetCipherKey(CIPHER *c, void *key, bool enc);
 UINT CipherProcess(CIPHER *c, void *iv, void *dest, void *src, UINT size);
+UINT CipherProcessAead(CIPHER *c, void *iv, void *tag, UINT tag_size, void *dest, void *src, UINT src_size, void *aad, UINT aad_size);
 
 // Hashing
 MD *NewMd(char *name);

--- a/src/bin/hamcore/openvpn_sample.ovpn
+++ b/src/bin/hamcore/openvpn_sample.ovpn
@@ -98,14 +98,9 @@ $TAG_BEFORE_REMOTE$remote $TAG_HOSTNAME$ $TAG_PORT$
 ###############################################################################
 # The encryption and authentication algorithm.
 # 
-# Default setting is good. Modify it as you prefer.
-# When you specify an unsupported algorithm, the error will occur.
-# 
-# The supported algorithms are as follows:
-#  cipher: [NULL-CIPHER] NULL AES-128-CBC AES-192-CBC AES-256-CBC BF-CBC
-#          CAST-CBC CAST5-CBC DES-CBC DES-EDE-CBC DES-EDE3-CBC DESX-CBC
-#          RC2-40-CBC RC2-64-CBC RC2-CBC CAMELLIA-128-CBC CAMELLIA-192-CBC CAMELLIA-256-CBC
-#  auth:   SHA SHA1 SHA256 SHA384 SHA512 MD5 MD4 RMD160
+# The default setting is compatible with most clients. Modify it as you prefer.
+# It is recommended to use a better algorithm if your client supports it.
+# When you specify an unsupported algorithm, an error will occur.
 
 cipher AES-128-CBC
 auth SHA1


### PR DESCRIPTION
This pull requests adds support for GCM ciphers to the OpenVPN protocol.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.