### PR TITLE
Make DHCP Client ID more unique

### DIFF
--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -1077,8 +1077,14 @@ BUF *IPCBuildDhcpRequestOptions(IPC *ipc, DHCP_OPTION_LIST *opt)
 	// Hostname
 	if (IsEmptyStr(opt->Hostname) == false)
 	{
+		UCHAR client_id[MAX_HOST_NAME_LEN + 32];
+		UCHAR macstr[30];
+		MacToStr(macstr, sizeof(macstr), ipc->MacAddress);
+
+		Format(client_id, sizeof(client_id), "%s/%s", opt->Hostname, macstr);
+
 		Add(o, NewDhcpOption(DHCP_ID_HOST_NAME, opt->Hostname, StrLen(opt->Hostname)));
-		Add(o, NewDhcpOption(DHCP_ID_CLIENT_ID, opt->Hostname, StrLen(opt->Hostname)));
+		Add(o, NewDhcpOption(DHCP_ID_CLIENT_ID, client_id, StrLen(client_id)));
 	}
 	else // Client MAC Address
 	{

--- a/src/Cedar/Proto_PPP.c
+++ b/src/Cedar/Proto_PPP.c
@@ -257,9 +257,9 @@ void PPPThread(THREAD *thread, void *param)
 			case PPP_EAP_TYPE_IDENTITY:
 			default: // We treat the unspecified protocol as the IDENTITY protocol
 				p->Eap_Protocol = PPP_EAP_TYPE_IDENTITY;
-				lcpEap = BuildEAPPacketEx(PPP_EAP_CODE_REQUEST, p->Eap_PacketId++, PPP_EAP_TYPE_IDENTITY, sizeof(welcomeMessage));
+				lcpEap = BuildEAPPacketEx(PPP_EAP_CODE_REQUEST, p->Eap_PacketId++, PPP_EAP_TYPE_IDENTITY, StrLen(welcomeMessage) + 1);
 				eapPacket = lcpEap->Data;
-				Copy(eapPacket->Data, welcomeMessage, sizeof(welcomeMessage));
+				Copy(eapPacket->Data, welcomeMessage, StrLen(welcomeMessage));
 				PPPSetStatus(p, PPP_STATUS_AUTHENTICATING);
 				if (!PPPSendAndRetransmitRequest(p, PPP_PROTOCOL_EAP, lcpEap))
 				{
@@ -3447,7 +3447,7 @@ void FreePPPSession(PPP_SESSION *p)
 	}
 	if (p->Eap_TlsCtx.CachedBufferSend != NULL)
 	{
-		Free(p->Eap_TlsCtx.CachedBufferRecv);
+		Free(p->Eap_TlsCtx.CachedBufferSend);
 	}
 	if (p->Eap_TlsCtx.SslPipe != NULL)
 	{


### PR DESCRIPTION
This is a bug which I encountered with DNSMasq (which I use on my setup instead of the built-in DHCP server for a more fine-grained control).

When several clients were logging in from the same external IP (eg different computers on the same NAT network) they were all assigned the exactly same IP by DNSMasq DHCP. The debugging of this problem gave me a headache, but then after analysing DNSMasq source codes I found out that it bases it's first match of a client based on the Client_ID DHCP option.

Which was filled with the ClientHostname. Which is the same for all theese clients from the same external IP. Whoopsie.

Now I know that DNSMasq introduced an option `--dhcp-ignore-clid`, which could probably fixed this exact behaviour on it. Except that this option was introduced only in version 2.81 (which was released only in march of 2020, so it's really new), while even Debian Testing still have 2.80 in it's repos. Also, it may be that it is not only DNSMasq which relies on Client ID DHCP option. So I changed that the Client ID option is generated using BOTH Hostname and MAC address (delimited by a slash).

This shouldn't break most of existing configurations, as most rely on hostname and/or MAC address, which I didn't touch. Client ID is rarely seen in configurations.

Now I would understand if you reject this pull request, after all making changes to fix quirks in software not related with SoftEther, and even more having in theese software configuration options to actually "bypass" the problem is not really healthy for the project (I guess?), but this problem really gave me a hard time, so maybe this change will save someone time and prevent someone's insanity =)