### PR TITLE
Mayaqua/Encrypt.h: fix missing AEAD macro for OpenBSD

### DIFF
--- a/src/Mayaqua/Encrypt.h
+++ b/src/Mayaqua/Encrypt.h
@@ -239,13 +239,19 @@ void RAND_Free_For_SoftEther();
 
 // OpenSSL <1.1 Shims
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-#	define EVP_CTRL_AEAD_GET_TAG EVP_CTRL_GCM_GET_TAG
-#	define EVP_CTRL_AEAD_SET_TAG EVP_CTRL_GCM_SET_TAG
 #	define EVP_PKEY_get0_RSA(obj) ((obj)->pkey.rsa)
 #	define EVP_PKEY_base_id(pkey) ((pkey)->type)
 #	define X509_get0_notBefore(x509) ((x509)->cert_info->validity->notBefore)
 #	define X509_get0_notAfter(x509) ((x509)->cert_info->validity->notAfter)
 #	define X509_get_serialNumber(x509) ((x509)->cert_info->serialNumber)
+#endif
+
+#ifndef EVP_CTRL_AEAD_GET_TAG
+#	define EVP_CTRL_AEAD_GET_TAG EVP_CTRL_GCM_GET_TAG
+#endif
+
+#ifndef EVP_CTRL_AEAD_SET_TAG
+#	define EVP_CTRL_AEAD_SET_TAG EVP_CTRL_GCM_SET_TAG
 #endif
 
 // Crypt context


### PR DESCRIPTION
Fixes #803.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.