### PR TITLE
Cedar: implement UDP system in Proto

### DIFF
--- a/src/Cedar/Proto.c
+++ b/src/Cedar/Proto.c
@@ -19,6 +19,102 @@ int ProtoImplCompare(void *p1, void *p2)
 	return false;
 }
 
+int ProtoSessionCompare(void *p1, void *p2)
+{
+	int ret;
+	PROTO_SESSION *session_1, *session_2;
+
+	if (p1 == NULL || p2 == NULL)
+	{
+		return 0;
+	}
+
+	session_1 = *(PROTO_SESSION **)p1;
+	session_2 = *(PROTO_SESSION **)p2;
+
+	// The source port must match
+	ret = COMPARE_RET(session_1->SrcPort, session_2->SrcPort);
+	if (ret != 0)
+	{
+		return ret;
+	}
+
+	// The destination port must match
+	ret = COMPARE_RET(session_1->DstPort, session_2->DstPort);
+	if (ret != 0)
+	{
+		return ret;
+	}
+
+	// The source IP address must match
+	ret = CmpIpAddr(&session_1->SrcIp, &session_2->SrcIp);
+	if (ret != 0)
+	{
+		return ret;
+	}
+
+	// The destination IP address must match
+	return CmpIpAddr(&session_1->DstIp, &session_2->DstIp);
+}
+
+UINT ProtoSessionHash(void *p)
+{
+	IP *ip;
+	UINT ret = 0;
+	PROTO_SESSION *session = p;
+
+	if (session == NULL)
+	{
+		return 0;
+	}
+
+	ip = &session->SrcIp;
+	if (IsIP6(ip))
+	{
+		UINT i;
+		for (i = 0; i < sizeof(ip->ipv6_addr); ++i)
+		{
+			ret += ip->ipv6_addr[i];
+		}
+
+		ret += ip->ipv6_scope_id;
+	}
+	else
+	{
+		UINT i;
+		for (i = 0; i < sizeof(ip->addr); ++i)
+		{
+			ret += ip->addr[i];
+		}
+	}
+
+	ret += session->SrcPort;
+
+	ip = &session->DstIp;
+	if (IsIP6(ip))
+	{
+		UINT i;
+		for (i = 0; i < sizeof(ip->ipv6_addr); ++i)
+		{
+			ret += ip->ipv6_addr[i];
+		}
+
+		ret += ip->ipv6_scope_id;
+	}
+	else
+	{
+		UINT i;
+		for (i = 0; i < sizeof(ip->addr); ++i)
+		{
+			ret += ip->addr[i];
+		}
+	}
+
+	ret += session->DstPort;
+
+	return ret;
+}
+
 PROTO *ProtoNew(CEDAR *cedar)
 {
 	PROTO *proto;
@@ -31,22 +127,36 @@ PROTO *ProtoNew(CEDAR *cedar)
 	proto = Malloc(sizeof(PROTO));
 	proto->Cedar = cedar;
 	proto->Impls = NewList(ProtoImplCompare);
+	proto->Sessions = NewHashList(ProtoSessionHash, ProtoSessionCompare, 0, true);
 
 	AddRef(cedar->ref);
 
 	// OpenVPN
 	ProtoImplAdd(proto, OvsGetProtoImpl());
 
+	proto->UdpListener = NewUdpListener(ProtoHandleDatagrams, proto, &cedar->Server->ListenIP);
+
 	return proto;
 }
 
 void ProtoDelete(PROTO *proto)
 {
+	UINT i = 0;
+
 	if (proto == NULL)
 	{
 		return;
 	}
 
+	StopUdpListener(proto->UdpListener);
+
+	for (i = 0; i < HASH_LIST_NUM(proto->Sessions); ++i)
+	{
+		ProtoDeleteSession(LIST_DATA(proto->Sessions->AllList, i));
+	}
+
+	FreeUdpListener(proto->UdpListener);
+	ReleaseHashList(proto->Sessions);
 	ReleaseList(proto->Impls);
 	ReleaseCedar(proto->Cedar);
 	Free(proto);
@@ -94,6 +204,109 @@ PROTO_IMPL *ProtoImplDetect(PROTO *proto, const PROTO_MODE mode, const UCHAR *da
 
 	Debug("ProtoImplDetect(): unrecognized protocol\n");
 	return NULL;
+}
+
+PROTO_SESSION *ProtoNewSession(PROTO *proto, PROTO_IMPL *impl, const IP *src_ip, const USHORT src_port, const IP *dst_ip, const USHORT dst_port)
+{
+	PROTO_SESSION *session;
+
+	if (impl == NULL || src_ip == NULL || src_port == 0 || dst_ip == NULL || dst_port == 0)
+	{
+		return NULL;
+	}
+
+	session = ZeroMalloc(sizeof(PROTO_SESSION));
+
+	session->SockEvent = NewSockEvent();
+	session->InterruptManager = NewInterruptManager();
+
+	if (impl->Init != NULL && impl->Init(&session->Param, proto->Cedar, session->InterruptManager, session->SockEvent) == false)
+	{
+		Debug("ProtoNewSession(): failed to initialize %s\n", impl->Name());
+
+		ReleaseSockEvent(session->SockEvent);
+		FreeInterruptManager(session->InterruptManager);
+		Free(session);
+
+		return NULL;
+	}
+
+	session->Proto = proto;
+	session->Impl = impl;
+
+	CopyIP(&session->SrcIp, src_ip);
+	session->SrcPort = src_port;
+	CopyIP(&session->DstIp, dst_ip);
+	session->DstPort = dst_port;
+
+	session->DatagramsIn = NewListFast(NULL);
+	session->DatagramsOut = NewListFast(NULL);
+
+	session->Lock = NewLock();
+	session->Thread = NewThread(ProtoSessionThread, session);
+
+	return session;
+}
+
+void ProtoDeleteSession(PROTO_SESSION *session)
+{
+	if (session == NULL)
+	{
+		return;
+	}
+
+	session->Halt = true;
+	SetSockEvent(session->SockEvent);
+
+	WaitThread(session->Thread, INFINITE);
+	ReleaseThread(session->Thread);
+
+	session->Impl->Free(session->Param);
+
+	ReleaseSockEvent(session->SockEvent);
+	FreeInterruptManager(session->InterruptManager);
+
+	ReleaseList(session->DatagramsIn);
+	ReleaseList(session->DatagramsOut);
+
+	DeleteLock(session->Lock);
+
+	Free(session);
+}
+
+bool ProtoSetListenIP(PROTO *proto, const IP *ip)
+{
+	if (proto == NULL || ip == NULL)
+	{
+		return false;
+	}
+
+	Copy(&proto->UdpListener->ListenIP, ip, sizeof(proto->UdpListener->ListenIP));
+
+	return true;
+}
+
+bool ProtoSetUdpPorts(PROTO *proto, const LIST *ports)
+{
+	UINT i = 0;
+
+	if (proto == NULL || ports == NULL)
+	{
+		return false;
+	}
+
+	DeleteAllPortFromUdpListener(proto->UdpListener);
+
+	for (i = 0; i < LIST_NUM(ports); ++i)
+	{
+		UINT port = *((UINT *)LIST_DATA(ports, i));
+		if (port >= 1 && port <= 65535)
+		{
+			AddPortToUdpListener(proto->UdpListener, port);
+		}
+	}
+
+	return true;
 }
 
 bool ProtoHandleConnection(PROTO *proto, SOCK *sock)
@@ -227,4 +440,121 @@ bool ProtoHandleConnection(PROTO *proto, SOCK *sock)
 	Free(buf);
 
 	return true;
+}
+
+void ProtoHandleDatagrams(UDPLISTENER *listener, LIST *datagrams)
+{
+	UINT i;
+	HASH_LIST *sessions;
+	PROTO *proto = listener->Param;
+
+	if (proto == NULL || listener == NULL || datagrams == NULL)
+	{
+		return;
+	}
+
+	sessions = proto->Sessions;
+
+	for (i = 0; i < LIST_NUM(datagrams); ++i)
+	{
+		UDPPACKET *datagram = LIST_DATA(datagrams, i);
+		PROTO_SESSION *session, tmp;
+
+		CopyIP(&tmp.SrcIp, &datagram->SrcIP);
+		tmp.SrcPort = datagram->SrcPort;
+		CopyIP(&tmp.DstIp, &datagram->DstIP);
+		tmp.DstPort = datagram->DestPort;
+
+		session = SearchHash(sessions, &tmp);
+		if (session == NULL)
+		{
+			tmp.Impl = ProtoImplDetect(proto, PROTO_MODE_UDP, datagram->Data, datagram->Size);
+			if (tmp.Impl == NULL)
+			{
+				continue;
+			}
+
+			session = ProtoNewSession(proto, tmp.Impl, &tmp.SrcIp, tmp.SrcPort, &tmp.DstIp, tmp.DstPort);
+			if (session == NULL)
+			{
+				continue;
+			}
+
+			AddHash(proto->Sessions, session);
+		}
+
+		if (session->Halt)
+		{
+			DeleteHash(sessions, session);
+			ProtoDeleteSession(session);
+			continue;
+		}
+
+		Lock(session->Lock);
+		{
+			void *data = Clone(datagram->Data, datagram->Size);
+			UDPPACKET *packet = NewUdpPacket(&datagram->SrcIP, datagram->SrcPort, &datagram->DstIP, datagram->DestPort, data, datagram->Size);
+			Add(session->DatagramsIn, packet);
+		}
+		Unlock(session->Lock);
+	}
+
+	for (i = 0; i < LIST_NUM(sessions->AllList); ++i)
+	{
+		PROTO_SESSION *session = LIST_DATA(sessions->AllList, i);
+		if (LIST_NUM(session->DatagramsIn) > 0)
+		{
+			SetSockEvent(session->SockEvent);
+		}
+	}
+}
+
+void ProtoSessionThread(THREAD *thread, void *param)
+{
+	PROTO_SESSION *session = param;
+
+	if (thread == NULL || session == NULL)
+	{
+		return;
+	}
+
+	while (session->Halt == false)
+	{
+		bool ok;
+		UINT interval;
+		void *param = session->Param;
+		PROTO_IMPL *impl = session->Impl;
+		LIST *received = session->DatagramsIn;
+		LIST *to_send = session->DatagramsOut;
+
+		Lock(session->Lock);
+		{
+			UINT i;
+
+			ok = impl->ProcessDatagrams(param, received, to_send);
+
+			UdpListenerSendPackets(session->Proto->UdpListener, to_send);
+
+			for (i = 0; i < LIST_NUM(received); ++i)
+			{
+				FreeUdpPacket(LIST_DATA(received, i));
+			}
+
+			DeleteAll(received);
+			DeleteAll(to_send);
+		}
+		Unlock(session->Lock);
+
+		if (ok == false)
+		{
+			Debug("ProtoSessionThread(): breaking main loop\n");
+			session->Halt = true;
+			break;
+		}
+
+		// Wait until the next event occurs
+		interval = GetNextIntervalForInterrupt(session->InterruptManager);
+		interval = MIN(interval, UDPLISTENER_WAIT_INTERVAL);
+		WaitSockEvent(session->SockEvent, interval);
+	}
 }

