### PR TITLE
Cedar/Proto.c: fix wrong NULL check in ProtoHandleDatagrams(), found by Coverity

### DIFF
--- a/src/Cedar/Proto.c
+++ b/src/Cedar/Proto.c
@@ -445,14 +445,15 @@ bool ProtoHandleConnection(PROTO *proto, SOCK *sock)
 void ProtoHandleDatagrams(UDPLISTENER *listener, LIST *datagrams)
 {
 	UINT i;
+	PROTO *proto;
 	HASH_LIST *sessions;
-	PROTO *proto = listener->Param;
 
-	if (proto == NULL || listener == NULL || datagrams == NULL)
+	if (listener == NULL || datagrams == NULL)
 	{
 		return;
 	}
 
+	proto = listener->Param;
 	sessions = proto->Sessions;
 
 	for (i = 0; i < LIST_NUM(datagrams); ++i)


### PR DESCRIPTION
```
*** CID 358434: Null pointer dereferences (REVERSE_INULL)
 /src/Cedar/Proto.c: 451 in ProtoHandleDatagrams()
 445   void ProtoHandleDatagrams(UDPLISTENER *listener, LIST *datagrams)
 446   {
 447       UINT i;
 448       HASH_LIST *sessions;
 449       PROTO *proto = listener->Param;
 450
 >>>   CID 358434: Null pointer dereferences (REVERSE_INULL)
 >>>   Null-checking "listener" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
 451       if (proto == NULL || listener == NULL || datagrams == NULL)
 452       {
 453           return;
 454       }
 455
 456       sessions = proto->Sessions;
```

