### PR TITLE
Fix to show correct version in Server Manager GUI

### DIFF
--- a/src/Cedar/Cedar.c
+++ b/src/Cedar/Cedar.c
@@ -1416,14 +1416,7 @@ void GetCedarVersion(char *tmp, UINT size)
 
 UINT GetCedarVersionNumber()
 {
-	UINT pow = 10;
-
-	while (CEDAR_VERSION_MAJOR >= pow)
-	{
-		pow *= 10;
-	}
-
-	return CEDAR_VERSION_MAJOR * pow + CEDAR_VERSION_MINOR;
+	return CEDAR_VERSION_MAJOR * 100 + CEDAR_VERSION_MINOR;
 }
 
 // Create Cedar object


### PR DESCRIPTION
## Changes proposed in this pull request:
Server Manager GUI shows incorrect server and client version in some windows. It is caused by an inconsistency between version number [generating code](https://github.com/SoftEtherVPN/SoftEtherVPN/blob/63c01ba736a4cd4ab75ba82ab34a3fdcf235a115/src/Cedar/Cedar.c#L1419-L1426) and [formatting code](https://github.com/SoftEtherVPN/SoftEtherVPN/blob/63c01ba736a4cd4ab75ba82ab34a3fdcf235a115/src/Cedar/Protocol.c#L1602). This patch fixes it.

### Before patching
![img1](https://user-images.githubusercontent.com/6236283/52769277-33351580-3073-11e9-9ad2-684c959f1535.png)

### After patching
![img2](https://user-images.githubusercontent.com/6236283/52769287-38926000-3073-11e9-8505-1d4664a50cb3.png)
