### PR TITLE
allow to SKIP_CPU_FEATURES explicitly, not only autodetect 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,12 +3,11 @@ FreeBSD_task:
     env:
       SSL: openssl
     env:
-      SSL: openssl111
-    env:
       SSL: libressl
     env:
       SSL: libressl-devel
     env:
+      # base openssl
       SSL:
   matrix:
     freebsd_instance:

--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -65,7 +65,7 @@ if(UNIX)
 
   target_link_libraries(mayaqua PRIVATE OpenSSL::SSL OpenSSL::Crypto Threads::Threads ZLIB::ZLIB)
 
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7l|aarch64|s390x)$" OR NOT HAVE_SYS_AUXV)
+  if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7l|aarch64|s390x)$" OR NOT HAVE_SYS_AUXV OR SKIP_CPU_FEATURES)
     add_definitions(-DSKIP_CPU_FEATURES)
   else()
     add_subdirectory(3rdparty/cpu_features)


### PR DESCRIPTION
Formerly, SKIP_CPU_FEATURES is automatically detected by system
processor. However, "^(armv7l|aarch64|s390x)$" does not cover all
processors that cpu_features should be skipped.

"armv6", "armv7", "mips", "mips64" on FreeBSD are examples [1]
that cpu_features is not correctly skipped.

This change intends to build SoftEther without any modifications on
CMakeLists.txt on such processors.

    cmake . -DSKIP_CPU_FEATURES=1

[1] https://www.freebsd.org/platforms/