### PR TITLE
Log client IP in failed accesses

### DIFF
--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -2017,8 +2017,11 @@ bool ServerAccept(CONNECTION *c)
 
 				if (auth_ret == false)
 				{
+					// Get client IP to feed tools such as Fail2Ban
+					char ip[64];
+					IPToStr(ip, sizeof(ip), &c->FirstSock->RemoteIP);
 					// Authentication failure
-					HLog(hub, "LH_AUTH_NG", c->Name, username);
+					HLog(hub, "LH_AUTH_NG", c->Name, username, ip);
 				}
 				else
 				{

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -1923,7 +1923,7 @@ LH_AUTH_CERT_NOT_SUPPORT_ON_OPEN_SOURCE	"%S" 的连接方法: 用户 "%S" 的身
 LH_AUTH_OK					连接 "%S": 成功认证为用户 "%S"。
 LH_AUTH_OK_CERT				虚拟 HUB 的安全账户管理器已经从 VPN Client 接收到如下证书，且接受了其内容作为当用户 "%S" 登录时的证书: %s
 LH_AUTH_NG_CERT				虚拟 HUB 的安全账户管理器已经从 VPN Client 接收到如下证书，但拒绝了其内容作为当用户 "%S" 登录时的证书，因为此证书的内容匹配虚拟 HUB 中注册的废止内容列表: %s
-LH_AUTH_NG					连接 "%S": 用户认证失败。提供的用户名为 "%S"。
+LH_AUTH_NG					Connection "%S": User authentication failed. The user name that has been provided was "%S", from %S.
 LH_LOCAL_ONLY				连接 "%S": 远程登录拒绝，因为用户 "%S" 的密码为空。
 LH_POLICY_ACCESS_NG			连接 "%S": 由于安全策略，用户 "%S" 拒绝访问。
 LH_USER_EXPIRES				连接 "%S": 由于有效期限已过，用户 "%S" 拒绝访问。

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -1905,7 +1905,7 @@ LH_AUTH_CERT_NOT_SUPPORT_ON_OPEN_SOURCE	Connection "%S": The authentication meth
 LH_AUTH_OK				Connection "%S": Successfully authenticated as user "%S".
 LH_AUTH_OK_CERT			The Virtual Hub's Security Account Manager has received the following certificate from the VPN Client and accepted its contents as the certificate for when user "%S" logs in: %s
 LH_AUTH_NG_CERT			Although the Virtual Hub's Security Account Manager has received the following certificate, has refused its contents as the certificate for when user "%S" logs in because this certificate's contents matches the contents that are registered in the Virtual Hub's certificates revocation list: %s
-LH_AUTH_NG				Connection "%S": User authentication failed. The user name that has been provided was "%S".
+LH_AUTH_NG				Connection "%S": User authentication failed. The user name that has been provided was "%S", from %S.
 LH_LOCAL_ONLY			Connection "%S": The remote login has been refused because of the password for user "%S" is blank.
 LH_POLICY_ACCESS_NG		Connection "%S": Access has beens refused to user "%S" based on the security policy.
 LH_USER_EXPIRES			Connection "%S": Access has been refused to user "%S" because of the expiration date has been expired.

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -1909,7 +1909,7 @@ LH_AUTH_CERT_NOT_SUPPORT_ON_OPEN_SOURCE	コネクション "%S": ユーザー "%
 LH_AUTH_OK				コネクション "%S": ユーザー "%S" として正しく認証されました。
 LH_AUTH_OK_CERT			仮想 HUB のセキュリティアカウントマネージャは、ユーザー "%S" がログインする際の証明書として、次の証明書を VPN Client から受理し、その内容を承認しました: %s
 LH_AUTH_NG_CERT			仮想 HUB のセキュリティアカウントマネージャは、ユーザー "%S" がログインする際の証明書として、次の証明書を VPN Client から受理しましたが、この証明書は仮想 HUB の無効な証明書一覧に登録されている内容に一致するため拒否しました: %s
-LH_AUTH_NG				コネクション "%S": ユーザー認証に失敗しました。提示されたユーザー名は "%S" でした。
+LH_AUTH_NG				Connection "%S": User authentication failed. The user name that has been provided was "%S", from %S.
 LH_LOCAL_ONLY			コネクション "%S": ユーザー "%S" のパスワードが空白のため、リモートからのログインは拒否されました。
 LH_POLICY_ACCESS_NG		コネクション "%S": ユーザー "%S" はセキュリティポリシーによってアクセスが拒否されています。
 LH_USER_EXPIRES			コネクション "%S": ユーザー "%S" の有効期限が切れており、アクセスが拒否されました。

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -1887,7 +1887,7 @@ LH_AUTH_CERT_NOT_SUPPORT_ON_OPEN_SOURCE 연결 "%S"사용자 "%S"의 인증 방�
 LH_AUTH_OK 연결 "%S"사용자 "%S"로 성공적으로 인증되었습니다.
 LH_AUTH_OK_CERT 가상 HUB 보안 계정 관리자는 사용자 "%S"가 로그인 할 때 인증서로 다음 인증서를 VPN Client에서 접수하고 그 내용을 승인했습니다:%s
 LH_AUTH_NG_CERT 가상 HUB 보안 계정 관리자는 사용자 "%S"가 로그인 할 때 인증서로 다음 인증서를 VPN Client에서 접수했지만,이 인증서는 가상 HUB의 잘못된 인증서 목록에 등록 되는 내용과 일치하는 거부했습니다:%s
-LH_AUTH_NG 연결 "%S": 사용자 인증에 실패했습니다. 제시된 사용자 이름은 "%S"였습니다.
+LH_AUTH_NG Connection "%S": User authentication failed. The user name that has been provided was "%S", from %S.
 LH_LOCAL_ONLY 연결 "%S"사용자 "%S"암호가 비어을위한 원격에서 로그인이 거부되었습니다.
 LH_POLICY_ACCESS_NG 연결 "%S"사용자 "%S"는 보안 정책에 의해 액세스가 거부되어 있습니다.
 LH_USER_EXPIRES 연결 "%S"사용자 "%S"의 유효 기간이 만료되어 액세스가 거부되었습니다.

--- a/src/bin/hamcore/strtable_pt_br.stb
+++ b/src/bin/hamcore/strtable_pt_br.stb
@@ -1906,7 +1906,7 @@ LH_AUTH_CERT_NOT_SUPPORT_ON_OPEN_SOURCE	Connection "%S": The authentication meth
 LH_AUTH_OK	Connection "%S": Successfully authenticated as user "%S".
 LH_AUTH_OK_CERT	The Virtual Hub's Security Account Manager has received the following certificate from the VPN Client and accepted its contents as the certificate for when user "%S" logs in: %s
 LH_AUTH_NG_CERT	Although the Virtual Hub's Security Account Manager has received the following certificate, has refused its contents as the certificate for when user "%S" logs in because this certificate's contents matches the contents that are registered in the Virtual Hub's certificates revocation list: %s
-LH_AUTH_NG	Connection "%S": User authentication failed. The user name that has been provided was "%S".
+LH_AUTH_NG	Connection "%S": User authentication failed. The user name that has been provided was "%S", from %S.
 LH_LOCAL_ONLY	Connection "%S": The remote login has been refused because of the password for user "%S" is blank.
 LH_POLICY_ACCESS_NG	Connection "%S": Access has beens refused to user "%S" based on the security policy.
 LH_USER_EXPIRES	Connection "%S": Access has been refused to user "%S" because of the expiration date has been expired.

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -1906,7 +1906,7 @@ LH_AUTH_CERT_NOT_SUPPORT_ON_OPEN_SOURCE	Connection "%S": The authentication meth
 LH_AUTH_OK				Connection "%S": Successfully authenticated as user "%S".
 LH_AUTH_OK_CERT			The Virtual Hub's Security Account Manager has received the following certificate from the VPN Client and accepted its contents as the certificate for when user "%S" logs in: %s
 LH_AUTH_NG_CERT			Although the Virtual Hub's Security Account Manager has received the following certificate, has refused its contents as the certificate for when user "%S" logs in because this certificate's contents matches the contents that are registered in the Virtual Hub's certificates revocation list: %s
-LH_AUTH_NG				Connection "%S": User authentication failed. The user name that has been provided was "%S".
+LH_AUTH_NG				Connection "%S": User authentication failed. The user name that has been provided was "%S", from %S.
 LH_LOCAL_ONLY			Connection "%S": The remote login has been refused because of the password for user "%S" is blank.
 LH_POLICY_ACCESS_NG		Connection "%S": Access has beens refused to user "%S" based on the security policy.
 LH_USER_EXPIRES			Connection "%S": Access has been refused to user "%S" because of the expiration date has been expired.

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -1926,7 +1926,7 @@ LH_AUTH_CERT_NOT_SUPPORT_ON_OPEN_SOURCE	"%S" 的連接方法: 用戶 "%S" 的身
 LH_AUTH_OK				連接 "%S": 成功認證為用戶 "%S"。
 LH_AUTH_OK_CERT			虛擬 HUB 的安全帳戶管理器已經從 VPN Client 接收到如下證書，且接受了其內容作為當使用者 "%S" 登入時的證書: %s
 LH_AUTH_NG_CERT			虛擬 HUB 的安全帳戶管理器已經從 VPN Client 接收到如下證書，但拒絕了其內容作為當使用者 "%S" 登入時的證書，因為此證書的內容匹配虛擬 HUB 中註冊的廢止內容清單: %s
-LH_AUTH_NG				連接 "%S": 用戶認證失敗。提供的用戶名為 "%S"。
+LH_AUTH_NG				Connection "%S": User authentication failed. The user name that has been provided was "%S", from %S.
 LH_LOCAL_ONLY			連接 "%S": 遠端登入拒絕，因為用戶 "%S" 的密碼為空。
 LH_POLICY_ACCESS_NG		連接 "%S": 由於安全性原則，用戶 "%S" 拒絕訪問。
 LH_USER_EXPIRES			連接 "%S": 由於有效期限已過，用戶 "%S" 拒絕訪問。


### PR DESCRIPTION
Hello,

This PR adds the client IP in the `LH_AUTH_NG` message, the authentication failure message.
This allow to use tools such as Fail2Ban to ban IPs with too many authentication failures / retries.

Thank you very much for your help & support 👍

-----

Same as https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/pull/8