### PR TITLE
CMake: build targets with versioning info on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,12 @@
 cmake_minimum_required(VERSION 3.7)
 
-project(SoftEtherVPN
+project("SoftEther VPN"
   VERSION 5.01.9664
   LANGUAGES C
 )
+
+set(TOP_DIRECTORY ${CMAKE_SOURCE_DIR})
+set(BUILD_DIRECTORY ${TOP_DIRECTORY}/build)
 
 # We define a dedicated variable because CMAKE_BUILD_TYPE can have different
 # configurations than "Debug" and "Release", such as "RelWithDebInfo".
@@ -14,12 +17,12 @@ else()
 endif()
 
 # Check that submodules are present only if source was downloaded with git
-if(EXISTS "${SoftEtherVPN_SOURCE_DIR}/.git" AND NOT EXISTS "${SoftEtherVPN_SOURCE_DIR}/src/Mayaqua/3rdparty/cpu_features/CMakeLists.txt")
+if(EXISTS "${TOP_DIRECTORY}/.git" AND NOT EXISTS "${TOP_DIRECTORY}/src/Mayaqua/3rdparty/cpu_features/CMakeLists.txt")
     message (FATAL_ERROR "Submodules are not initialized. Run\n\tgit submodule update --init --recursive")
 endif()
 
 # Compare ${PROJECT_VERSION} and src/CurrentBuild.txt
-file(READ ${SoftEtherVPN_SOURCE_DIR}/src/CurrentBuild.txt CurrentBuild)
+file(READ ${TOP_DIRECTORY}/src/CurrentBuild.txt CurrentBuild)
 
 string(REGEX MATCH "VERSION_MAJOR ([0-9]+)" temp ${CurrentBuild})
 string(REGEX REPLACE "VERSION_MAJOR ([0-9]+)" "\\1" CurrentBuild_MAJOR ${temp})
@@ -40,9 +43,8 @@ if(UNIX)
   Check_Include_File(sys/auxv.h HAVE_SYS_AUXV)
 endif()
 
-configure_file("${SoftEtherVPN_SOURCE_DIR}/AUTHORS.TXT" "${SoftEtherVPN_SOURCE_DIR}/src/bin/hamcore/authors.txt" COPYONLY)
+configure_file("${TOP_DIRECTORY}/AUTHORS.TXT" "${TOP_DIRECTORY}/src/bin/hamcore/authors.txt" COPYONLY)
 
-set(BUILD_DIRECTORY ${SoftEtherVPN_SOURCE_DIR}/build)
 set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 
 add_subdirectory(src)
@@ -54,11 +56,11 @@ if(UNIX)
   set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
   set(CPACK_PACKAGE_VENDOR "SoftEther")
   set(CPACK_PACKAGE_NAME "softether")
-  set(CPACK_PACKAGE_DESCRIPTION_FILE "${SoftEtherVPN_SOURCE_DIR}/description")
+  set(CPACK_PACKAGE_DESCRIPTION_FILE "${TOP_DIRECTORY}/description")
   set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SoftEther VPN is an open-source cross-platform multi-protocol VPN program, created as an academic project in the University of Tsukuba.")
 
   # DEB
-  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  if(BUILD_TYPE STREQUAL "Debug")
     set(CPACK_DEBIAN_PACKAGE_DEBUG ON)
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,17 @@ endif()
 
 configure_file("${TOP_DIRECTORY}/AUTHORS.TXT" "${TOP_DIRECTORY}/src/bin/hamcore/authors.txt" COPYONLY)
 
+# Date and time
+string(TIMESTAMP DATE_DAY "%d" UTC)
+string(TIMESTAMP DATE_MONTH "%m" UTC)
+string(TIMESTAMP DATE_YEAR "%Y" UTC)
+string(TIMESTAMP TIME_HOUR "%H" UTC)
+string(TIMESTAMP TIME_MINUTE "%M" UTC)
+string(TIMESTAMP TIME_SECOND "%S" UTC)
+
+message(STATUS "Build date: ${DATE_DAY}/${DATE_MONTH}/${DATE_YEAR}")
+message(STATUS "Build time: ${TIME_HOUR}:${TIME_MINUTE}:${TIME_SECOND}")
+
 set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 
 add_subdirectory(src)

--- a/src/BuildFiles/VerScript/ver.rc
+++ b/src/BuildFiles/VerScript/ver.rc
@@ -1,8 +1,8 @@
 #pragma code_page(932)
 
 1 VERSIONINFO
- FILEVERSION $VER_MAJOR$,$VER_MINOR$,0,$VER_BUILD$
- PRODUCTVERSION $VER_MAJOR$,$VER_MINOR$,0,$VER_BUILD$
+ FILEVERSION ${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},0,${PROJECT_VERSION_PATCH}
+ PRODUCTVERSION ${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},0,${PROJECT_VERSION_PATCH}
  FILEFLAGSMASK 0x17L
  FILEOS 0x4L
  FILETYPE 0x1L
@@ -12,15 +12,15 @@ BEGIN
     BEGIN
         BLOCK "041104b0"
         BEGIN
-            VALUE "CompanyName", "SoftEther VPN Project at University of Tsukuba, Japan. (Developer Edition)"
-            VALUE "FileDescription", "$PRODUCTNAME$ (Developer Edition)"
-            VALUE "FileVersion", "$VER_MAJOR$, $VER_MINOR$, 0, $VER_BUILD$"
-            VALUE "InternalName", "$INTERNALNAME$ (Developer Edition)"
-            VALUE "LegalCopyright", "Copyright (C) 2012-$YEAR$ SoftEther VPN Project. All Rights Reserved. (Developer Edition)"
+            VALUE "CompanyName", "SoftEther VPN Project at University of Tsukuba, Japan."
+            VALUE "FileDescription", "${PROJECT_NAME} ${COMPONENT_NAME} (Developer Edition)"
+            VALUE "FileVersion", "${PROJECT_VERSION_MAJOR}, ${PROJECT_VERSION_MINOR}, 0, ${PROJECT_VERSION_PATCH}"
+            VALUE "InternalName", "${COMPONENT_INTERNAL_NAME}"
+            VALUE "LegalCopyright", "Copyright (C) 2012-${DATE_YEAR} SoftEther VPN Project. All Rights Reserved."
             VALUE "LegalTrademarks", "SoftEther(R) is a registered trademark of SoftEther Corporation in Japan, United Status and People's Republic of China. SoftEther Corporation is a company founded at University of Tsukuba, Japan."
-            VALUE "OriginalFilename", "$FILENAME$"
-            VALUE "ProductName", "$PRODUCTNAME$ (Developer Edition)"
-            VALUE "ProductVersion", "$VER_MAJOR$, $VER_MINOR$, 0, $VER_BUILD$"
+            VALUE "OriginalFilename", "${COMPONENT_FILE_NAME}"
+            VALUE "ProductName", "${PROJECT_NAME} ${COMPONENT_NAME}"
+            VALUE "ProductVersion", "${PROJECT_VERSION_MAJOR}, ${PROJECT_VERSION_MINOR}, 0, ${PROJECT_VERSION_PATCH}"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/BuildUtil/Win32BuildUtil.cs
+++ b/src/BuildUtil/Win32BuildUtil.cs
@@ -199,24 +199,19 @@ namespace BuildUtil
 			string exeFileName = Path.GetFileName(targetExeName);
 			string internalName = Path.GetFileNameWithoutExtension(exeFileName);
 
-			if (Str.IsEmptyStr(product_name) == false)
-			{
-				body = Str.ReplaceStr(body, "$PRODUCTNAME$", product_name);
-			}
-			else
-			{
 #if !BU_SOFTETHER
-				body = Str.ReplaceStr(body, "$PRODUCTNAME$", "PacketiX VPN");
+			body = Str.ReplaceStr(body, "${PROJECT_NAME}", "PacketiX VPN");
 #else		
-				body = Str.ReplaceStr(body, "$PRODUCTNAME$", "SoftEther VPN");
+			body = Str.ReplaceStr(body, "${PROJECT_NAME}", "SoftEther VPN");
 #endif
-			}
-			body = Str.ReplaceStr(body, "$INTERNALNAME$", internalName);
-			body = Str.ReplaceStr(body, "$YEAR$", date.Year.ToString());
-			body = Str.ReplaceStr(body, "$FILENAME$", exeFileName);
-			body = Str.ReplaceStr(body, "$VER_MAJOR$", versionMajor.ToString());
-			body = Str.ReplaceStr(body, "$VER_MINOR$", versionMinor.ToString());
-			body = Str.ReplaceStr(body, "$VER_BUILD$", versionBuild.ToString());
+
+			body = Str.ReplaceStr(body, "${COMPONENT_NAME}", product_name);
+			body = Str.ReplaceStr(body, "${COMPONENT_INTERNAL_NAME}", internalName);
+			body = Str.ReplaceStr(body, "${DATE_YEAR}", date.Year.ToString());
+			body = Str.ReplaceStr(body, "${COMPONENT_FILE_NAME}", exeFileName);
+			body = Str.ReplaceStr(body, "${PROJECT_VERSION_MAJOR}", versionMajor.ToString());
+			body = Str.ReplaceStr(body, "${PROJECT_VERSION_MINOR}", versionMinor.ToString());
+			body = Str.ReplaceStr(body, "${PROJECT_VERSION_PATCH}", versionBuild.ToString());
 
 			IO f = IO.CreateTempFileByExt(".rc");
 			string filename = f.Name;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,11 +4,11 @@ if(UNIX)
   macro(install_wrapper_script component target)
     get_filename_component(file_name ${target} NAME)
 
-    file(WRITE ${CMAKE_SOURCE_DIR}/tmp/script/${file_name} "#!/bin/sh\n")
-    file(APPEND ${CMAKE_SOURCE_DIR}/tmp/script/${file_name} "${target} \"$@\"\n")
-    file(APPEND ${CMAKE_SOURCE_DIR}/tmp/script/${file_name} "exit $?\n")
+    file(WRITE ${TOP_DIRECTORY}/tmp/script/${file_name} "#!/bin/sh\n")
+    file(APPEND ${TOP_DIRECTORY}/tmp/script/${file_name} "${target} \"$@\"\n")
+    file(APPEND ${TOP_DIRECTORY}/tmp/script/${file_name} "exit $?\n")
 
-    install(FILES ${CMAKE_SOURCE_DIR}/tmp/script/${file_name}
+    install(FILES ${TOP_DIRECTORY}/tmp/script/${file_name}
       COMPONENT ${component}
       DESTINATION ${CMAKE_INSTALL_FULL_BINDIR}
       PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
@@ -100,7 +100,7 @@ add_subdirectory(vpntest)
 # hamcore.se2 archive file
 add_custom_target(hamcore-archive-build
   ALL
-  COMMAND hamcorebuilder "${CMAKE_SOURCE_DIR}/src/bin/hamcore/" "${BUILD_DIRECTORY}/hamcore.se2"
+  COMMAND hamcorebuilder "${TOP_DIRECTORY}/src/bin/hamcore/" "${BUILD_DIRECTORY}/hamcore.se2"
   DEPENDS hamcorebuilder
   COMMENT "Building hamcore.se2 archive file..."
   VERBATIM

--- a/src/Cedar/CMakeLists.txt
+++ b/src/Cedar/CMakeLists.txt
@@ -54,24 +54,13 @@ cmake_host_system_information(RESULT BUILDER_HOSTNAME QUERY HOSTNAME)
 
 add_definitions(-DBUILD_PLACE="${BUILDER_HOSTNAME}")
 
-# Date and time
-string(TIMESTAMP BUILD_DAY "%d" UTC)
-string(TIMESTAMP BUILD_MONTH "%m" UTC)
-string(TIMESTAMP BUILD_YEAR "%Y" UTC)
-string(TIMESTAMP BUILD_HOUR "%H" UTC)
-string(TIMESTAMP BUILD_MINUTE "%M" UTC)
-string(TIMESTAMP BUILD_SECOND "%S" UTC)
-
-## Remove leading 0
-string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_DAY "${BUILD_DAY}")
-string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_MONTH "${BUILD_MONTH}")
-string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_YEAR "${BUILD_YEAR}")
-string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_HOUR "${BUILD_HOUR}")
-string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_MINUTE "${BUILD_MINUTE}")
-string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_SECOND "${BUILD_SECOND}")
-
-message(STATUS "Build date: ${BUILD_DAY}/${BUILD_MONTH}/${BUILD_YEAR}")
-message(STATUS "Build time: ${BUILD_HOUR}:${BUILD_MINUTE}:${BUILD_SECOND}")
+# Remove leading 0 from date and time
+string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_DAY "${DATE_DAY}")
+string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_MONTH "${DATE_MONTH}")
+string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_YEAR "${DATE_YEAR}")
+string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_HOUR "${TIME_HOUR}")
+string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_MINUTE "${TIME_MINUTE}")
+string(REGEX REPLACE "^0([^ ]*)" "\\1" BUILD_SECOND "${TIME_SECOND}")
 
 add_definitions(-DBUILD_DATE_D=${BUILD_DAY} -DBUILD_DATE_M=${BUILD_MONTH} -DBUILD_DATE_Y=${BUILD_YEAR})
 add_definitions(-DBUILD_DATE_HO=${BUILD_HOUR} -DBUILD_DATE_MI=${BUILD_MINUTE} -DBUILD_DATE_SE=${BUILD_SECOND})

