### PR TITLE
Increase Radius timeout

### DIFF
--- a/src/Cedar/Radius.h
+++ b/src/Cedar/Radius.h
@@ -9,8 +9,8 @@
 #define	RADIUS_H
 
 #define	RADIUS_DEFAULT_PORT		1812			// The default port number
-#define	RADIUS_RETRY_INTERVAL	500				// Retransmission interval
-#define	RADIUS_RETRY_TIMEOUT	(10 * 1000)		// Time-out period
+#define	RADIUS_RETRY_INTERVAL	1000				// Retransmission interval
+#define	RADIUS_RETRY_TIMEOUT	(15 * 1000)		// Time-out period, keep it 2FA friendly
 #define	RADIUS_INITIAL_EAP_TIMEOUT	1600		// Initial timeout for EAP
 
 


### PR DESCRIPTION
Hello,

This PR increases by a little Radius timeout.
This to make SoftEtherVPN 2FA friendly.
Radius may be set to ask for a second authentication factor (through a push notification / validation for example), the default 10 seconds are then really short here.
15 seconds seem more reasonable to let users validate the second authentication factor.

Thank you very much for your help & support 👍

-----

Same as https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/pull/7