### PR TITLE
Add basic CI definition for illumos

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,14 @@ precise:
   <<: *ubuntu_def
   image: ubuntu:precise
 
+build_illumos:
+  tags: 
+    - illumos
+  stage: build
+  script:
+    - git submodule init && git submodule update
+    - CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=/opt/local -DCMAKE_CXX_FLAGS=-m64 -DCMAKE_C_FLAGS=-m64" ./configure
+    - gmake -C tmp
 
 #
 # flawfinder


### PR DESCRIPTION
Hello, 

Following up on #881, attached is a basic CI definition for illumos that I've tested on my private fork of SoftEtherVPN on gitlab[1]. 

The basic changes over a standard "out of the box" build are to force 64 bit mode and to look in /opt/local for non-system libraries (such as readline, etc)

I can link my illumos runner to this project if given a CI runner registration token.

[1] https://gitlab.com/hww3/SoftEtherVPN/