### PR TITLE
Enable crash minidump for Win32 vpntest

### DIFF
--- a/src/Mayaqua/Microsoft.c
+++ b/src/Mayaqua/Microsoft.c
@@ -12338,6 +12338,12 @@ bool MsGetMsiInstalledDir(char *component_code, wchar_t *dir, UINT dir_size)
 	return ret;
 }
 
+// Determine whether minidump is enabled
+bool MsIsMinidumpEnabled()
+{
+	return ms->MiniDumpEnabled;
+}
+
 // Determine whether to create a minidump
 void MsSetEnableMinidump(bool enabled)
 {

--- a/src/Mayaqua/Microsoft.h
+++ b/src/Mayaqua/Microsoft.h
@@ -886,6 +886,7 @@ bool MsIsWinXPOrWinVista();
 bool MsGetFileInformation(void *h, void *info);
 void MsSetErrorModeToSilent();
 void MsSetEnableMinidump(bool enabled);
+bool MsIsMinidumpEnabled();
 void MsWriteMinidump(wchar_t *filename, void *ex);
 
 

--- a/src/vpntest/vpntest.c
+++ b/src/vpntest/vpntest.c
@@ -116,7 +116,7 @@ int TestMain(char *cmd)
 	Print("   - In Jurassic Park: \"It's a UNIX system! I know this!\"\n\n");
 
 #ifdef	OS_WIN32
-	MsSetEnableMinidump(false);
+	MsSetEnableMinidump(true);
 #endif	// OS_WIN32
 
 	while (true)


### PR DESCRIPTION
Enables crash minidump for Win32 vpntest.
Minidump files will be saved to:

- `C:\Users\<username>\AppData\Local\Temp\vpn_debug` (for normal user)
- `src\bin\vpn_debug` (for administrator user).