--- a/src/Cedar/Proto.h
+++ b/src/Cedar/Proto.h
@@ -7,8 +7,12 @@
 
 #define PROTO_TCP_BUFFER_SIZE	(128 * 1024)
 
-#define PROTO_MODE_TCP			1
-#define PROTO_MODE_UDP			2
+typedef enum PROTO_MODE
+{
+	PROTO_MODE_UNKNOWN = 0,
+	PROTO_MODE_TCP = 1,
+	PROTO_MODE_UDP = 2
+} PROTO_MODE;
 
 typedef struct PROTO
 {
@@ -21,12 +25,9 @@ typedef struct PROTO_IMPL
 	bool (*Init)(void **param, CEDAR *cedar, INTERRUPT_MANAGER *im, SOCK_EVENT *se);
 	void (*Free)(void *param);
 	char *(*Name)();
-	UINT (*SupportedModes)();
-	bool (*IsPacketForMe)(const UCHAR *data, const UINT size);
+	bool (*IsPacketForMe)(const PROTO_MODE mode, const UCHAR *data, const UINT size);
 	bool (*ProcessData)(void *param, TCP_RAW_DATA *received_data, FIFO *data_to_send);
 	void (*BufferLimit)(void *param, const bool reached);
-	bool (*IsOk)(void *param);
-	UINT (*EstablishedSessions)(void *param);
 } PROTO_IMPL;
 
 int ProtoImplCompare(void *p1, void *p2);
