### PR TITLE
CI: avoid not needed builds, make AppVeyor upload src with submodules

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,11 @@ configuration: Release
 skip_branch_with_pr: true
 clone_depth: 1
 
+skip_commits:
+  files:
+    - .travis.yml
+    - .gitlab-ci.yml
+
 init:
   - ps: Update-AppveyorBuild -Version "build-$env:APPVEYOR_BUILD_NUMBER-$($env:APPVEYOR_REPO_COMMIT.substring(0,7))"
 
@@ -71,6 +76,7 @@ for:
     only:
       - image: Ubuntu1804
   before_build:
+    - sh: "if [ ${APPVEYOR_REPO_TAG} == \"true\" ]; then tar --exclude=.git -czf /tmp/${APPVEYOR_REPO_TAG_NAME}.tar.gz . && appveyor PushArtifact /tmp/${APPVEYOR_REPO_TAG_NAME}.tar.gz \nfi"
     - ./configure
   build_script:
     - make package -C tmp -j $(nproc || sysctl -n hw.ncpu || echo 4)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,10 @@
 .ubuntu: &ubuntu_def
   variables:
     CMAKE_VERSION: 3.9.6
+  except:
+    changes:
+      - .appveyor.yml
+      - .travis.yml
   before_script:
     - REPOSITORY="$PWD" && cd ..
     - apt-get update && apt-get install -y dpkg-dev wget g++ gcc libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev git file


### PR DESCRIPTION
Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one