### PR TITLE
Make install dir for unit files configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ if(UNIX)
 
   include(CheckIncludeFile)
   Check_Include_File(sys/auxv.h HAVE_SYS_AUXV)
+  if(EXISTS "/lib/systemd/system")
+    set(CMAKE_INSTALL_SYSTEMD_UNITDIR "/lib/systemd" CACHE STRING "Where to install systemd unit files")
+  endif()
 endif()
 
 configure_file("${TOP_DIRECTORY}/AUTHORS.TXT" "${TOP_DIRECTORY}/src/bin/hamcore/authors.txt" COPYONLY)

--- a/src/vpnbridge/CMakeLists.txt
+++ b/src/vpnbridge/CMakeLists.txt
@@ -40,11 +40,11 @@ if(UNIX)
   )
 
   install_wrapper_script("vpnbridge" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnbridge/vpnbridge")
-  if(EXISTS "/lib/systemd/system")
+  if (NOT CMAKE_INSTALL_SYSTEMD_UNITDIR STREQUAL "")
     configure_file(${TOP_DIRECTORY}/systemd/softether-vpnbridge.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnbridge.service)
     install(FILES ${CMAKE_BINARY_DIR}/systemd/softether-vpnbridge.service
       COMPONENT "vpnbridge"
-      DESTINATION "/lib/systemd/system"
+      DESTINATION ${CMAKE_INSTALL_SYSTEMD_UNITDIR}
       PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif()

--- a/src/vpnclient/CMakeLists.txt
+++ b/src/vpnclient/CMakeLists.txt
@@ -40,11 +40,11 @@ if(UNIX)
   )
 
   install_wrapper_script("vpnclient" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnclient/vpnclient")
-  if(EXISTS "/lib/systemd/system")
+  if (NOT CMAKE_INSTALL_SYSTEMD_UNITDIR STREQUAL "")
     configure_file(${TOP_DIRECTORY}/systemd/softether-vpnclient.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnclient.service)
     install(FILES ${CMAKE_BINARY_DIR}/systemd/softether-vpnclient.service
       COMPONENT "vpnclient"
-      DESTINATION "/lib/systemd/system"
+      DESTINATION ${CMAKE_INSTALL_SYSTEMD_UNITDIR}
       PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif()

--- a/src/vpnserver/CMakeLists.txt
+++ b/src/vpnserver/CMakeLists.txt
@@ -40,11 +40,11 @@ if(UNIX)
   )
 
   install_wrapper_script("vpnserver" "${CMAKE_INSTALL_FULL_LIBEXECDIR}/softether/vpnserver/vpnserver")
-  if(EXISTS "/lib/systemd/system")
+  if (NOT CMAKE_INSTALL_SYSTEMD_UNITDIR STREQUAL "")
     configure_file(${TOP_DIRECTORY}/systemd/softether-vpnserver.service ${CMAKE_BINARY_DIR}/systemd/softether-vpnserver.service)
     install(FILES ${CMAKE_BINARY_DIR}/systemd/softether-vpnserver.service
       COMPONENT "vpnserver"
-      DESTINATION "/lib/systemd/system"
+      DESTINATION ${CMAKE_INSTALL_SYSTEMD_UNITDIR}
       PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif()


### PR DESCRIPTION
Currently the systemd service unit files are installed
into /lib/systemd/system if that directory exists. This
might not be optimal for every user, e.g. when the build
system is not the target system or when building as an
unprivileged user using CMAKE_INSTALL_PREFIX.

Make this configurable by adding a cached cmake variable
CMAKE_INSTALL_SYSTEMD_UNITDIR. Usage:

- install unit files into /lib/systemd/system if it exists (old
behavior)

    cmake

- don't install unit files

   cmake -D CMAKE_INSTALL_SYSTEMD_UNITDIR=

- install into absolute path

   cmake -D CMAKE_INSTALL_SYSTEMD_UNITDIR=/path

- install into path relative to ${CMAKE_INSTALL_PREFIX}

   cmake -D CMAKE_INSTALL_SYSTEMD_UNITDIR=path