@@ -35,7 +36,7 @@ PROTO *ProtoNew(CEDAR *cedar);
 void ProtoDelete(PROTO *proto);
 
 bool ProtoImplAdd(PROTO *proto, PROTO_IMPL *impl);
-PROTO_IMPL *ProtoImplDetect(PROTO *proto, SOCK *sock);
+PROTO_IMPL *ProtoImplDetect(PROTO *proto, const PROTO_MODE mode, const UCHAR *data, const UINT size);
 
 bool ProtoHandleConnection(PROTO *proto, SOCK *sock);
 

--- a/src/Cedar/Proto_OpenVPN.c
+++ b/src/Cedar/Proto_OpenVPN.c
@@ -23,6 +23,7 @@ PROTO_IMPL *OvsGetProtoImpl()
 		OvsName,
 		OvsIsPacketForMe,
 		OvsProcessData,
+		OvsProcessDatagrams,
 		OvsBufferLimit,
 	};
 
@@ -82,14 +83,14 @@ bool OvsIsPacketForMe(const PROTO_MODE mode, const UCHAR *data, const UINT size)
 	return false;
 }
 
-bool OvsProcessData(void *param, TCP_RAW_DATA *received_data, FIFO *data_to_send)
+bool OvsProcessData(void *param, TCP_RAW_DATA *in, FIFO *out)
 {
 	bool ret = true;
 	UINT i;
 	OPENVPN_SERVER *server = param;
 	UCHAR buf[OPENVPN_TCP_MAX_PACKET_SIZE];
 
-	if (server == NULL || received_data == NULL || data_to_send == NULL)
+	if (server == NULL || in == NULL || out == NULL)
 	{
 		return false;
 	}
@@ -99,7 +100,7 @@ bool OvsProcessData(void *param, TCP_RAW_DATA *received_data, FIFO *data_to_send
 	{
 		UDPPACKET *packet;
 		USHORT payload_size, packet_size;
-		FIFO *fifo = received_data->Data;
+		FIFO *fifo = in->Data;
 		const UINT fifo_size = FifoSize(fifo);
 
 		if (fifo_size < sizeof(USHORT))
@@ -133,13 +134,12 @@ bool OvsProcessData(void *param, TCP_RAW_DATA *received_data, FIFO *data_to_send
 		}
 
 		// Insert packet into the list
-		packet = NewUdpPacket(&received_data->SrcIP, received_data->SrcPort, &received_data->DstIP, received_data->DstPort, Clone(buf + sizeof(USHORT), payload_size), payload_size);
-		packet->Type = OPENVPN_PROTOCOL_TCP;
+		packet = NewUdpPacket(&in->SrcIP, in->SrcPort, &in->DstIP, in->DstPort, Clone(buf + sizeof(USHORT), payload_size), payload_size);
 		Add(server->RecvPacketList, packet);
 	}
 
 	// Process the list of received datagrams
-	OvsRecvPacket(server, server->RecvPacketList);
+	OvsRecvPacket(server, server->RecvPacketList, OPENVPN_PROTOCOL_TCP);
 
 	// Release the received packet list
 	for (i = 0; i < LIST_NUM(server->RecvPacketList); ++i)
@@ -158,10 +158,10 @@ bool OvsProcessData(void *param, TCP_RAW_DATA *received_data, FIFO *data_to_send
 		// Store the size in the TCP send queue first
 		USHORT us = Endian16((USHORT)p->Size);
 
-		WriteFifo(data_to_send, &us, sizeof(USHORT));
+		WriteFifo(out, &us, sizeof(USHORT));
 
 		// Write the data body
-		WriteFifo(data_to_send, p->Data, p->Size);
+		WriteFifo(out, p->Data, p->Size);
 
 		// Packet release
 		FreeUdpPacket(p);
@@ -171,7 +171,8 @@ bool OvsProcessData(void *param, TCP_RAW_DATA *received_data, FIFO *data_to_send
 
 	if (server->Giveup <= server->Now)
 	{
-		for (UINT i = 0; i < LIST_NUM(server->SessionList); ++i)
+		UINT i;
+		for (i = 0; i < LIST_NUM(server->SessionList); ++i)
 		{
 			OPENVPN_SESSION *se = LIST_DATA(server->SessionList, i);
 
@@ -185,6 +186,47 @@ bool OvsProcessData(void *param, TCP_RAW_DATA *received_data, FIFO *data_to_send
 	}
 
 	return ret;
+}
+
+bool OvsProcessDatagrams(void *param, LIST *in, LIST *out)
+{
+	UINT i;
+	LIST *to_send;
+	OPENVPN_SERVER *server = param;
+
+	if (server == NULL || in == NULL || out == NULL)
+	{
+		return false;
+	}
+
+	OvsRecvPacket(server, in, OPENVPN_PROTOCOL_UDP);
+
+	to_send = server->SendPacketList;
+
+	for (i = 0; i < LIST_NUM(to_send); ++i)
+	{
+		Add(out, LIST_DATA(to_send, i));
+	}
+
+	DeleteAll(server->SendPacketList);
+
+	if (server->Giveup <= server->Now)
+	{
+		UINT i;
+		for (i = 0; i < LIST_NUM(server->SessionList); ++i)
+		{
+			OPENVPN_SESSION *se = LIST_DATA(server->SessionList, i);
+
+			if (se->Established)
+			{
+				return server->DisconnectCount < 1;
+			}
+		}
+
+		return false;
+	}
+
+	return true;
 }
 
 void OvsBufferLimit(void *param, const bool reached)
@@ -507,7 +549,7 @@ final:
 }
 
 // Process the received packet
-void OvsProceccRecvPacket(OPENVPN_SERVER *s, UDPPACKET *p)
+void OvsProceccRecvPacket(OPENVPN_SERVER *s, UDPPACKET *p, UINT protocol)
 {
 	OPENVPN_CHANNEL *c;
 	OPENVPN_SESSION *se;
@@ -519,7 +561,7 @@ void OvsProceccRecvPacket(OPENVPN_SERVER *s, UDPPACKET *p)
 	}
 
 	// Search for the session
-	se = OvsFindOrCreateSession(s, &p->DstIP, p->DestPort, &p->SrcIP, p->SrcPort, p->Type);
+	se = OvsFindOrCreateSession(s, &p->DstIP, p->DestPort, &p->SrcIP, p->SrcPort, protocol);
 	if (se == NULL)
 	{
 		return;
@@ -749,8 +791,13 @@ void OvsProcessRecvControlPacket(OPENVPN_SERVER *s, OPENVPN_SESSION *se, OPENVPN
 			// Create an SSL pipe
 			Lock(s->Cedar->lock);
 			{
-				bool cert_verify = true;
-				c->SslPipe = NewSslPipeEx(true, s->Cedar->ServerX, s->Cedar->ServerK, s->Dh, cert_verify, &c->ClientCert);
+				if (s->Dh->Size != s->Cedar->DhParamBits)
+				{
+					DhFree(s->Dh);
+					s->Dh = DhNewFromBits(s->Cedar->DhParamBits);
+				}
+
+				c->SslPipe = NewSslPipeEx(true, s->Cedar->ServerX, s->Cedar->ServerK, s->Dh, true, &c->ClientCert);
 			}
 			Unlock(s->Cedar->lock);
 
@@ -2165,7 +2212,7 @@ OPENVPN_SESSION *OvsSearchSession(OPENVPN_SERVER *s, IP *server_ip, UINT server_
 }
 
 // Receive packets in the OpenVPN server
-void OvsRecvPacket(OPENVPN_SERVER *s, LIST *recv_packet_list)
+void OvsRecvPacket(OPENVPN_SERVER *s, LIST *recv_packet_list, UINT protocol)
 {
 	UINT i, j;
 	LIST *delete_session_list = NULL;
@@ -2197,7 +2244,7 @@ void OvsRecvPacket(OPENVPN_SERVER *s, LIST *recv_packet_list)
 	{
 		UDPPACKET *p = LIST_DATA(recv_packet_list, i);
 
-		OvsProceccRecvPacket(s, p);
+		OvsProceccRecvPacket(s, p, protocol);
 	}
 
 	// Treat for all sessions and all channels
@@ -2908,7 +2955,7 @@ OPENVPN_SERVER *NewOpenVpnServer(CEDAR *cedar, INTERRUPT_MANAGER *interrupt, SOC
 
 	OvsLog(s, NULL, NULL, "LO_START");
 
-	s->Dh = DhNewFromBits(DH_PARAM_BITS_DEFAULT);
+	s->Dh = DhNewFromBits(cedar->DhParamBits);
 
 	return s;
 }
@@ -2955,124 +3002,4 @@ void FreeOpenVpnServer(OPENVPN_SERVER *s)
 	DhFree(s->Dh);
 
 	Free(s);
-}
-
-// UDP reception procedure
-void OpenVpnServerUdpListenerProc(UDPLISTENER *u, LIST *packet_list)
-{
-	OPENVPN_SERVER_UDP *us;
-	// Validate arguments
-	if (u == NULL || packet_list == NULL)
-	{
-		return;
-	}
-
-	us = (OPENVPN_SERVER_UDP *)u->Param;
-
-	if (us->OpenVpnServer != NULL)
-	{
-		{
-			u->PollMyIpAndPort = false;
-
-			ClearStr(us->Cedar->OpenVPNPublicPorts, sizeof(us->Cedar->OpenVPNPublicPorts));
-		}
-
-		OvsRecvPacket(us->OpenVpnServer, packet_list);
-
-		UdpListenerSendPackets(u, us->OpenVpnServer->SendPacketList);
-		DeleteAll(us->OpenVpnServer->SendPacketList);
-	}
-}
-
-// Create an OpenVPN server (UDP mode)
-OPENVPN_SERVER_UDP *NewOpenVpnServerUdp(CEDAR *cedar)
-{
-	OPENVPN_SERVER_UDP *u;
-	// Validate arguments
-	if (cedar == NULL)
-	{
-		return NULL;
-	}
-
-	u = ZeroMalloc(sizeof(OPENVPN_SERVER_UDP));
-
-	u->Cedar = cedar;
-
-	AddRef(u->Cedar->ref);
-
-	// Create a UDP listener
-	u->UdpListener = NewUdpListenerEx(OpenVpnServerUdpListenerProc, u, &cedar->Server->ListenIP, OPENVPN_PROTOCOL_UDP);
-
-	// Create an OpenVPN server
-	u->OpenVpnServer = NewOpenVpnServer(cedar, u->UdpListener->Interrupts, u->UdpListener->Event);
-
-	return u;
-}
-
-void OpenVpnServerUdpSetDhParam(OPENVPN_SERVER_UDP *u, DH_CTX *dh)
-{
-	// Validate arguments
-	if (u == NULL) {
-		return;
-	}
-
-	if (u->OpenVpnServer->Dh)
-	{
-		DhFree(u->OpenVpnServer->Dh);
-	}
-
-	u->OpenVpnServer->Dh = dh;
-}
-
-// Apply the port list to the OpenVPN server
-void OvsApplyUdpPortList(OPENVPN_SERVER_UDP *u, char *port_list, IP *listen_ip)
-{
-	LIST *o;
-	UINT i;
-	// Validate arguments
-	if (u == NULL)
-	{
-		return;
-	}
-
-	DeleteAllPortFromUdpListener(u->UdpListener);
-
-	if (u->UdpListener != NULL && listen_ip != NULL)
-	{
-		Copy(&u->UdpListener->ListenIP, listen_ip, sizeof(IP));
-	}
-
-	o = StrToIntList(port_list, true);
-
-	for (i = 0;i < LIST_NUM(o);i++)
-	{
-		UINT port = *((UINT *)LIST_DATA(o, i));
-
-		if (port >= 1 && port <= 65535)
-		{
-			AddPortToUdpListener(u->UdpListener, port);
-		}
-	}
-
-	ReleaseIntList(o);
-}
-
-// Release the OpenVPN server (UDP mode)
-void FreeOpenVpnServerUdp(OPENVPN_SERVER_UDP *u)
-{
-	// Validate arguments
-	if (u == NULL)
-	{
-		return;
-	}
-
-	// Stop the UDP listener
-	FreeUdpListener(u->UdpListener);
-
-	// Release the OpenVPN server
-	FreeOpenVpnServer(u->OpenVpnServer);
-
-	ReleaseCedar(u->Cedar);
-
-	Free(u);
 }

--- a/src/Cedar/Proto_OpenVPN.h
+++ b/src/Cedar/Proto_OpenVPN.h
@@ -204,15 +204,6 @@ struct OPENVPN_SERVER
 	UINT SessionEstablishedCount;						// Number of session establishment
 };
 
-// OpenVPN server (UDP mode)
-struct OPENVPN_SERVER_UDP
-{
-	CEDAR *Cedar;
-	UDPLISTENER *UdpListener;							// UDP listener
-	OPENVPN_SERVER *OpenVpnServer;						// OpenVPN server
-	UINT64 VgsNextGetPublicPortsTick;
-};
-
 // OpenVPN Default Client Option String
 #define	OVPN_DEF_CLIENT_OPTION_STRING	"dev-type tun,link-mtu 1500,tun-mtu 1500,cipher AES-128-CBC,auth SHA1,keysize 128,key-method 2,tls-client"
 
@@ -222,20 +213,16 @@ bool OvsInit(void **param, CEDAR *cedar, INTERRUPT_MANAGER *im, SOCK_EVENT *se);
 void OvsFree(void *param);
 char *OvsName();
 bool OvsIsPacketForMe(const PROTO_MODE mode, const UCHAR *data, const UINT size);
-bool OvsProcessData(void *param, TCP_RAW_DATA *received_data, FIFO *data_to_send);
+bool OvsProcessData(void *param, TCP_RAW_DATA *in, FIFO *out);
+bool OvsProcessDatagrams(void *param, LIST *in, LIST *out);
 void OvsBufferLimit(void *param, const bool reached);
 bool OvsIsOk(void *param);
 UINT OvsEstablishedSessions(void *param);
 
-OPENVPN_SERVER_UDP *NewOpenVpnServerUdp(CEDAR *cedar);
-void FreeOpenVpnServerUdp(OPENVPN_SERVER_UDP *u);
-void OpenVpnServerUdpListenerProc(UDPLISTENER *u, LIST *packet_list);
-void OvsApplyUdpPortList(OPENVPN_SERVER_UDP *u, char *port_list, IP *listen_ip);
-
 OPENVPN_SERVER *NewOpenVpnServer(CEDAR *cedar, INTERRUPT_MANAGER *interrupt, SOCK_EVENT *sock_event);
 void FreeOpenVpnServer(OPENVPN_SERVER *s);
-void OvsRecvPacket(OPENVPN_SERVER *s, LIST *recv_packet_list);
-void OvsProceccRecvPacket(OPENVPN_SERVER *s, UDPPACKET *p);
+void OvsRecvPacket(OPENVPN_SERVER *s, LIST *recv_packet_list, UINT protocol);
+void OvsProceccRecvPacket(OPENVPN_SERVER *s, UDPPACKET *p, UINT protocol);
 int OvsCompareSessionList(void *p1, void *p2);
 OPENVPN_SESSION *OvsSearchSession(OPENVPN_SERVER *s, IP *server_ip, UINT server_port, IP *client_ip, UINT client_port, UINT protocol);
 OPENVPN_SESSION *OvsNewSession(OPENVPN_SERVER *s, IP *server_ip, UINT server_port, IP *client_ip, UINT client_port, UINT protocol);
@@ -278,7 +265,5 @@ UINT OvsCalcTcpMss(OPENVPN_SERVER *s, OPENVPN_SESSION *se, OPENVPN_CHANNEL *c);
 
 CIPHER *OvsGetCipher(char *name);
 MD *OvsGetMd(char *name);
-
-void OpenVpnServerUdpSetDhParam(OPENVPN_SERVER_UDP *u, DH_CTX *dh);
 
 #endif	// PROTO_OPENVPN_H

--- a/src/Cedar/Proto_OpenVPN.h
+++ b/src/Cedar/Proto_OpenVPN.h
@@ -194,6 +194,7 @@ struct OPENVPN_SERVER
 	LIST *SendPacketList;								// Transmission packet list
 	LIST *SessionList;									// Session list
 	UINT64 Now;											// Current time
+	UINT64 Giveup;										// Session establishment deadline
 	SOCK_EVENT *SockEvent;								// Socket event
 	UCHAR TmpBuf[OPENVPN_TMP_BUFFER_SIZE];				// Temporary buffer
 	UINT DisconnectCount;								// The number of session lost that have occurred so far
@@ -220,8 +221,7 @@ PROTO_IMPL *OvsGetProtoImpl();
 bool OvsInit(void **param, CEDAR *cedar, INTERRUPT_MANAGER *im, SOCK_EVENT *se);
 void OvsFree(void *param);
 char *OvsName();
-UINT OvsSupportedModes();
-bool OvsIsPacketForMe(const UCHAR *buf, const UINT size);
+bool OvsIsPacketForMe(const PROTO_MODE mode, const UCHAR *data, const UINT size);
 bool OvsProcessData(void *param, TCP_RAW_DATA *received_data, FIFO *data_to_send);
 void OvsBufferLimit(void *param, const bool reached);
 bool OvsIsOk(void *param);

--- a/src/Cedar/Server.h
+++ b/src/Cedar/Server.h
@@ -244,7 +244,6 @@ struct SERVER
 
 	PROTO *Proto;						// Protocols handler
 	IPSEC_SERVER *IPsecServer;			// IPsec server function
-	OPENVPN_SERVER_UDP *OpenVpnServerUdp;	// OpenVPN server function
 	char OpenVpnServerUdpPorts[MAX_SIZE];	// UDP port list string
 	DDNS_CLIENT *DDnsClient;			// DDNS client feature
 	LOCK *OpenVpnSstpConfigLock;		// Lock OpenVPN and SSTP configuration

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -19329,6 +19329,19 @@ UDPLISTENER *NewUdpListenerEx(UDPLISTENER_RECV_PROC *recv_proc, void *param, IP 
 	return u;
 }
 
+// Stop the UDP listener
+void StopUdpListener(UDPLISTENER *u)
+{
+	if (u == NULL)
+	{
+		return;
+	}
+
+	u->Halt = true;
+	SetSockEvent(u->Event);
+	WaitThread(u->Thread, INFINITE);
+}
+
 // Release the UDP listener
 void FreeUdpListener(UDPLISTENER *u)
 {
@@ -19339,10 +19352,8 @@ void FreeUdpListener(UDPLISTENER *u)
 		return;
 	}
 
-	u->Halt = true;
-	SetSockEvent(u->Event);
+	StopUdpListener(u);
 
-	WaitThread(u->Thread, INFINITE);
 	ReleaseThread(u->Thread);
 	ReleaseSockEvent(u->Event);
 

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -1357,6 +1357,7 @@ UINT64 GetHostIPAddressListHash();
 UDPLISTENER *NewUdpListener(UDPLISTENER_RECV_PROC *recv_proc, void *param, IP *listen_ip);
 UDPLISTENER *NewUdpListenerEx(UDPLISTENER_RECV_PROC *recv_proc, void *param, IP *listen_ip, UINT packet_type);
 void UdpListenerThread(THREAD *thread, void *param);
+void StopUdpListener(UDPLISTENER *u);
 void FreeUdpListener(UDPLISTENER *u);
 void AddPortToUdpListener(UDPLISTENER *u, UINT port);
 void DeletePortFromUdpListener(UDPLISTENER *u, UINT port);


### PR DESCRIPTION
When a datagram is received, the matching session is looked up in a hash list; if it's not found, a new session is created.

This method allows to use a single UDP port for multiple protocols, as we do with TCP.

Also, each session has its own dedicated thread, used to process the received datagrams and generate the ones that are then sent through the UDP listener.

In addition to guaranteeing constant performance, separate threads also prevent a single one from blocking all sessions.

The setting that specified the UDP ports is still called `OpenVPN_UdpPortList`.

We will change it as soon as there's another UDP protocol implemented in Proto.