### PR TITLE
Proto: write message to log on session creation/deletion, remove redundant OpenVPN messages

### DIFF
--- a/src/Cedar/Proto.c
+++ b/src/Cedar/Proto.c
@@ -196,7 +196,7 @@ void ProtoDelete(PROTO *proto)
 
 	for (i = 0; i < HASH_LIST_NUM(proto->Sessions); ++i)
 	{
-		ProtoDeleteSession(LIST_DATA(proto->Sessions->AllList, i));
+		ProtoSessionDelete(LIST_DATA(proto->Sessions->AllList, i));
 	}
 	ReleaseHashList(proto->Sessions);
 
@@ -325,7 +325,7 @@ const PROTO_CONTAINER *ProtoDetect(const PROTO *proto, const PROTO_MODE mode, co
 	return NULL;
 }
 
-PROTO_SESSION *ProtoNewSession(PROTO *proto, const PROTO_CONTAINER *container, const IP *src_ip, const USHORT src_port, const IP *dst_ip, const USHORT dst_port)
+PROTO_SESSION *ProtoSessionNew(const PROTO *proto, const PROTO_CONTAINER *container, const IP *src_ip, const USHORT src_port, const IP *dst_ip, const USHORT dst_port)
 {
 	LIST *options;
 	PROTO_SESSION *session;
@@ -376,7 +376,7 @@ PROTO_SESSION *ProtoNewSession(PROTO *proto, const PROTO_CONTAINER *container, c
 	return session;
 }
 
-void ProtoDeleteSession(PROTO_SESSION *session)
+void ProtoSessionDelete(PROTO_SESSION *session)
 {
 	if (session == NULL)
 	{
@@ -632,7 +632,7 @@ void ProtoHandleDatagrams(UDPLISTENER *listener, LIST *datagrams)
 				continue;
 			}
 
-			session = ProtoNewSession(proto, container, &tmp.SrcIp, tmp.SrcPort, &tmp.DstIp, tmp.DstPort);
+			session = ProtoSessionNew(proto, container, &tmp.SrcIp, tmp.SrcPort, &tmp.DstIp, tmp.DstPort);
 			if (session == NULL)
 			{
 				continue;
@@ -659,7 +659,7 @@ void ProtoHandleDatagrams(UDPLISTENER *listener, LIST *datagrams)
 		if (session->Halt)
 		{
 			DeleteHash(sessions, session);
-			ProtoDeleteSession(session);
+			ProtoSessionDelete(session);
 			continue;
 		}
 

--- a/src/Cedar/Proto.h
+++ b/src/Cedar/Proto.h
@@ -94,8 +94,8 @@ void ProtoContainerDelete(PROTO_CONTAINER *container);
 
 const PROTO_CONTAINER *ProtoDetect(const PROTO *proto, const PROTO_MODE mode, const UCHAR *data, const UINT size);
 
-PROTO_SESSION *ProtoNewSession(PROTO *proto, const PROTO_CONTAINER *container, const IP *src_ip, const USHORT src_port, const IP *dst_ip, const USHORT dst_port);
-void ProtoDeleteSession(PROTO_SESSION *session);
+PROTO_SESSION *ProtoSessionNew(const PROTO *proto, const PROTO_CONTAINER *container, const IP *src_ip, const USHORT src_port, const IP *dst_ip, const USHORT dst_port);
+void ProtoSessionDelete(PROTO_SESSION *session);
 
 bool ProtoSetListenIP(PROTO *proto, const IP *ip);
 bool ProtoSetUdpPorts(PROTO *proto, const LIST *ports);

--- a/src/Cedar/Proto.h
+++ b/src/Cedar/Proto.h
@@ -78,6 +78,8 @@ typedef struct PROTO_SESSION
 	volatile bool Halt;
 } PROTO_SESSION;
 
+void ProtoLog(const PROTO *proto, const PROTO_SESSION *session, const char *name, ...);
+
 int ProtoOptionCompare(void *p1, void *p2);
 int ProtoContainerCompare(void *p1, void *p2);
 int ProtoSessionCompare(void *p1, void *p2);

--- a/src/Cedar/Proto_OpenVPN.c
+++ b/src/Cedar/Proto_OpenVPN.c
@@ -2139,8 +2139,6 @@ OPENVPN_SESSION *OvsNewSession(OPENVPN_SERVER *s, IP *server_ip, UINT server_por
 	Debug("OpenVPN New Session: %s:%u -> %s:%u Proto=%u\n", server_ip_str, server_port,
 	      client_ip_str, client_port, protocol);
 
-	OvsLog(s, se, NULL, "LO_NEW_SESSION", (protocol == OPENVPN_PROTOCOL_UDP ? "UDP" : "TCP"));
-
 	return se;
 }
 
@@ -2777,7 +2775,6 @@ void OvsRecvPacket(OPENVPN_SERVER *s, LIST *recv_packet_list, UINT protocol)
 			OPENVPN_SESSION *se = LIST_DATA(delete_session_list, i);
 
 			Debug("Deleting Session %p\n", se);
-			OvsLog(s, se, NULL, "LO_DELETE_SESSION");
 
 			OvsFreeSession(se);
 
@@ -2982,8 +2979,6 @@ OPENVPN_SERVER *NewOpenVpnServer(const LIST *options, CEDAR *cedar, INTERRUPT_MA
 
 	s->NextSessionId = 1;
 
-	OvsLog(s, NULL, NULL, "LO_START");
-
 	s->Dh = DhNewFromBits(cedar->DhParamBits);
 
 	return s;
@@ -2998,8 +2993,6 @@ void FreeOpenVpnServer(OPENVPN_SERVER *s)
 	{
 		return;
 	}
-
-	OvsLog(s, NULL, NULL, "LO_STOP");
 
 	// Release the sessions list
 	for (i = 0; i < LIST_NUM(s->SessionList); ++i)

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -1827,15 +1827,11 @@ LO_CLIENT_CERT			Client certificate received (subject: CN="%s"), will use certif
 LO_CLIENT_UNVERIFIED_CERT		Client certificate was provided but did not pass verification (error="%S"), will use password authentication.
 LO_CLIENT_NO_CERT		Client certificate is not provided, will use password authentication.
 LO_OPTION_STR_SEND		发送选项字符串："%S"
-LO_NEW_SESSION			已创建新的会话。协议：%S
 LO_INITIATE_REKEY			re-keying 进程已开始。
 LO_CHANNEL_ESTABLISHED		该通道成为已建立的状态。
 LO_PUSH_REPLY			完整字符串回答："%S"
 LO_CHANNEL_FAILED		无法连接通道。
 LO_CHANNEL_DISCONNECTED_BY_HUB	此 OpenVPN 的通道被终止，因为虚拟 HUB 管理员断开了此 VPN 会话。
-LO_DELETE_SESSION		删除会话中。
-LO_START				OpenVPN Server 模块正在启动。
-LO_STOP					OpenVPN Server 模块已停止。
 
 
 # (IPsec 日志)

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -1810,6 +1810,12 @@ LS_API_AUTH_ERROR		HTTPS API client "%r:%u" (%S): The embedded HTTPS web server 
 LS_API_RPC_CALL			HTTPS API client "%r:%u" (%S): The client called a JSON-API. Method: "%S", Returned error code: %u (0 = success), Returned error message: "%s"
 
 
+# (Proto log)
+LP_PREFIX_SESSION		[%s] %r:%u -> %r:%u (%s): 
+LP_SESSION_CREATED		Session created.
+LP_SESSION_DELETED		Session deleted.
+
+
 # (OpenVPN Logs)
 LO_PREFIX_RAW			OpenVPN 模块:
 LO_PREFIX_SESSION		OpenVPN 会话%u (%r:%u -> %r:%u):

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -1792,6 +1792,13 @@ LS_API_AUTH_OK			HTTPS API client "%r:%u" (%S): Administration mode: "%S": The e
 LS_API_AUTH_ERROR		HTTPS API client "%r:%u" (%S): The embedded HTTPS web server refused a login attempt. Username: "%S", Method: "%S", Path: "%S"
 LS_API_RPC_CALL			HTTPS API client "%r:%u" (%S): The client called a JSON-API. Method: "%S", Returned error code: %u (0 = success), Returned error message: "%s"
 
+
+# (Proto log)
+LP_PREFIX_SESSION		[%s] %r:%u -> %r:%u (%s): 
+LP_SESSION_CREATED		Session created.
+LP_SESSION_DELETED		Session deleted.
+
+
 # (OpenVPN Logs)
 LO_PREFIX_RAW			OpenVPN Module: 
 LO_PREFIX_SESSION		OpenVPN Session %u (%r:%u -> %r:%u): 

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -1810,15 +1810,11 @@ LO_CLIENT_CERT			Client certificate received (subject: CN="%s"), will use certif
 LO_CLIENT_UNVERIFIED_CERT		Client certificate was provided but did not pass verification (error="%S"), will use password authentication.
 LO_CLIENT_NO_CERT		Client certificate is not provided, will use password authentication.
 LO_OPTION_STR_SEND		Option Strings to Send: "%S"
-LO_NEW_SESSION			A new session is created. Protocol: %S
 LO_INITIATE_REKEY		The re-keying process is started.
 LO_CHANNEL_ESTABLISHED	The channel becomes the established state.
 LO_PUSH_REPLY			The full strings replied: "%S"
 LO_CHANNEL_FAILED		Failed to connect a channel.
 LO_CHANNEL_DISCONNECTED_BY_HUB	This OpenVPN channel is being terminated because the administrator of the Virtual Hub has disconnected this the VPN Session.
-LO_DELETE_SESSION		Deleting the session.
-LO_START				The OpenVPN Server Module is starting.
-LO_STOP					The OpenVPN Server Module is stopped.
 
 
 # (IPsec Logs)

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -1812,15 +1812,11 @@ LO_CLIENT_CERT			Client certificate received (subject: CN="%s"), will use certif
 LO_CLIENT_UNVERIFIED_CERT		Client certificate was provided but did not pass verification (error="%S"), will use password authentication.
 LO_CLIENT_NO_CERT		Client certificate is not provided, will use password authentication.
 LO_OPTION_STR_SEND		送信するオプション文字列: "%S"
-LO_NEW_SESSION			新しいセッションを作成しました。プロトコル: %S
 LO_INITIATE_REKEY		このチャネルのリキーを開始します。
 LO_CHANNEL_ESTABLISHED	チャネルが確立状態になりました。
 LO_PUSH_REPLY			応答オプション文字列の全文: "%S"
 LO_CHANNEL_FAILED		チャネルの接続処理に失敗しました。
 LO_CHANNEL_DISCONNECTED_BY_HUB	仮想 HUB の管理者によって VPN セッションが切断されたため、この OpenVPN チャネルを切断します。
-LO_DELETE_SESSION		セッションを削除します。
-LO_START				OpenVPN サーバーモジュールを起動しました。
-LO_STOP					OpenVPN サーバーモジュールを停止しました。
 
 
 # (IPsec ログ)

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -1796,6 +1796,11 @@ LS_API_AUTH_OK			HTTPS API クライアント "%r:%u" (%S): 管理モード: "%S
 LS_API_AUTH_ERROR		HTTPS API クライアント "%r:%u" (%S): 組み込み HTTPS Web サーバーを用いてログインに失敗しました。使用されたユーザー名: "%S", メソッド: "%S", パス: "%S"
 LS_API_RPC_CALL			HTTPS API クライアント "%r:%u" (%S): JSON-API を呼び出しました。メソッド名: "%S", 結果エラーコード: %u (0 = 成功), 結果エラーメッセージ: "%s"
 
+# (Proto ログ)
+LP_PREFIX_SESSION		[%s] %r:%u -> %r:%u (%s): 
+LP_SESSION_CREATED		Session created.
+LP_SESSION_DELETED		Session deleted.
+
 # (OpenVPN ログ)
 LO_PREFIX_RAW			OpenVPN モジュール: 
 LO_PREFIX_SESSION		OpenVPN セッション %u (%r:%u -> %r:%u): 

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -1778,6 +1778,12 @@ LS_API_AUTH_ERROR		HTTPS API client "%r:%u" (%S): The embedded HTTPS web server 
 LS_API_RPC_CALL			HTTPS API client "%r:%u" (%S): The client called a JSON-API. Method: "%S", Returned error code: %u (0 = success), Returned error message: "%s"
 
 
+# (Proto 로그)
+LP_PREFIX_SESSION [%s] %r:%u -> %r:%u (%s): 
+LP_SESSION_CREATED Session created.
+LP_SESSION_DELETED Session deleted.
+
+
 # (OpenVPN 로그)
 LO_PREFIX_RAW OpenVPN 모듈:
 LO_PREFIX_SESSION OpenVPN 세션 %u (%r:%u -> %r:%u):

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -1792,15 +1792,11 @@ LO_NEW_CHANNEL 새로운 채널을 만들었습니다.
 LO_CHANNEL_ESTABLISHED_NEWKEY 채널이 설정 상태가되었습니다 (원인:리키 완료).
 LO_OPTION_STR_RECV 받은 옵션 문자열:"%S"
 LO_OPTION_STR_SEND 보내는 옵션 문자열:"%S"
-LO_NEW_SESSION 새 세션을 만들었습니다. 프로토콜:%S
 LO_INITIATE_REKEY 이 채널의 리키를 시작합니다.
 LO_CHANNEL_ESTABLISHED 채널이 설정 상태가되었습니다 .
 LO_PUSH_REPLY 응답 옵션 문자열 전체:"%S"
 LO_CHANNEL_FAILED 채널의 접속 처리에 실패했습니다.
 LO_CHANNEL_DISCONNECTED_BY_HUB 가상 HUB 관리자가 VPN 세션이 끊어 졌기 때문에이 OpenVPN 채널을 끊습니다.
-LO_DELETE_SESSION 세션을 삭제합니다.
-LO_START OpenVPN 서버 모듈을 시작했습니다.
-LO_STOP OpenVPN 서버 모듈을 중지했습니다.
 
 
 # IPsec (로그)

--- a/src/bin/hamcore/strtable_pt_br.stb
+++ b/src/bin/hamcore/strtable_pt_br.stb
@@ -1810,15 +1810,11 @@ LO_CLIENT_CERT	Client certificate received (subject: CN="%s"), will use certific
 LO_CLIENT_UNVERIFIED_CERT	Client certificate was provided but did not pass verification (error="%S"), will use password authentication.
 LO_CLIENT_NO_CERT	Client certificate is not provided, will use password authentication.
 LO_OPTION_STR_SEND	Option Strings to Send: "%S"
-LO_NEW_SESSION	A new session is created. Protocol: %S
 LO_INITIATE_REKEY	The re-keying process is started.
 LO_CHANNEL_ESTABLISHED	The channel becomes the established state.
 LO_PUSH_REPLY	The full strings replied: "%S"
 LO_CHANNEL_FAILED	Failed to connect a channel.
 LO_CHANNEL_DISCONNECTED_BY_HUB	This OpenVPN channel is being terminated because the administrator of the Virtual Hub has disconnected this the VPN Session.
-LO_DELETE_SESSION	Deleting the session.
-LO_START	The OpenVPN Server Module is starting.
-LO_STOP	The OpenVPN Server Module is stopped.
 
 
 # (IPsec Logs)

--- a/src/bin/hamcore/strtable_pt_br.stb
+++ b/src/bin/hamcore/strtable_pt_br.stb
@@ -1793,6 +1793,12 @@ LS_API_AUTH_ERROR	HTTPS API client "%r:%u" (%S): The embedded HTTPS web server r
 LS_API_RPC_CALL	HTTPS API client "%r:%u" (%S): The client called a JSON-API. Method: "%S", Returned error code: %u (0 = success), Returned error message: "%s"
 
 
+# (Proto log)
+LP_PREFIX_SESSION		[%s] %r:%u -> %r:%u (%s): 
+LP_SESSION_CREATED		Session created.
+LP_SESSION_DELETED		Session deleted.
+
+
 # (OpenVPN Logs)
 LO_PREFIX_RAW	OpenVPN Module: 
 LO_PREFIX_SESSION	OpenVPN Session %u (%r:%u -> %r:%u): 

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -1810,15 +1810,11 @@ LO_CLIENT_CERT			Client certificate received (subject: CN="%s"), will use certif
 LO_CLIENT_UNVERIFIED_CERT		Client certificate was provided but did not pass verification (error="%S"), will use password authentication.
 LO_CLIENT_NO_CERT		Client certificate is not provided, will use password authentication.
 LO_OPTION_STR_SEND		Option Strings to Send: "%S"
-LO_NEW_SESSION			A new session is created. Protocol: %S
 LO_INITIATE_REKEY		The re-keying process is started.
 LO_CHANNEL_ESTABLISHED	The channel becomes the established state.
 LO_PUSH_REPLY			The full strings replied: "%S"
 LO_CHANNEL_FAILED		Failed to connect a channel.
 LO_CHANNEL_DISCONNECTED_BY_HUB	This OpenVPN channel is being terminated because the administrator of the Virtual Hub has disconnected this the VPN Session.
-LO_DELETE_SESSION		Deleting the session.
-LO_START				The OpenVPN Server Module is starting.
-LO_STOP					The OpenVPN Server Module is stopped.
 
 
 # (IPsec Logs)

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -1793,6 +1793,12 @@ LS_API_AUTH_ERROR		HTTPS API client "%r:%u" (%S): The embedded HTTPS web server 
 LS_API_RPC_CALL			HTTPS API client "%r:%u" (%S): The client called a JSON-API. Method: "%S", Returned error code: %u (0 = success), Returned error message: "%s"
 
 
+# (Proto log)
+LP_PREFIX_SESSION		[%s] %r:%u -> %r:%u (%s): 
+LP_SESSION_CREATED		Session created.
+LP_SESSION_DELETED		Session deleted.
+
+
 # (OpenVPN Logs)
 LO_PREFIX_RAW			OpenVPN Module: 
 LO_PREFIX_SESSION		OpenVPN Session %u (%r:%u -> %r:%u): 

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -1813,7 +1813,13 @@ LS_API_AUTH_ERROR		HTTPS API client "%r:%u" (%S): The embedded HTTPS web server 
 LS_API_RPC_CALL			HTTPS API client "%r:%u" (%S): The client called a JSON-API. Method: "%S", Returned error code: %u (0 = success), Returned error message: "%s"
 
 
-# (OpenVPN Logs)
+# (Proto 日誌)
+LP_PREFIX_SESSION		[%s] %r:%u -> %r:%u (%s): 
+LP_SESSION_CREATED		Session created.
+LP_SESSION_DELETED		Session deleted.
+
+
+# (OpenVPN 日誌)
 LO_PREFIX_RAW			OpenVPN 模組:
 LO_PREFIX_SESSION		OpenVPN 會話%u (%r:%u -> %r:%u):
 LO_PREFIX_CHANNEL		OpenVPN 會話%u (%r:%u -> %r:%u) 通道 %u:

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -1830,15 +1830,11 @@ LO_CLIENT_CERT			Client certificate received (subject: CN="%s"), will use certif
 LO_CLIENT_UNVERIFIED_CERT		Client certificate was provided but did not pass verification (error="%S"), will use password authentication.
 LO_CLIENT_NO_CERT		Client certificate is not provided, will use password authentication.
 LO_OPTION_STR_SEND		發送選項字串："%S"
-LO_NEW_SESSION			已創建新的會話。協議：%S
 LO_INITIATE_REKEY			re-keying 進程已開始。
 LO_CHANNEL_ESTABLISHED		該通道成為已建立的狀態。
 LO_PUSH_REPLY			完整字串回答："%S"
 LO_CHANNEL_FAILED		無法連接通道。
 LO_CHANNEL_DISCONNECTED_BY_HUB	此 OpenVPN 的通道被終止，因為虛擬 HUB 管理員斷開了此 VPN 會話。
-LO_DELETE_SESSION		刪除會話中。
-LO_START				OpenVPN Server 模組正在啟動。
-LO_STOP					OpenVPN Server 模組已停止。
 
 
 # (IPsec 日誌)


### PR DESCRIPTION
Example of the new messages:
```
[OpenVPN] 192.168.122.100:47390 -> 0.0.0.0:1194 (UDP): Session created.
[OpenVPN] 192.168.122.100:47390 -> 0.0.0.0:1194 (UDP): Session deleted.

[OpenVPN] 192.168.122.100:49866 -> 192.168.122.1:1194 (TCP): Session created.
[OpenVPN] 192.168.122.100:49866 -> 192.168.122.1:1194 (TCP): Session deleted.
```

Example of the redundant messages (now removed):
```
OpenVPN Module: The OpenVPN Server Module is starting.
OpenVPN Session 1 (192.168.122.211:47390 -> 0.0.0.0:1194): A new session is created. Protocol: UDP

OpenVPN Session 1 (192.168.122.211:47390 -> 0.0.0.0:1194): Deleting the session.
OpenVPN Module: The OpenVPN Server Module is stopped.
```