### PR TITLE
Protocol.c: fix bug in ClientConnectGetSocket() causing custom HTTP header not to work

### DIFF
--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -6056,7 +6056,7 @@ SOCK *ClientConnectGetSocket(CONNECTION *c, bool additional_connect)
 	w.ProxyPort = o->ProxyPort;
 	StrCpy(w.ProxyUsername, sizeof(w.ProxyUsername), o->ProxyUsername);
 	StrCpy(w.ProxyPassword, sizeof(w.ProxyPassword), o->ProxyPassword);
-	StrCpy(w.CustomHttpHeader, sizeof(w.CustomHttpHeader), w.CustomHttpHeader);
+	StrCpy(w.CustomHttpHeader, sizeof(w.CustomHttpHeader), o->CustomHttpHeader);
 
 	switch (o->ProxyType)
 	{


### PR DESCRIPTION
The bug was caused by a typo in the `StrCpy()` call: the source buffer was the same as the destination one, meaning that the function didn't do anything.

The feature was introduced in #772.