### PR TITLE
Fix buffer overflow during NETBIOS name resolution

### DIFF
--- a/src/Cedar/Virtual.c
+++ b/src/Cedar/Virtual.c
@@ -6118,7 +6118,7 @@ void EncodeNetBiosName(UCHAR *dst, char *src)
 		copy_len = 16;
 	}
 
-	Copy(tmp, src, StrLen(src));
+	Copy(tmp, src, copy_len);
 
 	wp = 0;
 


### PR DESCRIPTION
If SecureNAT is enabled and the hostname of the server
is longer than 16characters, every NETBIOS name resolution
query triggers the buffer overflow. If the server was built
with stack protection, the process will be killed.