### PR TITLE
Mayaqua: Replace GNU specific sys/poll.h header with POSIX poll.h

### DIFF
--- a/src/Mayaqua/Mayaqua.h
+++ b/src/Mayaqua/Mayaqua.h
@@ -157,8 +157,8 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 #ifdef	UNIX_SOLARIS
 #include <sys/filio.h>
 #endif	// UNIX_SOLARIS
-#include <sys/poll.h>
 #include <sys/resource.h>
+#include <poll.h>
 #include <pthread.h>
 #ifdef	UNIX_LINUX
 #include <sys/prctl.h>


### PR DESCRIPTION
Fixes warning from the musl libc:

warning redirecting incorrect #include <sys/poll.h> to <poll.h>