### PR TITLE
Cedar: various improvements to Proto

### DIFF
--- a/src/Cedar/Cedar.c
+++ b/src/Cedar/Cedar.c
@@ -1606,9 +1606,6 @@ void InitCedar()
 
 	// Initialize protocol module
 	InitProtocol();
-
-	// Initialize third-party protocol interface
-	ProtoInit();
 }
 
 // Free Cedar communication module
@@ -1618,9 +1615,6 @@ void FreeCedar()
 	{
 		return;
 	}
-
-	// Free third-party protocol interface
-	ProtoFree();
 
 	// Free protocol module
 	FreeProtocol();

--- a/src/Cedar/Connection.c
+++ b/src/Cedar/Connection.c
@@ -2935,10 +2935,10 @@ void ConnectionAccept(CONNECTION *c)
 	{
 		if (c->Cedar != NULL && c->Cedar->Server != NULL)
 		{
-			c->Type = CONNECTION_TYPE_OTHER;
-
-			if (ProtoHandleConnection(c->Cedar, s) == true)
+			PROTO *proto = c->Cedar->Server->Proto;
+			if (proto && ProtoHandleConnection(proto, s) == true)
 			{
+				c->Type = CONNECTION_TYPE_OTHER;
 				goto FINAL;
 			}
 		}

--- a/src/Cedar/Proto.h
+++ b/src/Cedar/Proto.h
@@ -10,6 +10,12 @@
 #define PROTO_MODE_TCP			1
 #define PROTO_MODE_UDP			2
 
+typedef struct PROTO
+{
+	CEDAR *Cedar;
+	LIST *Impls;
+} PROTO;
+
 typedef struct PROTO_IMPL
 {
 	bool (*Init)(void **param, CEDAR *cedar, INTERRUPT_MANAGER *im, SOCK_EVENT *se);
@@ -23,22 +29,14 @@ typedef struct PROTO_IMPL
 	UINT (*EstablishedSessions)(void *param);
 } PROTO_IMPL;
 
-typedef struct PROTO
-{
-	PROTO_IMPL *impl;
-} PROTO;
+int ProtoImplCompare(void *p1, void *p2);
 
-int ProtoCompare(void *p1, void *p2);
+PROTO *ProtoNew(CEDAR *cedar);
+void ProtoDelete(PROTO *proto);
 
-void ProtoInit();
-void ProtoFree();
+bool ProtoImplAdd(PROTO *proto, PROTO_IMPL *impl);
+PROTO_IMPL *ProtoImplDetect(PROTO *proto, SOCK *sock);
 
-bool ProtoAdd(PROTO_IMPL *impl);
-
-UINT ProtoNum();
-PROTO *ProtoGet(const UINT index);
-PROTO *ProtoDetect(SOCK *sock);
-
-bool ProtoHandleConnection(CEDAR *cedar, SOCK *sock);
+bool ProtoHandleConnection(PROTO *proto, SOCK *sock);
 
 #endif

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -2623,15 +2623,13 @@ void SiInitConfiguration(SERVER *s)
 	s->AutoSaveConfigSpan = SERVER_FILE_SAVE_INTERVAL_DEFAULT;
 	s->BackupConfigOnlyWhenModified = true;
 
-	// IPsec server
 	if (s->Cedar->Bridge == false)
 	{
+		// Protocols handler
+		s->Proto = ProtoNew(s->Cedar);
+		// IPsec server
 		s->IPsecServer = NewIPsecServer(s->Cedar);
-	}
-
-	// OpenVPN server (UDP)
-	if (s->Cedar->Bridge == false)
-	{
+		// OpenVPN server (UDP)
 		s->OpenVpnServerUdp = NewOpenVpnServerUdp(s->Cedar);
 	}
 
@@ -6538,6 +6536,11 @@ void SiFreeConfiguration(SERVER *s)
 	s->SaveHaltEvent = NULL;
 	s->SaveThread = NULL;
 
+	// Stop the protocols handler
+	if (s->Proto != NULL)
+	{
+		ProtoDelete(s->Proto);
+	}
 
 	// Stop the IPsec server
 	if (s->IPsecServer != NULL)

--- a/src/Cedar/Server.h
+++ b/src/Cedar/Server.h
@@ -242,6 +242,7 @@ struct SERVER
 	volatile bool HaltDeadLockThread;	// Halting flag
 	EVENT *DeadLockWaitEvent;			// Waiting Event
 
+	PROTO *Proto;						// Protocols handler
 	IPSEC_SERVER *IPsecServer;			// IPsec server function
 	OPENVPN_SERVER_UDP *OpenVpnServerUdp;	// OpenVPN server function
 	char OpenVpnServerUdpPorts[MAX_SIZE];	// UDP port list string


### PR DESCRIPTION
The `PROTO` structure is now used to identify the system as a whole, rather than a single protocol. It's stored and initialized in `Server`.

`ProtoCompare()`, `ProtoAdd()` and `ProtoDetected()` are renamed to make the difference between `PROTO` and `PROTO_IMPL` more clear.

`ProtoGet()` and `ProtoNum()` are removed because the related list can now be accessed directly by `Server`.