### PR TITLE
Bugfix: Fix the SecureNAT connection problem with ignoring TCP ECN bit enabled packets

### DIFF
--- a/src/Cedar/Virtual.c
+++ b/src/Cedar/Virtual.c
@@ -1446,7 +1446,7 @@ void NnTcpRecvForInternet(VH *v, UINT src_ip, UINT src_port, UINT dest_ip, UINT 
 		// Create a new session because there is no existing one
 		UINT public_port;
 
-		if (old_tcp->Flag != TCP_SYN)
+		if (((old_tcp->Flag & TCP_SYN) && ((old_tcp->Flag & TCP_ACK) == 0)) == false)
 		{
 			// If there is no existing session, pass through only for SYN packet
 			return;


### PR DESCRIPTION
Changes proposed in this pull request:
 - Bugfix: Fix the SecureNAT connection problem with ignoring TCP ECN bit enabled packets
 - 
 - 