--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -31,22 +31,22 @@ if(WIN32)
   if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
     find_library(LIB_SSL
       NAMES libssl ssleay32
-      HINTS "${CMAKE_SOURCE_DIR}/src/BuildFiles/Library/vs2017/x64_${BUILD_TYPE}"
+      HINTS "${TOP_DIRECTORY}/src/BuildFiles/Library/vs2017/x64_${BUILD_TYPE}"
     )
 
     find_library(LIB_CRYPTO
       NAMES libcrypto libeay32
-      HINTS "${CMAKE_SOURCE_DIR}/src/BuildFiles/Library/vs2017/x64_${BUILD_TYPE}"
+      HINTS "${TOP_DIRECTORY}/src/BuildFiles/Library/vs2017/x64_${BUILD_TYPE}"
     )
   else()
     find_library(LIB_SSL
       NAMES libssl ssleay32
-      HINTS "${CMAKE_SOURCE_DIR}/src/BuildFiles/Library/vs2017/Win32_${BUILD_TYPE}"
+      HINTS "${TOP_DIRECTORY}/src/BuildFiles/Library/vs2017/Win32_${BUILD_TYPE}"
     )
 
     find_library(LIB_CRYPTO
       NAMES libcrypto libeay32
-      HINTS "${CMAKE_SOURCE_DIR}/src/BuildFiles/Library/vs2017/Win32_${BUILD_TYPE}"
+      HINTS "${TOP_DIRECTORY}/src/BuildFiles/Library/vs2017/Win32_${BUILD_TYPE}"
     )
   endif()
 

