### PR TITLE
WIP: add "no-deprecated" to openssl builds

### DIFF
--- a/.ci/build-openssl.sh
+++ b/.ci/build-openssl.sh
@@ -12,7 +12,7 @@ build_openssl () {
     if [[ "$(cat ${OPENSSL_INSTALL_DIR}/.openssl-version)" != "${OPENSSL_VERSION}" ]]; then
         tar zxf "download-cache/openssl-${OPENSSL_VERSION}.tar.gz"
         cd "openssl-${OPENSSL_VERSION}/"
-        ./config shared --prefix="${OPENSSL_INSTALL_DIR}" --openssldir="${OPENSSL_INSTALL_DIR}" -DPURIFY
+        ./config shared no-deprecated --prefix="${OPENSSL_INSTALL_DIR}" --openssldir="${OPENSSL_INSTALL_DIR}" -DPURIFY
         make -j $(nproc || sysctl -n hw.ncpu || echo 4) all
         make install_sw
         echo "${OPENSSL_VERSION}" > "${OPENSSL_INSTALL_DIR}/.openssl-version"


### PR DESCRIPTION
"no-deprecated" is widely used in openwrt devices


