### PR TITLE
Fixup ppp unices

### DIFF
--- a/src/Cedar/Proto_PPP.c
+++ b/src/Cedar/Proto_PPP.c
@@ -1088,8 +1088,13 @@ bool PPPProcessLCPRequestPacket(PPP_SESSION *p, PPP_PACKET *pp)
 	USHORT NegotiatedMRU = PPP_UNSPECIFIED;
 	// MSCHAPv2 code
 	UCHAR ms_chap_v2_code[3];
+
+	UINT currentMagic = 0;
+
 	WRITE_USHORT(ms_chap_v2_code, PPP_LCP_AUTH_CHAP);
 	ms_chap_v2_code[2] = PPP_CHAP_ALG_MS_CHAP_V2;
+
+	Debug("Got LCP packet request ID=%i OptionsListSize=%i\n", pp->Lcp->Id, LIST_NUM(pp->Lcp->OptionList));
 
 	for (i = 0; i < LIST_NUM(pp->Lcp->OptionList); i++)
 	{
@@ -1792,6 +1797,12 @@ bool PPPAckLCPOptionsEx(PPP_SESSION *p, PPP_PACKET* pp, bool simulate)
 	UINT i = 0;
 	PPP_PACKET* ret;
 	bool toBeACKed = false;
+	if (LIST_NUM(pp->Lcp->OptionList) == 0)
+	{
+		// We acknoweldge an empty option list
+		toBeACKed = true;
+		Debug("ACKing empty LCP options list, id=%i\n", pp->Lcp->Id);
+	}
 	for (i = 0; i < LIST_NUM(pp->Lcp->OptionList); i++)
 	{
 		PPP_OPTION *t = LIST_DATA(pp->Lcp->OptionList, i);
@@ -1826,7 +1837,7 @@ bool PPPAckLCPOptionsEx(PPP_SESSION *p, PPP_PACKET* pp, bool simulate)
 		}
 	}
 
-	if (LIST_NUM(ret->Lcp->OptionList) == 0 || simulate)
+	if (simulate)
 	{
 		FreePPPPacket(ret);
 		return false;

--- a/src/Cedar/Proto_PPP.h
+++ b/src/Cedar/Proto_PPP.h
@@ -82,6 +82,7 @@
 // LCP Option Type
 #define	PPP_LCP_OPTION_MRU				1
 #define	PPP_LCP_OPTION_AUTH				3
+#define PPP_LCP_OPTION_MAGIC			5
 
 // IPCP option type
 #define	PPP_IPCP_OPTION_IP				3

--- a/src/Cedar/Proto_PPP.h
+++ b/src/Cedar/Proto_PPP.h
@@ -82,7 +82,6 @@
 // LCP Option Type
 #define	PPP_LCP_OPTION_MRU				1
 #define	PPP_LCP_OPTION_AUTH				3
-#define PPP_LCP_OPTION_MAGIC			5
 
 // IPCP option type
 #define	PPP_IPCP_OPTION_IP				3


### PR DESCRIPTION
This is an attempt to fix up the bug #1102 .

It consists of two steps:
1. It fixes the original LCP handshake by processing LCP packets with an empty OptionsList.
2. It fixes the fallback to DHCP parsing when a static IP is rejected by processing IPCP packets without IP-Address set.

Theese fixes makes pppd under Linux be able to connect and open an IPv4 tunnel. It should be noted that by default pppd tries to configure itself statically by using IPs from its other interfaces, which gets accepted by the SoftEtherVPN's own DHCP server, but is not accepted by using any other DHCP server (in my case, DNSMasq) with meaningful settings.

Another drawback is that pppd still discards the first MS-CHAP handshake from the server because it still haven't finished the LCP handshake, but it gets accepted on the next packet resend anyway, so not really a problem, just a small delay.

I do need some tests of this code from MacOS and iOS devices, as I do not own them, but judging by the logs in the #1102 bug, the problems are similar with pppd processing.

I also tested Windows and VPN Client on Android with SSTP - they also do connect like they connected before.