### PR TITLE
Mayaqua: query OpenSSL for the list of available ciphers instead of relying on a static list

### DIFF
--- a/src/Cedar/Command.c
+++ b/src/Cedar/Command.c
@@ -8850,6 +8850,8 @@ UINT PsServerCipherGet(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 		c->Write(c, tmp);
 	}
 
+	FreeToken(ciphers);
+
 	FreeRpcStr(&t);
 
 	FreeParamValueList(o);

--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -17029,6 +17029,7 @@ void SmSslDlgInit(HWND hWnd, SM_SSL *s)
 		StrToUni(tmp, sizeof(tmp), name);
 		CbAddStr(hWnd, C_CIPHER, tmp, 0);
 	}
+	FreeToken(cipher_list);
 
 	if (s->p != NULL)
 	{


### PR DESCRIPTION
In preparation for #360.

Tested with OpenSSL 1.1.1a.

Before:
```
VPN Server>ServerCipherGet
ServerCipherGet command - Get the Encrypted Algorithm Used for VPN Communication.
Encrypted Algorithm Currently Used by VPN Server: 
 ~DEFAULT~

List of Usable Encrypted Algorithm Names: 
 RC4-MD5
 RC4-SHA
 AES128-SHA
 AES256-SHA
 DES-CBC-SHA
 DES-CBC3-SHA
 DHE-RSA-AES128-SHA
 DHE-RSA-AES256-SHA
 AES128-GCM-SHA256
 AES128-SHA256
 AES256-GCM-SHA384
 AES256-SHA256
 DHE-RSA-AES128-GCM-SHA256
 DHE-RSA-AES128-SHA256
 DHE-RSA-AES256-GCM-SHA384
 DHE-RSA-AES256-SHA256
 ECDHE-RSA-AES128-GCM-SHA256
 ECDHE-RSA-AES128-SHA256
 ECDHE-RSA-AES256-GCM-SHA384
 ECDHE-RSA-AES256-SHA384
 DHE-RSA-CHACHA20-POLY1305
 ECDHE-RSA-CHACHA20-POLY1305
The command completed successfully.
```

After:
```
VPN Server>ServerCipherGet
ServerCipherGet command - Get the Encrypted Algorithm Used for VPN Communication.
Encrypted Algorithm Currently Used by VPN Server: 
 ~DEFAULT~

List of Usable Encrypted Algorithm Names: 
 TLS_AES_256_GCM_SHA384
 TLS_CHACHA20_POLY1305_SHA256
 TLS_AES_128_GCM_SHA256
 ECDHE-ECDSA-AES256-GCM-SHA384
 ECDHE-RSA-AES256-GCM-SHA384
 DHE-RSA-AES256-GCM-SHA384
 ECDHE-ECDSA-CHACHA20-POLY1305
 ECDHE-RSA-CHACHA20-POLY1305
 DHE-RSA-CHACHA20-POLY1305
 ECDHE-ECDSA-AES128-GCM-SHA256
 ECDHE-RSA-AES128-GCM-SHA256
 DHE-RSA-AES128-GCM-SHA256
 ECDHE-ECDSA-AES256-SHA384
 ECDHE-RSA-AES256-SHA384
 DHE-RSA-AES256-SHA256
 ECDHE-ECDSA-AES128-SHA256
 ECDHE-RSA-AES128-SHA256
 DHE-RSA-AES128-SHA256
 ECDHE-ECDSA-AES256-SHA
 ECDHE-RSA-AES256-SHA
 DHE-RSA-AES256-SHA
 ECDHE-ECDSA-AES128-SHA
 ECDHE-RSA-AES128-SHA
 DHE-RSA-AES128-SHA
 AES256-GCM-SHA384
 AES128-GCM-SHA256
 AES256-SHA256
 AES128-SHA256
 AES256-SHA
 AES128-SHA
The command completed successfully.
```

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.