### PR TITLE
Fix crashes in GetCipherList() and StGetServerCipherList()

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -8156,7 +8156,7 @@ UINT StGetServerCipherList(ADMIN *a, RPC_STR *t)
 		{
 			UINT size = StrSize(ciphers->Token[0]);
 			t->String = Malloc(size);
-			StrCat(t->String, size, ciphers->Token[0]);
+			StrCpy(t->String, size, ciphers->Token[0]);
 			i = 1;
 
 			for (; i < ciphers->NumTokens; i++)

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -16507,7 +16507,6 @@ TOKEN_LIST *GetCipherList()
 	}
 
 	sk_SSL_CIPHER_free(sk);
-	FreeSSLCtx(ctx);
 	SSL_free(ssl);
 
 	return ciphers;

--- a/src/bin/hamcore/vpninstall_cn.inf
+++ b/src/bin/hamcore/vpninstall_cn.inf
@@ -1,5 +1,5 @@
 ﻿# SoftEther VPN Client 自动安装设定文件
-# (为了 VPN Client Web 安装程序的样品设定文件)
+# (VPN Client Web 安装程序示例设定文件)
 # 
 # Copyright (c) SoftEther Project at University of Tsukuba, Japan.
 # All Rights Reserved.
@@ -9,22 +9,22 @@
 # ※ 如果在这个文件内包含中文等的 2 字节字符，
 #    字符编码请使用 UTF-8。
 # 
-# 文字 "#" 在 (sharp) 开始的行是评语。
+# “#” 之后的文字为注释。
 
 
 # vpninstall.exe 版本号
-# (请在 vpninstall.exe 文件的 [属性] 画面确认。
+# (请在 vpninstall.exe 文件的 [属性] 页中确认。
 #  请在这里输入文件版本的末尾的 4 位整数。)
 VpnInstallBuild				$VER_BUILD$
 VpnClientBuild				$VER_BUILD$
 
 
-# 有关Windows 事情的 VPN Client 包装文件的信息
-# ※ 请指定 Web 服务器上的 URL。盘上的传球名不能指定。
+# Windows 下的 VPN Client 安装包路径
+# ※ 请指定 Web 服务器上的 URL 路径。 不可指定本地文件路径。
 VpnClientPath				http://example.com/any_folder/$PACKAGE_FILENAME$
 
-# 是不是要 VPN Client 的安装完成紧接之后的动作方式 "简单模式" 和 "标准模式" 的哪边。
-# 写 true 的话 "标准模式"，那个以外的情况成为 "简单模式"。
+# 该值为 "true" 时, VPN Client Manager将会使用标准模式。
+# 保留默认值则为简单模式。
 NormalMode					$NORMAL_MODE$
 
 


### PR DESCRIPTION
Fixes #861.

---

`SSL_free()` also frees the associated context.

https://github.com/openssl/openssl/blob/d6c3c1896cf3c0d69bc27da923d63f8130b13ca0/ssl/ssl_lib.c#L1209

From https://www.openssl.org/docs/man1.1.1/man3/SSL_free.html:

> SSL_free() also calls the free()ing procedures for indirectly affected items, if applicable: the buffering BIO, the read and write BIOs, cipher lists specially created for this **ssl**, the **SSL_SESSION**. Do not explicitly free these indirectly freed up items before or after calling SSL_free(), as trying to free things twice may lead to program failure.

---

https://github.com/SoftEtherVPN/SoftEtherVPN/blob/e939f887c45e5c092bf5c8b69d5c187448d52c9e/src/Cedar/Admin.c#L8157-L8159

`StrCat()` appends a string to an already existing string. In order to know where the existing string ends, it uses `StrLen()` which in turn uses `strlen()`, a function considered unsafe because it doesn't stop until it finds the null character.

Since the string was allocated but not initialized, `StrCat()` was either:
- Working correctly.
- Copying only a part of the string.
- Making the program crash via `strlen()`.

The fix consists in using `StrCpy()`, which starts writing at the beginning of the string.