### PR TITLE
Mayaqua: fix segmentation fault, add new FreeSafe() function

### DIFF
--- a/src/Mayaqua/Memory.c
+++ b/src/Mayaqua/Memory.c
@@ -3777,6 +3777,13 @@ void Free(void *addr)
 	InternalFree(tag);
 }
 
+// Free and set pointer's value to NULL
+void FreeSafe(void **addr)
+{
+	Free(*addr);
+	*addr = NULL;
+}
+
 // Check the memtag
 void CheckMemTag(MEMTAG *tag)
 {

--- a/src/Mayaqua/Memory.h
+++ b/src/Mayaqua/Memory.h
@@ -276,6 +276,7 @@ void *ZeroMalloc(UINT size);
 void *ZeroMallocEx(UINT size, bool zero_clear_when_free);
 void *ReAlloc(void *addr, UINT size);
 void Free(void *addr);
+void FreeSafe(void **addr);
 void CheckMemTag(MEMTAG *tag);
 UINT GetMemSize(void *addr);
 

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -20564,7 +20564,7 @@ HTTP_HEADER *RecvHttpHeader(SOCK *s)
 	// Split into tokens
 	token = ParseToken(str, " ");
 
-	Free(str);
+	FreeSafe((void **)&str);
 
 	if (token->NumTokens < 3)
 	{
@@ -20590,18 +20590,18 @@ HTTP_HEADER *RecvHttpHeader(SOCK *s)
 		if (IsEmptyStr(str))
 		{
 			// End of header
-			Free(str);
+			FreeSafe((void **)&str);
 			break;
 		}
 
 		if (AddHttpValueStr(header, str) == false)
 		{
-			Free(str);
+			FreeSafe((void **)&str);
 			FreeHttpHeader(header);
 			break;
 		}
 
-		Free(str);
+		FreeSafe((void **)&str);
 	}
 
 	return header;

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -20563,12 +20563,14 @@ HTTP_HEADER *RecvHttpHeader(SOCK *s)
 
 	// Split into tokens
 	token = ParseToken(str, " ");
-	if (token->NumTokens < 3)
-	{
-		goto LABEL_ERROR;
-	}
 
 	Free(str);
+
+	if (token->NumTokens < 3)
+	{
+		FreeToken(token);
+		return NULL;
+	}
 
 	// Creating a header object
 	header = NewHttpHeader(token->Token[0], token->Token[1], token->Token[2]);
@@ -20594,21 +20596,15 @@ HTTP_HEADER *RecvHttpHeader(SOCK *s)
 
 		if (AddHttpValueStr(header, str) == false)
 		{
-			goto LABEL_ERROR;
+			Free(str);
+			FreeHttpHeader(header);
+			break;
 		}
 
 		Free(str);
 	}
 
 	return header;
-
-LABEL_ERROR:
-	// Memory release
-	Free(str);
-	FreeToken(token);
-	FreeHttpHeader(header);
-
-	return NULL;
 }
 
 // Receive a line


### PR DESCRIPTION
Changes proposed in this pull request:
 - Revamp `RecvHttpHeader()` so that cleanup functions are not called twice.
 - Add new `FreeSafe()` function which frees the memory and sets the passed pointer's value to `NULL`. It's useful to guarantee that freed area is not accessed with that pointer (it causes a segmentation fault). This also allows to safely call cleanup functions multiple times.

Both changes solve the crash I experienced:
```c
#0  0x00007fd306127e22 in FreeToken (tokens=0x560a0090ba40) at /src/Mayaqua/Str.c:2353
#1  0x00007fd306120653 in RecvHttpHeader (s=s@entry=0x7fd2f00fc840) at /src/Mayaqua/Network.c:20608
#2  0x00007fd30645ba98 in ServerDownloadSignature (c=c@entry=0x560a00909060, error_detail_str=error_detail_str@entry=0x7fd2e74399a0) at /src/Cedar/Protocol.c:5665
#3  0x00007fd30645e249 in ServerAccept (c=c@entry=0x560a00909060) at /src/Cedar/Protocol.c:1290
#4  0x00007fd3064182b1 in ConnectionAccept (c=c@entry=0x560a00909060) at /src/Cedar/Connection.c:3125
#5  0x00007fd30643204a in TCPAcceptedThread (t=<optimized out>, param=<optimized out>) at /src/Cedar/Listener.c:273
#6  0x00007fd306101bb5 in ThreadPoolProc (t=0x7fd2f04ef890, param=0x7fd2f04ef5d0) at /src/Mayaqua/Kernel.c:983
#7  0x00007fd306133b7c in UnixDefaultThreadProc (param=0x7fd2f04f7690) at /src/Mayaqua/Unix.c:1672
#8  0x00007fd304741494 in start_thread (arg=0x7fd2e7443440) at pthread_create.c:333
#9  0x00007fd305e10acf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.