### PR TITLE
Further FreeBSD CI refinements

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,30 +1,29 @@
 FreeBSD_task:
-  freebsd_instance:
-    image: freebsd-12-1-release-amd64
+  matrix:
+    env:
+      SSL: openssl
+    env:
+      SSL: openssl111
+    env:
+      SSL: libressl
+    env:
+      SSL: libressl-devel
+  matrix:
+    freebsd_instance:
+      image: freebsd-12-1-release-amd64
+    freebsd_instance:
+      # 11-3-release doesn't boot: https://cirrus-ci.org/guide/FreeBSD/
+      image: freebsd-11-3-stable-amd64-v20191205
   env:
     ASSUME_ALWAYS_YES: TRUE # required for unattanded "pkg" invocation
-  install_script:
-    - pkg install cmake openssl111 git
+  prepare_script:
+    - pkg install cmake git $SSL
     - git submodule update --init --recursive
-  script:
+  configure_script:
     - ./configure
+  build_script:
     - make -j $(sysctl -n hw.ncpu || echo 4) -C tmp
-    - ldd build/vpnserver
-    - .ci/memory-leak-test.sh
-    - .ci/vpntools-check.sh
-
-FreeBSD_task:
-  freebsd_instance:
-    # 11-3-release doesn't boot: https://cirrus-ci.org/guide/FreeBSD/
-    image: freebsd-11-3-stable-amd64-v20191205
-  env:
-    ASSUME_ALWAYS_YES: TRUE # required for unattanded "pkg" invocation
-  install_script:
-    - pkg install cmake openssl111 git
-    - git submodule update --init --recursive
-  script:
-    - ./configure
-    - make -j $(sysctl -n hw.ncpu || echo 4) -C tmp
+  test_script:
     - ldd build/vpnserver
     - .ci/memory-leak-test.sh
     - .ci/vpntools-check.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,15 +11,10 @@ FreeBSD_task:
     env:
       SSL:
   matrix:
-    freebsd_instance:
-      image: freebsd-12-1-release-amd64
-    freebsd_instance:
-      # 11-3-release doesn't boot: https://cirrus-ci.org/guide/FreeBSD/
-      image: freebsd-11-3-stable-amd64-v20191205
-  env:
-    ASSUME_ALWAYS_YES: TRUE # required for unattanded "pkg" invocation
+      image_family: freebsd-12-1-release-amd64
+      image_family: freebsd-11-3-snap
   prepare_script:
-    - pkg install cmake git $SSL
+    - pkg install -y cmake git $SSL
     - git submodule update --init --recursive
   configure_script:
     - ./configure

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,9 @@ FreeBSD_task:
     env:
       SSL:
   matrix:
-      image_family: freebsd-12-1-release-amd64
+    freebsd_instance:
+      image_family: freebsd-12-1
+    freebsd_instance:
       image_family: freebsd-11-3-snap
   prepare_script:
     - pkg install -y cmake git $SSL

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,6 +8,8 @@ FreeBSD_task:
       SSL: libressl
     env:
       SSL: libressl-devel
+    env:
+      SSL:
   matrix:
     freebsd_instance:
       image: freebsd-12-1-release-amd64


### PR DESCRIPTION
Hi, I've learned Cirrus CI and made further refinements on FreeBSD CI.

Cirrus CI also has matrix to define multiple build conditions, so I use it. FreeBSD has multiple SSL libraries, so perform build test for each.
* base system OpenSSL
* ports OpenSSL
* ports OpenSSL 1.1.1
* ports LibreSSL
* ports LibreSSL development version

And also perform CI test with supported FreeBSD version 11 and 12.

Also, separate build procedure into prepare, configure, build, and test stage.
