### PR TITLE
Mayaqua: add "PTR_TO_PTR" macro intended to be used with FreeSafe()

### DIFF
--- a/src/Mayaqua/Memory.h
+++ b/src/Mayaqua/Memory.h
@@ -128,6 +128,7 @@
 #define	MEMTAG_TO_POINTER(p)				((void *)(((UCHAR *)(p)) + sizeof(MEMTAG)))
 #define	POINTER_TO_MEMTAG(p)				((MEMTAG *)(((UCHAR *)(p)) - sizeof(MEMTAG)))
 #define	IS_NULL_POINTER(p)					(((p) == NULL) || ((POINTER_TO_UINT64(p) == (UINT64)sizeof(MEMTAG))))
+#define	PTR_TO_PTR(p)						((void **)(&p))
 
 // Fixed size of a block of memory pool
 #define	MEMPOOL_MAX_SIZE					3000

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -20564,7 +20564,7 @@ HTTP_HEADER *RecvHttpHeader(SOCK *s)
 	// Split into tokens
 	token = ParseToken(str, " ");
 
-	FreeSafe((void **)&str);
+	FreeSafe(PTR_TO_PTR(str));
 
 	if (token->NumTokens < 3)
 	{
@@ -20590,18 +20590,18 @@ HTTP_HEADER *RecvHttpHeader(SOCK *s)
 		if (IsEmptyStr(str))
 		{
 			// End of header
-			FreeSafe((void **)&str);
+			FreeSafe(PTR_TO_PTR(str));
 			break;
 		}
 
 		if (AddHttpValueStr(header, str) == false)
 		{
-			FreeSafe((void **)&str);
+			FreeSafe(PTR_TO_PTR(str));
 			FreeHttpHeader(header);
 			break;
 		}
 
-		FreeSafe((void **)&str);
+		FreeSafe(PTR_TO_PTR(str));
 	}
 
 	return header;


### PR DESCRIPTION
`FreeSafe()` (introduced in #841) needs an argument of type `void **` (pointer to pointer), so that it can set the pointer's value to `NULL` once the memory is freed.

Pointers of different data types are implicitly converted to `void *` when required, however it's not the case for `void **` (it results in a compiler warning).

The new `PTR_TO_PTR` macro does the required conversion, allowing to write:
```c
char *str = Malloc(1);
FreeSafe(PTR_TO_PTR(str));
```

instead of:

```c
char *str = Malloc(1);
FreeSafe((void **)&str));
```

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.