### PR TITLE
Mayaqua.h: include <stdarg.h> for "va_list" on Illumos

### DIFF
--- a/src/Mayaqua/Mayaqua.h
+++ b/src/Mayaqua/Mayaqua.h
@@ -8,6 +8,7 @@
 #ifndef	MAYAQUA_H
 #define	MAYAQUA_H
 
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
 


### PR DESCRIPTION
#1009 introduced a new source file, which doesn't include any standard headers.

The missing include was not spotted because the GitLab CI is not enabled for pull requests.