### PR TITLE
Cedar: fix ProtoSetUdpPorts() call in SiLoadServerCfg()

### DIFF
--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -5691,7 +5691,7 @@ void SiLoadServerCfg(SERVER *s, FOLDER *f)
 			}
 			ReleaseIntList(ports);
 
-			ProtoSetUdpPorts(s->Proto, ports);
+			ProtoSetUdpPorts(s->Proto, s->PortsUDP);
 		}
 		{
 			RPC_KEEP k;


### PR DESCRIPTION
I accidentally passed the wrong variable in 4514ba5e2f597b3ecbedda2eee48bebf8ae693fe.
