### PR TITLE
Cedar: fix server crash in CleanupSession()

### DIFF
--- a/src/Cedar/Session.c
+++ b/src/Cedar/Session.c
@@ -1267,7 +1267,10 @@ void CleanupSession(SESSION *s)
 		FreePacketAdapter(s->PacketAdapter);
 	}
 #ifdef OS_UNIX
-	UnixVLanSetState(s->ClientOption->DeviceName, false);
+	if (s->ClientOption != NULL)
+	{
+		UnixVLanSetState(s->ClientOption->DeviceName, false);
+	}
 #endif
 	if (s->OldTraffic != NULL)
 	{


### PR DESCRIPTION
`ClientOption`, as the name implies, is only used in a client context.

The issue was introduced in #1157. Before that, an unrelated check prevented `UnixVLanSetState()` from being called in a server context.