### PR TITLE
src/Cedar/Admin.c: remove redundant check

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -411,7 +411,7 @@ bool AdminWebHandleFileRequest(ADMIN *a, CONNECTION *c, SOCK *s, HTTP_HEADER *h,
 	bool ret = false;
 	char url[MAX_PATH];
 	UINT i, len;
-	if (a == NULL || c == NULL || s == NULL || h == NULL || url == NULL || query_string == NULL ||
+	if (a == NULL || c == NULL || s == NULL || h == NULL || query_string == NULL ||
 		virtual_root_dir == NULL || physical_root_dir == NULL)
 	{
 		return false;


### PR DESCRIPTION
found by Coverity

*** CID 341551:  Incorrect expression  (NO_EFFECT)
/src/Cedar/Admin.c: 414 in AdminWebHandleFileRequest()
408     // Handle the file request
409     bool AdminWebHandleFileRequest(ADMIN *a, CONNECTION *c, SOCK *s, HTTP_HEADER *h, char *url_src, char *query_string, char *virtual_root_dir, char *physical_root_dir)
410     {
411             bool ret = false;
412             char url[MAX_PATH];
413             UINT i, len;
>>>     CID 341551:  Incorrect expression  (NO_EFFECT)
>>>     Comparing an array to null is not useful: "url == NULL", since the test will always evaluate as true.
414             if (a == NULL || c == NULL || s == NULL || h == NULL || url == NULL || query_string == NULL ||
415                     virtual_root_dir == NULL || physical_root_dir == NULL)
416             {
417                     return false;
418             }
419


