### PR TITLE
Only enable getifaddrs support when available

### DIFF
--- a/src/Mayaqua/Mayaqua.h
+++ b/src/Mayaqua/Mayaqua.h
@@ -128,9 +128,11 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, char *CmdLine, int CmdShow)
 #ifdef	OS_UNIX
 #ifndef	UNIX_SOLARIS
 #ifndef	CPU_SH4
+#if	!defined(__UCLIBC__) || defined(__UCLIBC_SUPPORT_AI_ADDRCONFIG__)
 // Getifaddrs system call is supported on UNIX other than Solaris.
 // However, it is not supported also by the Linux on SH4 CPU
 #define	MAYAQUA_SUPPORTS_GETIFADDRS
+#endif	// !UCLIBC || UCLIBC_SUPPORT_AI_ADDRCONFIG
 #endif	// CPU_SH4
 #endif	// UNIX_SOLARIS
 #endif	// OS_UNIX


### PR DESCRIPTION
On uClibc, the ifaddrs.h support is optional. While the default
Buildroot uClibc configuration has it enabled, some external
toolchains may not. Therefore this patch detects that and adjusts
softether usage of ifaddrs accordingly.

Based on an initial patch from Bernd Kuhls.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/softether/0009-uclibc-ai-addrconfig.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>