### PR TITLE
AppVeyor: shorten artifacts path, move github token to variables

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,14 +25,14 @@ for:
     - src\BuildAll.cmd
     - exit %errorlevel%
   after_build:
-    - 7z a "%APPVEYOR_BUILD_FOLDER%\src\bin\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x86_%CONFIGURATION%_PDBs-vs2015.zip" "%APPVEYOR_BUILD_FOLDER%\src\DebugFiles\pdb\Win32_Release\*.pdb"
-    - 7z a "%APPVEYOR_BUILD_FOLDER%\src\bin\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%_PDBs-vs2015.zip" "%APPVEYOR_BUILD_FOLDER%\src\DebugFiles\pdb\x64_Release\*.pdb"
+    - 7z a "%APPVEYOR_BUILD_FOLDER%\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x86_%CONFIGURATION%_PDBs-vs2015.zip" "%APPVEYOR_BUILD_FOLDER%\src\DebugFiles\pdb\Win32_Release\*.pdb"
+    - 7z a "%APPVEYOR_BUILD_FOLDER%\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%_PDBs-vs2015.zip" "%APPVEYOR_BUILD_FOLDER%\src\DebugFiles\pdb\x64_Release\*.pdb"
   artifacts:
     - path: output\pkg\*\*
       name: Release
-    - path: src\bin\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x86_%CONFIGURATION%_PDBs-vs2015.zip
+    - path: "%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x86_%CONFIGURATION%_PDBs-vs2015.zip"
       name: PDBs (x86)
-    - path: src\bin\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%_PDBs-vs2015.zip
+    - path: "%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%_PDBs-vs2015.zip"
       name: PDBs (x64)
 -
   matrix:
@@ -48,13 +48,13 @@ for:
     - ps: cd $env:APPVEYOR_BUILD_FOLDER
     - ps: .\.ci\appveyor-vpntest.ps1
   after_build:
-    - 7z a "%APPVEYOR_BUILD_FOLDER%\build\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%-vs2017.zip" "%APPVEYOR_BUILD_FOLDER%\build\*.exe"
-    - 7z a "%APPVEYOR_BUILD_FOLDER%\build\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%-vs2017.zip" "%APPVEYOR_BUILD_FOLDER%\build\hamcore.se2"
-    - 7z a "%APPVEYOR_BUILD_FOLDER%\build\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%_PDBs-vs2017.zip" "%APPVEYOR_BUILD_FOLDER%\build\*.pdb"
+    - 7z a "%APPVEYOR_BUILD_FOLDER%\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%-vs2017.zip" "%APPVEYOR_BUILD_FOLDER%\build\*.exe"
+    - 7z a "%APPVEYOR_BUILD_FOLDER%\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%-vs2017.zip" "%APPVEYOR_BUILD_FOLDER%\build\hamcore.se2"
+    - 7z a "%APPVEYOR_BUILD_FOLDER%\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%_PDBs-vs2017.zip" "%APPVEYOR_BUILD_FOLDER%\build\*.pdb"
   artifacts:
-    - path: build\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%-vs2017.zip
+    - path: "%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%-vs2017.zip"
       name: Release
-    - path: build\%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%_PDBs-vs2017.zip
+    - path: "%APPVEYOR_PROJECT_NAME%_%APPVEYOR_BUILD_VERSION%_Windows_x64_%CONFIGURATION%_PDBs-vs2017.zip"
       name: PDBs
 -
   matrix:
@@ -81,7 +81,6 @@ for:
 deploy:
   description: 'automatic release'
   provider: GitHub
-  auth_token:
-    secure: AMFTEsa7hI1osVhKFo+e8ueIWyzP7dITIGVWkhCoOfHEnHaYBzz7acqrJD/qB0H8
+  auth_token: $(github_token)
   on:
     APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one