### PR TITLE
CMake: don't hardcode build directories

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -70,7 +70,7 @@ for:
   before_build:
     - ./configure
   build_script:
-    - make package -C tmp -j $(nproc || sysctl -n hw.ncpu || echo 4)
+    - make package -C build -j $(nproc || sysctl -n hw.ncpu || echo 4)
   test_script:
     - .ci/appveyor-deb-install-test.sh
     - sudo apt-get update && sudo apt-get -y install autoconf libtool liblzo2-dev libpam-dev fping unzip # openvpn build deps
@@ -85,7 +85,7 @@ for:
     - sh: "if [ ${APPVEYOR_REPO_TAG} == \"true\" ]; then .ci/appveyor-create-release-tarball.sh\nfi"
     - ./configure
   build_script:
-    - make package -C tmp -j $(nproc || sysctl -n hw.ncpu || echo 4)
+    - make package -C build -j $(nproc || sysctl -n hw.ncpu || echo 4)
     - .ci/memory-leak-test.sh
   test_script:
     - .ci/appveyor-deb-install-test.sh

--- a/.ci/azure-pipelines-linux.yml
+++ b/.ci/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
   - script: |
       sudo apt -y install cmake gcc g++ libncurses5-dev libreadline-dev libssl-dev make zlib1g-dev
       ./configure
-      make package -C tmp -j $(nproc || sysctl -n hw.ncpu || echo 4)
+      make package -C build -j $(nproc || sysctl -n hw.ncpu || echo 4)
       .ci/appveyor-deb-install-test.sh
       sudo apt-get -y install autoconf libtool liblzo2-dev libpam-dev fping unzip # openvpn build deps
       sudo .ci/start-se-openvpn.sh

--- a/.ci/azure-pipelines-win.yml
+++ b/.ci/azure-pipelines-win.yml
@@ -11,7 +11,7 @@ jobs:
       configure
   - script: |
      call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-      cd tmp
+      cd build
       nmake
   - powershell: |
      . .ci\appveyor-vpntest.ps1

--- a/.ci/sonarcloud.sh
+++ b/.ci/sonarcloud.sh
@@ -5,7 +5,7 @@ RUN_SONARCLOUD="${RUN_SONARCLOUD:-0}"
 
 if [ "${RUN_SONARCLOUD}" = "1" ] && [ ! -z ${SONAR_TOKEN+x} ]; then
    ./configure
-   build-wrapper-linux-x86-64 --out-dir bw-output make -C tmp
+   build-wrapper-linux-x86-64 --out-dir bw-output make -C build
    sonar-scanner -Dsonar.projectKey=SoftEtherVPN_SoftEtherVPN -Dsonar.organization=softethervpn -Dsonar.sources=. -Dsonar.cfamily.build-wrapper-output=bw-output -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${SONAR_TOKEN}
 else
     echo "Skipping sonar-scan because \$RUN_SONARCLOUD != \"1\" or \$SONAR_TOKEN is not set"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,7 @@ FreeBSD_task:
   configure_script:
     - ./configure
   build_script:
-    - make -j $(sysctl -n hw.ncpu || echo 4) -C tmp
+    - make -j $(sysctl -n hw.ncpu || echo 4) -C build
   test_script:
     - ldd build/vpnserver
     - .ci/memory-leak-test.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@
     - cd "$REPOSITORY" && git submodule update --init --recursive
   script:
     - ./configure
-    - make package -C tmp
+    - make package -C build
     - dpkg -i build/softether-vpn*.deb
     - .ci/memory-leak-test.sh
 
@@ -36,7 +36,7 @@ build_illumos:
   script:
     - git submodule init && git submodule update
     - CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=/opt/local -DCMAKE_CXX_FLAGS=-m64 -DCMAKE_C_FLAGS=-m64" ./configure
-    - gmake -C tmp
+    - gmake -C build
 
 #
 # flawfinder

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
         - true
       script:
         - ./configure
-        - make -C tmp
+        - make -C build
         - otool -L build/vpnserver
         - .ci/memory-leak-test.sh
 
@@ -76,7 +76,7 @@ script:
   - .ci/coverity.sh
   - .ci/sonarcloud.sh
   - ./configure
-  - make -j $(nproc || sysctl -n hw.ncpu || echo 4) -C tmp
+  - make -j $(nproc || sysctl -n hw.ncpu || echo 4) -C build
   - ldd build/vpnserver
-  - if [ "${BUILD_DEB}" = "1" ]; then make package -C tmp; fi
+  - if [ "${BUILD_DEB}" = "1" ]; then make package -C build; fi
   - .ci/memory-leak-test.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project("SoftEther VPN"
 )
 
 set(TOP_DIRECTORY ${CMAKE_SOURCE_DIR})
