### PR TITLE
Fix some issues found with Cppcheck static analysis

### DIFF
--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -4621,7 +4621,7 @@ REDIRECTED:
 		UINT use_port = 0;
 		UINT current_port = c->ServerPort;
 		UCHAR ticket[SHA1_SIZE];
-		X *server_cert;
+		X *server_cert = NULL;
 		BUF *b;
 
 		// Redirect mode

--- a/src/Cedar/Sam.c
+++ b/src/Cedar/Sam.c
@@ -114,7 +114,10 @@ bool SmbAuthenticate(char* name, char* password, char* domainname, char* groupna
 	char  buffer[255];
 	char  ntlm_timeout[32];
 	char* proc_parameter[6];
-	
+
+    // DNS Name 255 chars + OU names are limited to 64 characters +  cmdline 32 + 1
+    char  requiremember[352];
+
 	if (name == NULL || password == NULL || domainname == NULL || groupname == NULL)
 	{
 		Debug("Sam.c - SmbAuthenticate - wrong password parameter\n");
@@ -156,14 +159,11 @@ bool SmbAuthenticate(char* name, char* password, char* domainname, char* groupna
 
 	if (strlen(groupname) > 1)
 	{
-		// DNS Name 255 chars + OU names are limited to 64 characters +  cmdline 32 + 1
-		char  requiremember[352];
-
 		// Truncate string if unsafe char
 		EnSafeStr(groupname, '\0');
 
 		snprintf(requiremember, sizeof(requiremember), "--require-membership-of=%s\\%s", domainname, groupname);
-		
+
 		proc_parameter[4] = requiremember;
 		proc_parameter[5] = 0;
 	}


### PR DESCRIPTION
I also found some code in [BridgeUnix.c](src/Cedar/BridgeUnix.c) used for Solaris platform that likely won't work. Here is a report for [ParseUnixEthDeviceName](https://github.com/SoftEtherVPN/SoftEtherVPN/blob/22272ec8388a2c50cbfc9ca563e966be9b6469f9/src/Cedar/BridgeUnix.c#L1022):
```
[error:uninitvar][src/Cedar/BridgeUnix.c:1066]: Uninitialized variable: len
[error:uninitvar][src/Cedar/BridgeUnix.c:1056]: Uninitialized variable: i
```
