### PR TITLE
Fixed that NewDhcpOption can't handle DHCP options longer than 255 bytes

### DIFF
--- a/src/Mayaqua/TcpIp.c
+++ b/src/Mayaqua/TcpIp.c
@@ -3468,8 +3468,8 @@ DHCP_OPTION *NewDhcpOption(UINT id, void *data, UINT size)
 	ret = ZeroMalloc(sizeof(DHCP_OPTION));
 	ret->Data = ZeroMalloc(size);
 	Copy(ret->Data, data, size);
-	ret->Size = (UCHAR)size;
-	ret->Id = (UCHAR)id;
+	ret->Size = size;
+	ret->Id = id;
 
 	return ret;
 }


### PR DESCRIPTION
Changes proposed in this pull request:
 - Fixed the problem that BuildDhcpOptionsBuf could not interpret the option size correctly because NewDhcpOption truncated the option size to 8bit.
This causes problems when the virtual DHCP server has more than 28 static routes defined.
(It may not be necessary to remove the cast on id.)

---

Fixes #326.