-set(BUILD_DIRECTORY ${TOP_DIRECTORY}/build)
+set(BUILD_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # We define a dedicated variable because CMAKE_BUILD_TYPE can have different
 # configurations than "Debug" and "Release", such as "RelWithDebInfo".

--- a/configure
+++ b/configure
@@ -17,8 +17,8 @@ echo
 echo 'Welcome to the corner-cutting configure script !'
 echo
 
-if [ ! -d "tmp" ]; then
-  mkdir tmp
+if [ ! -d "build" ]; then
+  mkdir build
 fi
 
 if [ ! -z ${CMAKE_FLAGS+x} ]; then
@@ -50,9 +50,9 @@ fi
 
 echo ""
 
-(cd tmp && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ${CMAKE_FLAGS} .. || exit 1)
+(cd build && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ${CMAKE_FLAGS} .. || exit 1)
 
 
 echo ""
 
-echo "The Makefile is generated. Run 'make -C tmp' to build SoftEther VPN."
+echo "The Makefile is generated. Run 'make -C build' to build SoftEther VPN."

--- a/configure.cmd
+++ b/configure.cmd
@@ -13,11 +13,11 @@ echo.
 echo Welcome to the corner-cutting configure script !
 echo.
 
-if not exist "tmp" (
-	mkdir tmp
+if not exist "build" (
+	mkdir build
 )
 
-cd tmp
+cd build
 
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -G "NMake Makefiles" ..
 

--- a/src/hamcorebuilder/CMakeLists.txt
+++ b/src/hamcorebuilder/CMakeLists.txt
@@ -1,17 +1,3 @@
 add_executable(hamcorebuilder hamcorebuilder.c)
 
-set_target_properties(hamcorebuilder
-  PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/tmp"
-  LIBRARY_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/tmp"
-  RUNTIME_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/tmp"
-)
-
-if(WIN32)
-  set_target_properties(hamcorebuilder
-    PROPERTIES
-    PDB_OUTPUT_DIRECTORY "${TOP_DIRECTORY}/tmp"
-  )
-endif()
-
 target_link_libraries(hamcorebuilder cedar mayaqua)

--- a/src/vpnbridge/CMakeLists.txt
+++ b/src/vpnbridge/CMakeLists.txt
@@ -19,8 +19,8 @@ if(WIN32)
   get_filename_component(COMPONENT_FILE_NAME vpnbridge NAME)
   set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
 
-  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpnbridge.rc")
-  target_sources(vpnbridge PRIVATE vpnbridge.rc "${CMAKE_BINARY_DIR}/VerScript/vpnbridge.rc")
+  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+  target_sources(vpnbridge PRIVATE "vpnbridge.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
 endif()
 
 target_link_libraries(vpnbridge cedar mayaqua)

--- a/src/vpnclient/CMakeLists.txt
+++ b/src/vpnclient/CMakeLists.txt
@@ -19,8 +19,8 @@ if(WIN32)
   get_filename_component(COMPONENT_FILE_NAME vpnclient NAME)
   set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
 
-  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpnclient.rc")
-  target_sources(vpnclient PRIVATE vpnclient.rc "${CMAKE_BINARY_DIR}/VerScript/vpnclient.rc")
+  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+  target_sources(vpnclient PRIVATE "vpnclient.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
 endif()
 
 target_link_libraries(vpnclient cedar mayaqua)

--- a/src/vpncmd/CMakeLists.txt
+++ b/src/vpncmd/CMakeLists.txt
@@ -19,8 +19,8 @@ if(WIN32)
   get_filename_component(COMPONENT_FILE_NAME vpncmd NAME)
   set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
 
-  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpncmd.rc")
-  target_sources(vpncmd PRIVATE vpncmd.rc "${CMAKE_BINARY_DIR}/VerScript/vpncmd.rc")
+  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+  target_sources(vpncmd PRIVATE "vpncmd.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
 endif()
 
 target_link_libraries(vpncmd cedar mayaqua)

--- a/src/vpncmgr/CMakeLists.txt
+++ b/src/vpncmgr/CMakeLists.txt
@@ -10,8 +10,8 @@ add_executable(vpncmgr WIN32 vpncmgr.c vpncmgr.rc)
 get_filename_component(COMPONENT_FILE_NAME vpncmgr NAME)
 set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
 
-configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpncmgr.rc")
-target_sources(vpncmgr PRIVATE "${CMAKE_BINARY_DIR}/VerScript/vpncmgr.rc")
+configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+target_sources(vpncmgr PRIVATE "vpncmgr.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
 
 if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
   target_sources(vpncmgr PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest")

--- a/src/vpnserver/CMakeLists.txt
+++ b/src/vpnserver/CMakeLists.txt
@@ -19,8 +19,8 @@ if(WIN32)
   get_filename_component(COMPONENT_FILE_NAME vpnserver NAME)
   set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
 
-  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpnserver.rc")
-  target_sources(vpnserver PRIVATE vpnserver.rc "${CMAKE_BINARY_DIR}/VerScript/vpnserver.rc")
+  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+  target_sources(vpnserver PRIVATE "vpnserver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
 endif()
 
 target_link_libraries(vpnserver cedar mayaqua)

--- a/src/vpnsmgr/CMakeLists.txt
+++ b/src/vpnsmgr/CMakeLists.txt
@@ -10,8 +10,8 @@ add_executable(vpnsmgr WIN32 vpnsmgr.c vpnsmgr.rc)
 get_filename_component(COMPONENT_FILE_NAME vpnsmgr NAME)
 set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
 
-configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpnsmgr.rc")
-target_sources(vpnsmgr PRIVATE "${CMAKE_BINARY_DIR}/VerScript/vpnsmgr.rc")
+configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+target_sources(vpnsmgr PRIVATE "vpnsmgr.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
 
 if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
   target_sources(vpnsmgr PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest")

--- a/src/vpntest/CMakeLists.txt
+++ b/src/vpntest/CMakeLists.txt
@@ -19,8 +19,8 @@ if(WIN32)
   get_filename_component(COMPONENT_FILE_NAME vpntest NAME)
   set(COMPONENT_FILE_NAME "${COMPONENT_FILE_NAME}.exe")
 
-  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_BINARY_DIR}/VerScript/vpntest.rc")
-  target_sources(vpntest PRIVATE vpntest.rc "${CMAKE_BINARY_DIR}/VerScript/vpntest.rc")
+  configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+  target_sources(vpntest PRIVATE "vpntest.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
 
   if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
     target_sources(vpntest PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest")


### PR DESCRIPTION
Our CMake project used to forcefully create and use two different build directories: `build` and `tmp`.

This commit changes the behavior so that only the build directory CMake is ran in is used.