### PR TITLE
Mayaqua: fix segmentation fault, add new FreeHttpHeaderSafe() function

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -20645,7 +20645,7 @@ HTTP_HEADER *RecvHttpHeader(SOCK *s)
 		if (AddHttpValueStr(header, str) == false)
 		{
 			FreeSafe(PTR_TO_PTR(str));
-			FreeHttpHeader(header);
+			FreeHttpHeaderSafe(&header);
 			break;
 		}
 
@@ -20898,6 +20898,13 @@ void FreeHttpHeader(HTTP_HEADER *header)
 	ReleaseList(header->ValueList);
 
 	Free(header);
+}
+
+// Release the HTTP header and set pointer's value to NULL
+void FreeHttpHeaderSafe(HTTP_HEADER **header)
+{
+	FreeHttpHeader(*header);
+	*header = NULL;
 }
 
 // Receive a PACK

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -1037,6 +1037,7 @@ HTTP_HEADER *NewHttpHeaderEx(char *method, char *target, char *version, bool no_
 int CompareHttpValue(void *p1, void *p2);
 void FreeHttpValue(HTTP_VALUE *value);
 void FreeHttpHeader(HTTP_HEADER *header);
+void FreeHttpHeaderSafe(HTTP_HEADER **header);
 
 bool SendPack(SOCK *s, PACK *p);
 PACK *RecvPack(SOCK *s);


### PR DESCRIPTION
This fixes the following crash:
```c
#0  FreeHttpValue (value=0x25) at /src/Mayaqua/Network.c:20822
#1  0x00007fe160af5cb3 in FreeHttpHeader (header=0x7fe150021170) at /src/Mayaqua/Network.c:20846
#2  0x00007fe160e31b43 in ServerDownloadSignature (c=c@entry=0x7fe15000b350, error_detail_str=error_detail_str@entry=0x7fe15df559a0) at /src/Cedar/Protocol.c:5851
#3  0x00007fe160e341f9 in ServerAccept (c=c@entry=0x7fe15000b350) at /src/Cedar/Protocol.c:1290
#4  0x00007fe160dee261 in ConnectionAccept (c=c@entry=0x7fe15000b350) at /src/Cedar/Connection.c:3125
#5  0x00007fe160e07ffa in TCPAcceptedThread (t=<optimized out>, param=<optimized out>) at /src/Cedar/Listener.c:273
#6  0x00007fe160ad7c05 in ThreadPoolProc (t=0x55d33eda5620, param=0x55d33edc3c20) at /src/Mayaqua/Kernel.c:983
#7  0x00007fe160b09c1c in UnixDefaultThreadProc (param=0x55d33eda59e0) at /src/Mayaqua/Unix.c:1672
#8  0x00007fe15f117494 in start_thread (arg=0x7fe15df5f440) at pthread_create.c:333
#9  0x00007fe1607e6acf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

---

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

I choose option 1.