### PR TITLE
Cedar/Server.c: load UDP ports from configuration file and apply them

### DIFF
--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -5677,6 +5677,23 @@ void SiLoadServerCfg(SERVER *s, FOLDER *f)
 		OPENVPN_SSTP_CONFIG config;
 		FOLDER *syslog_f;
 		{
+			UINT i;
+			LIST *ports;
+
+			// Load and set UDP ports
+			CfgGetStr(f, "PortsUDP", tmp, sizeof(tmp));
+			NormalizeIntListStr(tmp, sizeof(tmp), tmp, true, ", ");
+
+			ports = StrToIntList(tmp, true);
+			for (i = 0; i < LIST_NUM(ports); ++i)
+			{
+				AddInt(s->PortsUDP, *(UINT *)LIST_DATA(ports, i));
+			}
+			ReleaseIntList(ports);
+
+			ProtoSetUdpPorts(s->Proto, ports);
+		}
+		{
 			RPC_KEEP k;
 
 			// Keep-alive related


### PR DESCRIPTION
Unfortunately I realized only now that I didn't add the code in #1130.