--- a/src/PenCore/CMakeLists.txt
+++ b/src/PenCore/CMakeLists.txt
@@ -6,9 +6,9 @@ add_library(PenCore SHARED pencore.c pencore.rc)
 
 set_target_properties(PenCore
   PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/src/bin/hamcore"
-  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/src/bin/hamcore"
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/src/bin/hamcore"
+  ARCHIVE_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/src/bin/hamcore"
+  LIBRARY_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/src/bin/hamcore"
+  RUNTIME_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/src/bin/hamcore"
   PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 

--- a/src/hamcorebuilder/CMakeLists.txt
+++ b/src/hamcorebuilder/CMakeLists.txt
@@ -2,15 +2,15 @@ add_executable(hamcorebuilder hamcorebuilder.c)
 
 set_target_properties(hamcorebuilder
   PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp"
-  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp"
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp"
+  ARCHIVE_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/tmp"
+  LIBRARY_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/tmp"
+  RUNTIME_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/tmp"
 )
 
 if(WIN32)
   set_target_properties(hamcorebuilder
     PROPERTIES
-    PDB_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/tmp"
+    PDB_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/tmp"
   )
 endif()
 

--- a/src/vpnbridge/CMakeLists.txt
+++ b/src/vpnbridge/CMakeLists.txt
@@ -38,7 +38,7 @@ if(UNIX)
 
   install_wrapper_script("vpnbridge" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnbridge/vpnbridge")
   if(EXISTS "/lib/systemd/system")
-    configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnbridge.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnbridge.service)
+    configure_file(${TOP_DIRECTORY}/systemd/softether-vpnbridge.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnbridge.service)
     install(FILES ${CMAKE_BINARY_DIR}/systemd/softether-vpnbridge.service
       COMPONENT "vpnbridge"
       DESTINATION "/lib/systemd/system"

--- a/src/vpnbridge/CMakeLists.txt
+++ b/src/vpnbridge/CMakeLists.txt
@@ -1,10 +1,7 @@
-set(VPNBRIDGE_SOURCES vpnbridge.c)
+set(COMPONENT_NAME "Bridge")
+set(COMPONENT_INTERNAL_NAME "vpnbridge")
 
-if(WIN32)
-  set(VPNBRIDGE_SOURCES ${VPNBRIDGE_SOURCES} vpnbridge.rc)
-endif()
-
-add_executable(vpnbridge ${VPNBRIDGE_SOURCES})
+add_executable(vpnbridge vpnbridge.c)
 
 set_target_properties(vpnbridge
   PROPERTIES
@@ -18,6 +15,12 @@ if(WIN32)
     PROPERTIES
     PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
   )
+
+  get_filename_component(COMPONENT_FILE_NAME vpnbridge NAME)
+  set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
+
+  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpnbridge.rc")
+  target_sources(vpnbridge PRIVATE vpnbridge.rc "${CMAKE_BINARY_DIR}/VerScript/vpnbridge.rc")
 endif()
 
 target_link_libraries(vpnbridge cedar mayaqua)

--- a/src/vpnclient/CMakeLists.txt
+++ b/src/vpnclient/CMakeLists.txt
@@ -1,10 +1,7 @@
-set(VPNCLIENT_SOURCES vpncsvc.c vpncsvc.h)
+set(COMPONENT_NAME "Client")
+set(COMPONENT_INTERNAL_NAME "vpnclient")
 
-if(WIN32)
-  set(VPNCLIENT_SOURCES ${VPNCLIENT_SOURCES} vpnclient.rc)
-endif()
-
-add_executable(vpnclient ${VPNCLIENT_SOURCES})
+add_executable(vpnclient vpncsvc.c vpncsvc.h)
 
 set_target_properties(vpnclient
   PROPERTIES
@@ -18,6 +15,12 @@ if(WIN32)
     PROPERTIES
     PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
   )
+
+  get_filename_component(COMPONENT_FILE_NAME vpnclient NAME)
+  set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
+
+  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpnclient.rc")
+  target_sources(vpnclient PRIVATE vpnclient.rc "${CMAKE_BINARY_DIR}/VerScript/vpnclient.rc")
 endif()
 
 target_link_libraries(vpnclient cedar mayaqua)

--- a/src/vpnclient/CMakeLists.txt
+++ b/src/vpnclient/CMakeLists.txt
@@ -38,7 +38,7 @@ if(UNIX)
 
   install_wrapper_script("vpnclient" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnclient/vpnclient")
   if(EXISTS "/lib/systemd/system")
-    configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnclient.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnclient.service)
+    configure_file(${TOP_DIRECTORY}/systemd/softether-vpnclient.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnclient.service)
     install(FILES ${CMAKE_BINARY_DIR}/systemd/softether-vpnclient.service
       COMPONENT "vpnclient"
       DESTINATION "/lib/systemd/system"

--- a/src/vpncmd/CMakeLists.txt
+++ b/src/vpncmd/CMakeLists.txt
@@ -1,10 +1,7 @@
-set(VPNCMD_SOURCES vpncmd.c)
+set(COMPONENT_NAME "Command Line Management Utility")
+set(COMPONENT_INTERNAL_NAME "vpncmd")
 
-if(WIN32)
-  set(VPNCMD_SOURCES ${VPNCMD_SOURCES} vpncmd.rc)
-endif()
-
-add_executable(vpncmd ${VPNCMD_SOURCES})
+add_executable(vpncmd vpncmd.c)
 
 set_target_properties(vpncmd
   PROPERTIES
@@ -18,6 +15,12 @@ if(WIN32)
     PROPERTIES
     PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
   )
+
+  get_filename_component(COMPONENT_FILE_NAME vpncmd NAME)
+  set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
+
+  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpncmd.rc")
+  target_sources(vpncmd PRIVATE vpncmd.rc "${CMAKE_BINARY_DIR}/VerScript/vpncmd.rc")
 endif()
 
 target_link_libraries(vpncmd cedar mayaqua)

--- a/src/vpncmgr/CMakeLists.txt
+++ b/src/vpncmgr/CMakeLists.txt
@@ -5,9 +5,9 @@ endif()
 set(VPNCMGR_SOURCES vpncmgr.c vpncmgr.rc)
 
 if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
-  set(VPNCMGR_SOURCES ${VPNCMGR_SOURCES} ${CMAKE_SOURCE_DIR}/src/BuildFiles/Manifests/x64_user.manifest)
+  set(VPNCMGR_SOURCES ${VPNCMGR_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest)
 else()
-  set(VPNCMGR_SOURCES ${VPNCMGR_SOURCES} ${CMAKE_SOURCE_DIR}/src/BuildFiles/Manifests/x86_user.manifest)
+  set(VPNCMGR_SOURCES ${VPNCMGR_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest)
 endif()
 
 add_executable(vpncmgr WIN32 ${VPNCMGR_SOURCES})

--- a/src/vpncmgr/CMakeLists.txt
+++ b/src/vpncmgr/CMakeLists.txt
@@ -2,15 +2,22 @@ if(NOT WIN32)
   message(FATAL_ERROR "VPN Client Manager is available only for Windows.")
 endif()
 
-set(VPNCMGR_SOURCES vpncmgr.c vpncmgr.rc)
+set(COMPONENT_NAME "Client Manager")
+set(COMPONENT_INTERNAL_NAME "vpncmgr")
+
+add_executable(vpncmgr WIN32 vpncmgr.c vpncmgr.rc)
+
+get_filename_component(COMPONENT_FILE_NAME vpncmgr NAME)
+set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
+
+configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpncmgr.rc")
+target_sources(vpncmgr PRIVATE "${CMAKE_BINARY_DIR}/VerScript/vpncmgr.rc")
 
 if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
-  set(VPNCMGR_SOURCES ${VPNCMGR_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest)
+  target_sources(vpncmgr PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest")
 else()
-  set(VPNCMGR_SOURCES ${VPNCMGR_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest)
+  target_sources(vpncmgr PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest")
 endif()
-
-add_executable(vpncmgr WIN32 ${VPNCMGR_SOURCES})
 
 set_target_properties(vpncmgr
   PROPERTIES

--- a/src/vpnserver/CMakeLists.txt
+++ b/src/vpnserver/CMakeLists.txt
@@ -38,7 +38,7 @@ if(UNIX)
 
   install_wrapper_script("vpnserver" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnserver/vpnserver")
   if(EXISTS "/lib/systemd/system")
-    configure_file(${CMAKE_SOURCE_DIR}/systemd/softether-vpnserver.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnserver.service)
+    configure_file(${TOP_DIRECTORY}/systemd/softether-vpnserver.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnserver.service)
     install(FILES ${CMAKE_BINARY_DIR}/systemd/softether-vpnserver.service
       COMPONENT "vpnserver"
       DESTINATION "/lib/systemd/system"

--- a/src/vpnserver/CMakeLists.txt
+++ b/src/vpnserver/CMakeLists.txt
@@ -1,10 +1,7 @@
-set(VPNSERVER_SOURCES vpnserver.c)
+set(COMPONENT_NAME "Server")
+set(COMPONENT_INTERNAL_NAME "vpnserver")
 
-if(WIN32)
-  set(VPNSERVER_SOURCES ${VPNSERVER_SOURCES} vpnserver.rc)
-endif()
-
-add_executable(vpnserver ${VPNSERVER_SOURCES})
+add_executable(vpnserver vpnserver.c)
 
 set_target_properties(vpnserver
   PROPERTIES
@@ -18,6 +15,12 @@ if(WIN32)
     PROPERTIES
     PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
   )
+
+  get_filename_component(COMPONENT_FILE_NAME vpnserver NAME)
+  set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
+
+  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpnserver.rc")
+  target_sources(vpnserver PRIVATE vpnserver.rc "${CMAKE_BINARY_DIR}/VerScript/vpnserver.rc")
 endif()
 
 target_link_libraries(vpnserver cedar mayaqua)

--- a/src/vpnsmgr/CMakeLists.txt
+++ b/src/vpnsmgr/CMakeLists.txt
@@ -5,9 +5,9 @@ endif()
 set(VPNSMGR_SOURCES vpnsmgr.c vpnsmgr.rc)
 
 if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
-  set(VPNSMGR_SOURCES ${VPNSMGR_SOURCES} ${CMAKE_SOURCE_DIR}/src/BuildFiles/Manifests/x64_user.manifest)
+  set(VPNSMGR_SOURCES ${VPNSMGR_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest)
 else()
-  set(VPNSMGR_SOURCES ${VPNSMGR_SOURCES} ${CMAKE_SOURCE_DIR}/src/BuildFiles/Manifests/x86_user.manifest)
+  set(VPNSMGR_SOURCES ${VPNSMGR_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest)
 endif()
 
 add_executable(vpnsmgr WIN32 ${VPNSMGR_SOURCES})

--- a/src/vpnsmgr/CMakeLists.txt
+++ b/src/vpnsmgr/CMakeLists.txt
@@ -2,15 +2,22 @@ if(NOT WIN32)
   message(FATAL_ERROR "VPN Server Manager is available only for Windows.")
 endif()
 
-set(VPNSMGR_SOURCES vpnsmgr.c vpnsmgr.rc)
+set(COMPONENT_NAME "Server Manager")
+set(COMPONENT_INTERNAL_NAME "vpnsmgr")
+
+add_executable(vpnsmgr WIN32 vpnsmgr.c vpnsmgr.rc)
+
+get_filename_component(COMPONENT_FILE_NAME vpnsmgr NAME)
+set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
+
+configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpnsmgr.rc")
+target_sources(vpnsmgr PRIVATE "${CMAKE_BINARY_DIR}/VerScript/vpnsmgr.rc")
 
 if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
-  set(VPNSMGR_SOURCES ${VPNSMGR_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest)
+  target_sources(vpnsmgr PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest")
 else()
-  set(VPNSMGR_SOURCES ${VPNSMGR_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest)
+  target_sources(vpnsmgr PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest")
 endif()
-
-add_executable(vpnsmgr WIN32 ${VPNSMGR_SOURCES})
 
 set_target_properties(vpnsmgr
   PROPERTIES

--- a/src/vpntest/CMakeLists.txt
+++ b/src/vpntest/CMakeLists.txt
@@ -1,14 +1,7 @@
-set(VPNTEST_SOURCES vpntest.c vpntest.h)
+set(COMPONENT_NAME "Testing Utility")
+set(COMPONENT_INTERNAL_NAME "vpntest")
 
-if(WIN32)
-  if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
-    set(VPNTEST_SOURCES ${VPNTEST_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest)
-  else()
-    set(VPNTEST_SOURCES ${VPNTEST_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest)
-  endif()
-endif()
-
-add_executable(vpntest ${VPNTEST_SOURCES})
+add_executable(vpntest vpntest.c vpntest.h)
 
 set_target_properties(vpntest
   PROPERTIES
@@ -22,6 +15,18 @@ if(WIN32)
     PROPERTIES
     PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
   )
+
+  get_filename_component(COMPONENT_FILE_NAME vpntest NAME)
+  set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
+
+  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpntest.rc")
+  target_sources(vpntest PRIVATE vpntest.rc "${CMAKE_BINARY_DIR}/VerScript/vpntest.rc")
+
+  if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
+    target_sources(vpntest PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest")
+  else()
+    target_sources(vpntest PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest")
+  endif()
 endif()
 
 target_link_libraries(vpntest cedar mayaqua)

--- a/src/vpntest/CMakeLists.txt
+++ b/src/vpntest/CMakeLists.txt
@@ -2,9 +2,9 @@ set(VPNTEST_SOURCES vpntest.c vpntest.h)
 
 if(WIN32)
   if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
-    set(VPNTEST_SOURCES ${VPNTEST_SOURCES} ${CMAKE_SOURCE_DIR}/src/BuildFiles/Manifests/x64_user.manifest)
+    set(VPNTEST_SOURCES ${VPNTEST_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest)
   else()
-    set(VPNTEST_SOURCES ${VPNTEST_SOURCES} ${CMAKE_SOURCE_DIR}/src/BuildFiles/Manifests/x86_user.manifest)
+    set(VPNTEST_SOURCES ${VPNTEST_SOURCES} ${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest)
   endif()
 endif()
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - Changes the versioning resource template so that it uses CMake's variables syntax.
 - Configure CMake so that it uses the versioning resource template for each target.
 - Edit `BuildUtil` so that it uses the new variables.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.