### PR TITLE
Cedar/IPC.c: fix memory leak occurring when both the username and common name are not present (OpenVPN)

### DIFF
--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -433,6 +433,13 @@ IPC *NewIPC(CEDAR *cedar, char *client_name, char *postfix, char *hubname, char 
 	{
 		p = PackLoginWithPlainPassword(hubname, username, password);
 	}
+
+	if (p == NULL)
+	{
+		err = ERR_AUTH_FAILED;
+		goto LABEL_ERROR;
+	}
+
 	PackAddStr(p, "hello", client_name);
 	PackAddInt(p, "client_ver", cedar->Version);
 	PackAddInt(p, "client_build", cedar->Build);

--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -7126,6 +7126,7 @@ PACK *PackLoginWithOpenVPNCertificate(char *hubname, char *username, X *x)
 	{
 		if (x->subject_name == NULL)
 		{
+			FreePack(p);
 			return NULL;
 		}
 		UniToStr(cn_username, sizeof(cn_username), x->subject_name->CommonName);


### PR DESCRIPTION
`PackLoginWithOpenVPNCertificate()` returned `NULL` without calling `FreePack()` on the allocated object.

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.