### PR TITLE
ver.rc: fix misspelling

### DIFF
--- a/src/BuildFiles/VerScript/ver.rc
+++ b/src/BuildFiles/VerScript/ver.rc
@@ -17,7 +17,7 @@ BEGIN
             VALUE "FileVersion", "${PROJECT_VERSION_MAJOR}, ${PROJECT_VERSION_MINOR}, 0, ${PROJECT_VERSION_PATCH}"
             VALUE "InternalName", "${COMPONENT_INTERNAL_NAME}"
             VALUE "LegalCopyright", "Copyright (c) 2012-${DATE_YEAR} all contributors on SoftEther VPN project in GitHub. Copyright (C) 2004-${DATE_YEAR} Daiyuu Nobori, SoftEther Project at University of Tsukuba, and SoftEther Corporation. All Rights Reserved."
-            VALUE "LegalTrademarks", "SoftEther(R) is a registered trademark of SoftEther Corporation in Japan, United Status and People's Republic of China. SoftEther Corporation is a company founded at University of Tsukuba, Japan."
+            VALUE "LegalTrademarks", "SoftEther(R) is a registered trademark of SoftEther Corporation in Japan, United States and People's Republic of China. SoftEther Corporation is a company founded at University of Tsukuba, Japan."
             VALUE "OriginalFilename", "${COMPONENT_FILE_NAME}"
             VALUE "ProductName", "${PROJECT_NAME} ${COMPONENT_NAME}"
             VALUE "ProductVersion", "${PROJECT_VERSION_MAJOR}, ${PROJECT_VERSION_MINOR}, 0, ${PROJECT_VERSION_PATCH}"


### PR DESCRIPTION
## Changes proposed in this pull request:
This patch fixes the trademark statement in `ver.rc` file that indicates `United Status`. (misspelling of `United States`?)
