### PR TITLE
FreeBSD CI: quit freebsd-11-3-snap

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,8 +12,6 @@ FreeBSD_task:
   matrix:
     freebsd_instance:
       image_family: freebsd-12-1
-    freebsd_instance:
-      image_family: freebsd-11-3-snap
   prepare_script:
     - pkg install -y cmake git $SSL
     - git submodule update --init --recursive


### PR DESCRIPTION
testing on a single FreeBSD version is enough.  `-snap` images are
unstable to perform CI test.