### PR TITLE
CMake: specify "WIN32" for targets that have WinMain(), add manifest for all targets that have it in the MSBuild project

### DIFF
--- a/src/vpnbridge/CMakeLists.txt
+++ b/src/vpnbridge/CMakeLists.txt
@@ -1,16 +1,9 @@
 set(COMPONENT_NAME "Bridge")
 set(COMPONENT_INTERNAL_NAME "vpnbridge")
 
-add_executable(vpnbridge vpnbridge.c)
-
-set_target_properties(vpnbridge
-  PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
-  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
-  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
-)
-
 if(WIN32)
+  add_executable(vpnbridge WIN32 vpnbridge.c)
+
   set_target_properties(vpnbridge
     PROPERTIES
     PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
@@ -21,7 +14,16 @@ if(WIN32)
 
   configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
   target_sources(vpnbridge PRIVATE "vpnbridge.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+else()
+  add_executable(vpnbridge vpnbridge.c)
 endif()
+
+set_target_properties(vpnbridge
+  PROPERTIES
+  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+)
 
 target_link_libraries(vpnbridge cedar mayaqua)
 

--- a/src/vpnbridge/CMakeLists.txt
+++ b/src/vpnbridge/CMakeLists.txt
@@ -14,6 +14,12 @@ if(WIN32)
 
   configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
   target_sources(vpnbridge PRIVATE "vpnbridge.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+
+  if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
+    target_sources(vpnbridge PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest")
+  else()
+    target_sources(vpnbridge PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest")
+  endif()
 else()
   add_executable(vpnbridge vpnbridge.c)
 endif()

--- a/src/vpnclient/CMakeLists.txt
+++ b/src/vpnclient/CMakeLists.txt
@@ -14,6 +14,12 @@ if(WIN32)
 
   configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
   target_sources(vpnclient PRIVATE "vpnclient.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+
+  if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
+    target_sources(vpnclient PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest")
+  else()
+    target_sources(vpnclient PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest")
+  endif()
 else()
   add_executable(vpnclient vpncsvc.c vpncsvc.h)
 endif()

--- a/src/vpnclient/CMakeLists.txt
+++ b/src/vpnclient/CMakeLists.txt
@@ -1,16 +1,9 @@
 set(COMPONENT_NAME "Client")
 set(COMPONENT_INTERNAL_NAME "vpnclient")
 
-add_executable(vpnclient vpncsvc.c vpncsvc.h)
-
-set_target_properties(vpnclient
-  PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
-  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
-  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
-)
-
 if(WIN32)
+  add_executable(vpnclient WIN32 vpncsvc.c vpncsvc.h)
+
   set_target_properties(vpnclient
     PROPERTIES
     PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
@@ -21,7 +14,16 @@ if(WIN32)
 
   configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
   target_sources(vpnclient PRIVATE "vpnclient.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+else()
+  add_executable(vpnclient vpncsvc.c vpncsvc.h)
 endif()
+
+set_target_properties(vpnclient
+  PROPERTIES
+  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+)
 
 target_link_libraries(vpnclient cedar mayaqua)
 

--- a/src/vpncmd/CMakeLists.txt
+++ b/src/vpncmd/CMakeLists.txt
@@ -21,6 +21,12 @@ if(WIN32)
 
   configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
   target_sources(vpncmd PRIVATE "vpncmd.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+
+  if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
+    target_sources(vpncmd PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest")
+  else()
+    target_sources(vpncmd PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest")
+  endif()
 endif()
 
 target_link_libraries(vpncmd cedar mayaqua)

--- a/src/vpnserver/CMakeLists.txt
+++ b/src/vpnserver/CMakeLists.txt
@@ -14,6 +14,12 @@ if(WIN32)
 
   configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
   target_sources(vpnserver PRIVATE "vpnserver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+
+  if(${COMPILER_ARCHITECTURE} STREQUAL "x64")
+    target_sources(vpnserver PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x64_user.manifest")
+  else()
+    target_sources(vpnserver PRIVATE "${TOP_DIRECTORY}/src/BuildFiles/Manifests/x86_user.manifest")
+  endif()
 else()
   add_executable(vpnserver vpnserver.c)
 endif()

--- a/src/vpnserver/CMakeLists.txt
+++ b/src/vpnserver/CMakeLists.txt
@@ -1,16 +1,9 @@
 set(COMPONENT_NAME "Server")
 set(COMPONENT_INTERNAL_NAME "vpnserver")
 
-add_executable(vpnserver vpnserver.c)
-
-set_target_properties(vpnserver
-  PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
-  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
-  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
-)
-
 if(WIN32)
+  add_executable(vpnserver WIN32 vpnserver.c)
+
   set_target_properties(vpnserver
     PROPERTIES
     PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
@@ -21,7 +14,16 @@ if(WIN32)
 
   configure_file("${TOP_DIRECTORY}/src/BuildFiles/VerScript/ver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
   target_sources(vpnserver PRIVATE "vpnserver.rc" "${CMAKE_CURRENT_BINARY_DIR}/ver.rc")
+else()
+  add_executable(vpnserver vpnserver.c)
 endif()
+
+set_target_properties(vpnserver
+  PROPERTIES
+  ARCHIVE_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+  RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
+)
 
 target_link_libraries(vpnserver cedar mayaqua)
 


### PR DESCRIPTION
When `VPN_EXE` is defined, Mayaqua.h defines `WinMain()`, which handles arguments in a special way.

This commit passes `WIN32` to `add_executable()`, so that `WinMain()` is used as entry point instead of `main()`.

The use of `main()` instead of `WinMain()` was causing service mode not to work due to the `/service` argument being discarded.

`vpntest` is not a service, but for consistency we specify `WIN32` for it as well because it defines `VPN_EXE`.