### PR TITLE
travis-ci: try to fix coverity scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ script:
   - export LD_LIBRARY_PATH="${HOME}/opt/lib:${LD_LIBRARY_PATH:-}"
   - export CFLAGS="-I${HOME}/opt/include"
   - export LDFLAGS="-L${HOME}/opt/lib"
+  - echo "check_certificate = off" > ~/.wgetrc
   - .ci/coverity.sh
   - ./configure
   - make -j $(nproc || sysctl -n hw.ncpu || echo 4) -C tmp


### PR DESCRIPTION
Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- one

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.