### PR TITLE
Fix security issue: Fix the security of JSON-API

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -1018,11 +1018,14 @@ ADMIN *JsonRpcAuthLogin(CEDAR *c, SOCK *sock, HTTP_HEADER *h)
 			{
 				Lock(h->lock);
 				{
-					if (Cmp(pw_hash, h->HashedPassword, SHA1_SIZE) == 0)
+					if (Cmp(h->HashedPassword, empty_pw_hash, SHA1_SIZE) != 0 && IsZero(h->HashedPassword, sizeof(h->HashedPassword)) == false)
 					{
-						is_hub_admin = true;
+						if (Cmp(pw_hash, h->HashedPassword, SHA1_SIZE) == 0)
+						{
+							is_hub_admin = true;
 
-						StrCpy(hub_name, sizeof(hub_name), h->Name);
+							StrCpy(hub_name, sizeof(hub_name), h->Name);
+						}
 					}
 				}
 				Unlock(h->lock);


### PR DESCRIPTION
Fix security issue: Fix the security of JSON-API. If the administrator password of the Virtual Hub is empty, JSON-API will not be able to access to the virtual hub with a empty password since this release. Because there are relatively many cases in which administrator password is empty for a virtual hub, being able to manage a virtual hub without a password using JSON-API was a security problem. In this release, this behavior has been changed so that JSON-API cannot be accessed in the Virtual Hub management mode until it is configured with non-empty password.