### PR TITLE
Mayaqua: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/src/Mayaqua/Secure.c
+++ b/src/Mayaqua/Secure.c
@@ -32,6 +32,7 @@
 #include <openssl/rc4.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>
+#include <openssl/rsa.h>
 #include <Mayaqua/Mayaqua.h>
 #include <Mayaqua/cryptoki.h>
 


### PR DESCRIPTION
Initialization and deinitialization are deprecated.

Missing headers were added.

Explicit threading is also deprecated.