### PR TITLE
Cedar: add new "UsernameHubSeparator" configuration option for the server, to specify a different character from '@'

### DIFF
--- a/src/Cedar/Cedar.h
+++ b/src/Cedar/Cedar.h
@@ -209,6 +209,9 @@
 // Hidden password string of 8 characters
 #define	HIDDEN_PASSWORD				"********"
 
+// Default separator character for the hub name in the username
+#define	DEFAULT_USERNAME_HUB_SEPARATOR	'@'
+
 
 //////////////////////////////////////////////////////////////////////
 // 
@@ -1024,6 +1027,7 @@ typedef struct CEDAR
 	COUNTER *ConnectionIncrement;	// Connection increment counter
 	X *ServerX;						// Server certificate
 	K *ServerK;						// Private key of the server certificate
+	char UsernameHubSeparator;		// Character which separates the username from the hub name
 	char *CipherList;				// List of encryption algorithms
 	UINT Version;					// Version information
 	UINT Build;						// Build Number

--- a/src/Cedar/Proto_PPP.c
+++ b/src/Cedar/Proto_PPP.c
@@ -807,14 +807,14 @@ bool PPPParseUsername(CEDAR *cedar, char *src_username, ETHERIP_ID *dst)
 	}
 	else
 	{
-		// Search for the last "@" in the string
+		// Search for the separator character's last position in the string
 		len = StrLen(src);
 		last_at = INFINITE;
 		for (i = 0;i < len;i++)
 		{
 			char c = src[i];
 
-			if (c == '@')
+			if (c == cedar->UsernameHubSeparator)
 			{
 				last_at = i;
 			}
@@ -825,12 +825,11 @@ bool PPPParseUsername(CEDAR *cedar, char *src_username, ETHERIP_ID *dst)
 
 		if (last_at == INFINITE)
 		{
-			// "@" is not specified
+			// The separator character is not specified
 			StrCpy(token1, sizeof(token1), src);
 		}
 		else
 		{
-			// Split with last "@"
 			StrCpy(token1, sizeof(token1), src);
 			token1[last_at] = 0;
 

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -2540,6 +2540,9 @@ void SiLoadInitialConfiguration(SERVER *s)
 	// Set the server certificate to default
 	SiInitDefaultServerCert(s);
 
+	// Set the character which separates the username from the hub name
+	s->Cedar->UsernameHubSeparator = DEFAULT_USERNAME_HUB_SEPARATOR;
+
 	// Create a default HUB
 	{
 		SiInitDefaultHubList(s);
@@ -5936,6 +5939,12 @@ void SiLoadServerCfg(SERVER *s, FOLDER *f)
 			FreeK(k);
 		}
 
+		// Character which separates the username from the hub name
+		if (CfgGetStr(f, "UsernameHubSeparator", tmp, sizeof(tmp)))
+		{
+			c->UsernameHubSeparator = IsPrintableAsciiChar(tmp[0]) ? tmp[0] : DEFAULT_USERNAME_HUB_SEPARATOR;
+		}
+
 		// Cipher Name
 		if (CfgGetStr(f, "CipherName", tmp, sizeof(tmp)))
 		{
@@ -6312,6 +6321,13 @@ void SiWriteServerCfg(FOLDER *f, SERVER *s)
 		b = KToBuf(c->ServerK, false, NULL);
 		CfgAddBuf(f, "ServerKey", b);
 		FreeBuf(b);
+
+		{
+			// Character which separates the username from the hub name
+			char str[2];
+			StrCpy(str, sizeof(str), &c->UsernameHubSeparator);
+			CfgAddStr(f, "UsernameHubSeparator", str);
+		}
 
 		// Traffic information
 		Lock(c->TrafficLock);


### PR DESCRIPTION
Requested in #809.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.