### PR TITLE
Mayaqua: Fix compilation with external iconv

### DIFF
--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -59,7 +59,7 @@ if(UNIX)
   find_package(ZLIB REQUIRED)
 
   # In some cases libiconv is not included in libc
-  find_library(LIB_ICONV iconv)
+  find_library(LIB_ICONV iconv HINTS "${ICONV_LIB_PATH}")
 
   find_library(LIB_RT rt)
 


### PR DESCRIPTION
This small modification is needed for external iconv. This patch is carried in OpenWrt.
