### PR TITLE
Proto_OpenVPN.c: fix segmentation fault in OvsProceccRecvPacket()

### DIFF
--- a/src/Cedar/Proto_OpenVPN.c
+++ b/src/Cedar/Proto_OpenVPN.c
@@ -681,10 +681,12 @@ void OvsProceccRecvPacket(OPENVPN_SERVER *s, UDPPACKET *p)
 			{
 				// Decrypt
 				size = OvsDecrypt(c->CipherDecrypt, c->MdRecv, c->IvRecv, data, recv_packet->Data, recv_packet->DataSize);
-
-				// Seek buffer after the packet ID
-				data += sizeof(UINT);
-				size -= sizeof(UINT);
+				if (size > sizeof(UINT))
+				{
+					// Seek buffer after the packet ID
+					data += sizeof(UINT);
+					size -= sizeof(UINT);
+				}
 			}
 
 			// Update of last communication time


### PR DESCRIPTION
`OvsDecrypt()` returns 0 when it fails, resulting in `size` rolling over with an end result of `4294967292`.

This commit fixes the issue by checking whether `size` is greater than `sizeof(UINT)` before performing the subtraction.

---

Fixes #1017.