### PR TITLE
BuildUtil: fix an issue encountered with Visual Studio 2008 on Windows XP

### DIFF
--- a/src/BuildUtil/VpnBuilder.cs
+++ b/src/BuildUtil/VpnBuilder.cs
@@ -269,14 +269,17 @@ namespace BuildUtil
 			}
 
 			// Get the VC++ directory
+			// Get Microsoft SDK 6.0a directory
 			// Visual Studio 2008
 			if (IntPtr.Size == 4)
 			{
 				Paths.VisualStudioVCDir = IO.RemoteLastEnMark(Reg.ReadStr(RegRoot.LocalMachine, @"SOFTWARE\Microsoft\VisualStudio\9.0\Setup\VC", "ProductDir"));
+				Paths.MicrosoftSDKDir = IO.RemoteLastEnMark(Reg.ReadStr(RegRoot.LocalMachine, @"SOFTWARE\Microsoft\Microsoft SDKs\Windows\v6.0A", "InstallationFolder"));
 			}
 			else
 			{
 				Paths.VisualStudioVCDir = IO.RemoteLastEnMark(Reg.ReadStr(RegRoot.LocalMachine, @"SOFTWARE\Wow6432Node\Microsoft\VisualStudio\9.0\Setup\VC", "ProductDir"));
+				Paths.MicrosoftSDKDir = IO.RemoteLastEnMark(Reg.ReadStr(RegRoot.LocalMachine, @"SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v6.0A", "InstallationFolder"));
 			}
 			if (Str.IsEmptyStr(Paths.VisualStudioVCDir))
 			{
@@ -295,16 +298,6 @@ namespace BuildUtil
 			}
 
 			bool x86_dir = false;
-
-			// Get Microsoft SDK 6.0a directory
-			if (IntPtr.Size == 4)
-			{
-				Paths.MicrosoftSDKDir = IO.RemoteLastEnMark(Reg.ReadStr(RegRoot.LocalMachine, @"SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v6.0A", "InstallationFolder"));
-			}
-			else
-			{
-				Paths.MicrosoftSDKDir = IO.RemoteLastEnMark(Reg.ReadStr(RegRoot.LocalMachine, @"SOFTWARE\Microsoft\Microsoft SDKs\Windows\v6.0A", "InstallationFolder"));
-			}
 
 			// Get makecat.exe file name
 			Paths.MakeCatFilename = Path.Combine(Paths.MicrosoftSDKDir, @"bin\" + (x86_dir ? @"x86\" : "") + "makecat.exe");


### PR DESCRIPTION
Changes proposed in this pull request:
 - When building on Windows XP using Visual Studio 2008, I encountered the following issue.
 - I did a fresh install of Windows XP SP3 32-bit, then applied updates including .NET 3.5. Next I installed MS Visual Studio 2008, then updated with sp1. All of this according to the documentation in your readme for building on Windows.
 - In file src/BuildUtils/VpnBuilder.cs, there are two "if" statements testing the same thing, which is to determine if it is a 32-bit or 64-bit machine/compiler. But the then and else clauses are reversed, so clearly, one of them is wrong. The result I saw is that the SDK path being used to run RC.exe is left as the NULL string and so it fails to run the RC.exe program.
 - This happens early in the build process, building the build utils. The two "if" statements are used to set paths for the Visual Studio VC and SDK directories. Depending on the integer pointer size, it uses different paths in the registry.
 - When I looked in the registry on my Windows XP machine, there is no key HKLM\SOFTWARE\Wow6432Node, I have only seen that on 64-bit machines.
 - For the fix, I consolidated the two "if" statements into one, the existing statement on line 380 would only set a value for Paths.VisualStudioVCDir (which got set correctly). Now I moved the code for also setting Paths.MicrosoftSDKDir, while reversing the values from the incorrectly coded "if" statement.
 - I can understand that under certain circumstances, this issue would not be encountered, but should be easily reproducible when installing a clean system.
 - Please forgive me if I have made any mistakes in the process of submitting this pull request as I am just learning how to use git. I wonder if you could expand on your guidelines for submitting a pull request, starting by telling a person they need to create a fork. And it looks like every line of the file I modified got flagged by the diff, I think because of the line endings change. Is there a way I should have done this request that would work better?

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- I choose option #1, you are allowed to apply this patch.

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

