### PR TITLE
Fix Parameter Descriptions in the JSON-RPC Documentation

### DIFF
--- a/developer_tools/vpnserver-jsonrpc-clients/README.html
+++ b/developer_tools/vpnserver-jsonrpc-clients/README.html
@@ -580,32 +580,32 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Recv.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Recv)</td>
+<td>Broadcast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Recv)</td>
+<td>Number of broadcast packets (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast count (Recv)</td>
+<td>Unicast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Recv)</td>
+<td>Unicast count (Recv)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Send)</td>
+<td>Broadcast bytes (Send)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Send)</td>
+<td>Number of broadcast packets (Send)</td>
 </tr>
 <tr>
 <td><code>Send.UnicastBytes_u64</code></td>
@@ -615,7 +615,7 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Send.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Send)</td>
+<td>Unicast count (Send)</td>
 </tr>
 <tr>
 <td><code>CurrentTime_dt</code></td>
@@ -2695,32 +2695,32 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Recv.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Recv)</td>
+<td>Broadcast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Recv)</td>
+<td>Number of broadcast packets (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast count (Recv)</td>
+<td>Unicast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Recv)</td>
+<td>Unicast count (Recv)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Send)</td>
+<td>Broadcast bytes (Send)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Send)</td>
+<td>Number of broadcast packets (Send)</td>
 </tr>
 <tr>
 <td><code>Send.UnicastBytes_u64</code></td>
@@ -2730,7 +2730,7 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Send.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Send)</td>
+<td>Unicast count (Send)</td>
 </tr>
 <tr>
 <td><code>SecureNATEnabled_bool</code></td>
@@ -6212,32 +6212,32 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Recv.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Recv)</td>
+<td>Broadcast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Recv)</td>
+<td>Number of broadcast packets (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast count (Recv)</td>
+<td>Unicast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Recv)</td>
+<td>Unicast count (Recv)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Send)</td>
+<td>Broadcast bytes (Send)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Send)</td>
+<td>Number of broadcast packets (Send)</td>
 </tr>
 <tr>
 <td><code>Send.UnicastBytes_u64</code></td>
@@ -6247,7 +6247,7 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Send.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Send)</td>
+<td>Unicast count (Send)</td>
 </tr>
 <tr>
 <td><code>UsePolicy_bool</code></td>
@@ -6683,32 +6683,32 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Recv.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Recv)</td>
+<td>Broadcast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Recv)</td>
+<td>Number of broadcast packets (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast count (Recv)</td>
+<td>Unicast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Recv)</td>
+<td>Unicast count (Recv)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Send)</td>
+<td>Broadcast bytes (Send)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Send)</td>
+<td>Number of broadcast packets (Send)</td>
 </tr>
 <tr>
 <td><code>Send.UnicastBytes_u64</code></td>
@@ -6718,7 +6718,7 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Send.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Send)</td>
+<td>Unicast count (Send)</td>
 </tr>
 <tr>
 <td><code>UsePolicy_bool</code></td>
@@ -7103,32 +7103,32 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Recv.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Recv)</td>
+<td>Broadcast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Recv)</td>
+<td>Number of broadcast packets (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast count (Recv)</td>
+<td>Unicast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Recv)</td>
+<td>Unicast count (Recv)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Send)</td>
+<td>Broadcast bytes (Send)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Send)</td>
+<td>Number of broadcast packets (Send)</td>
 </tr>
 <tr>
 <td><code>Send.UnicastBytes_u64</code></td>
@@ -7138,7 +7138,7 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Send.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Send)</td>
+<td>Unicast count (Send)</td>
 </tr>
 <tr>
 <td><code>UsePolicy_bool</code></td>
@@ -7747,32 +7747,32 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Recv.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Recv)</td>
+<td>Broadcast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Recv)</td>
+<td>Number of broadcast packets (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast count (Recv)</td>
+<td>Unicast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Recv)</td>
+<td>Unicast count (Recv)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Send)</td>
+<td>Broadcast bytes (Send)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Send)</td>
+<td>Number of broadcast packets (Send)</td>
 </tr>
 <tr>
 <td><code>Send.UnicastBytes_u64</code></td>
@@ -7782,7 +7782,7 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Send.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Send)</td>
+<td>Unicast count (Send)</td>
 </tr>
 <tr>
 <td><code>UsePolicy_bool</code></td>
@@ -8137,32 +8137,32 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Recv.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Recv)</td>
+<td>Broadcast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Recv)</td>
+<td>Number of broadcast packets (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast count (Recv)</td>
+<td>Unicast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Recv)</td>
+<td>Unicast count (Recv)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Send)</td>
+<td>Broadcast bytes (Send)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Send)</td>
+<td>Number of broadcast packets (Send)</td>
 </tr>
 <tr>
 <td><code>Send.UnicastBytes_u64</code></td>
@@ -8172,7 +8172,7 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Send.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Send)</td>
+<td>Unicast count (Send)</td>
 </tr>
 <tr>
 <td><code>UsePolicy_bool</code></td>
@@ -8485,32 +8485,32 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Recv.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Recv)</td>
+<td>Broadcast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Recv)</td>
+<td>Number of broadcast packets (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast count (Recv)</td>
+<td>Unicast bytes (Recv)</td>
 </tr>
 <tr>
 <td><code>Recv.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Recv)</td>
+<td>Unicast count (Recv)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastBytes_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Number of broadcast packets (Send)</td>
+<td>Broadcast bytes (Send)</td>
 </tr>
 <tr>
 <td><code>Send.BroadcastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Broadcast bytes (Send)</td>
+<td>Number of broadcast packets (Send)</td>
 </tr>
 <tr>
 <td><code>Send.UnicastBytes_u64</code></td>
@@ -8520,7 +8520,7 @@ All APIs are based on the <a href="https://www.jsonrpc.org/specification">JSON-R
 <tr>
 <td><code>Send.UnicastCount_u64</code></td>
 <td><code>number</code> (uint64)</td>
-<td>Unicast bytes (Send)</td>
+<td>Unicast count (Send)</td>
 </tr>
 <tr>
 <td><code>UsePolicy_bool</code></td>

--- a/developer_tools/vpnserver-jsonrpc-clients/README.md
+++ b/developer_tools/vpnserver-jsonrpc-clients/README.md
@@ -404,14 +404,14 @@ Name | Type | Description
 `AssignedClientLicenses_u32` | `number` (uint32) | Number of assigned client licenses (Useful to make a commercial version)
 `AssignedBridgeLicensesTotal_u32` | `number` (uint32) | Number of Assigned bridge license (cluster-wide), useful to make a commercial version
 `AssignedClientLicensesTotal_u32` | `number` (uint32) | Number of assigned client licenses (cluster-wide), useful to make a commercial version
-`Recv.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Recv)
-`Recv.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Recv)
-`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast count (Recv)
-`Recv.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Recv)
-`Send.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Send)
-`Send.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Recv.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Recv)
+`Recv.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Recv)
+`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Recv)
+`Recv.UnicastCount_u64` | `number` (uint64) | Unicast count (Recv)
+`Send.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Send.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Send)
 `Send.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Send)
-`Send.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Send)
+`Send.UnicastCount_u64` | `number` (uint64) | Unicast count (Send)
 `CurrentTime_dt` | `Date` | Current time
 `CurrentTick_u64` | `number` (uint64) | 64 bit High-Precision Logical System Clock
 `StartTime_dt` | `Date` | VPN Server Start-up time
@@ -1759,14 +1759,14 @@ Name | Type | Description
 `NumGroups_u32` | `number` (uint32) | Number of groups
 `NumMacTables_u32` | `number` (uint32) | Number of MAC table entries
 `NumIpTables_u32` | `number` (uint32) | Number of IP table entries
-`Recv.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Recv)
-`Recv.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Recv)
-`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast count (Recv)
-`Recv.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Recv)
-`Send.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Send)
-`Send.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Recv.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Recv)
+`Recv.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Recv)
+`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Recv)
+`Recv.UnicastCount_u64` | `number` (uint64) | Unicast count (Recv)
+`Send.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Send.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Send)
 `Send.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Send)
-`Send.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Send)
+`Send.UnicastCount_u64` | `number` (uint64) | Unicast count (Send)
 `SecureNATEnabled_bool` | `boolean` | Whether SecureNAT is enabled
 `LastCommTime_dt` | `Date` | Last communication date and time
 `LastLoginTime_dt` | `Date` | Last login date and time
@@ -3712,14 +3712,14 @@ Name | Type | Description
 `RadiusUsername_utf` | `string` (UTF8) | Username in RADIUS server, optional, valid only if AuthType_u32 == Radius(4).
 `NtUsername_utf` | `string` (UTF8) | Username in NT Domain server, optional, valid only if AuthType_u32 == NT(5).
 `NumLogin_u32` | `number` (uint32) | Number of total logins of the user
-`Recv.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Recv)
-`Recv.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Recv)
-`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast count (Recv)
-`Recv.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Recv)
-`Send.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Send)
-`Send.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Recv.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Recv)
+`Recv.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Recv)
+`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Recv)
+`Recv.UnicastCount_u64` | `number` (uint64) | Unicast count (Recv)
+`Send.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Send.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Send)
 `Send.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Send)
-`Send.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Send)
+`Send.UnicastCount_u64` | `number` (uint64) | Unicast count (Send)
 `UsePolicy_bool` | `boolean` | The flag whether to use security policy
 `policy:Access_bool` | `boolean` | Security policy: Allow Access. The users, which this policy value is true, have permission to make VPN connection to VPN Server.
 `policy:DHCPFilter_bool` | `boolean` | Security policy: Filter DHCP Packets (IPv4). All IPv4 DHCP packets in sessions defined this policy will be filtered.
@@ -3925,14 +3925,14 @@ Name | Type | Description
 `RadiusUsername_utf` | `string` (UTF8) | Username in RADIUS server, optional, valid only if AuthType_u32 == Radius(4).
 `NtUsername_utf` | `string` (UTF8) | Username in NT Domain server, optional, valid only if AuthType_u32 == NT(5).
 `NumLogin_u32` | `number` (uint32) | Number of total logins of the user
-`Recv.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Recv)
-`Recv.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Recv)
-`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast count (Recv)
-`Recv.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Recv)
-`Send.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Send)
-`Send.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Recv.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Recv)
+`Recv.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Recv)
+`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Recv)
+`Recv.UnicastCount_u64` | `number` (uint64) | Unicast count (Recv)
+`Send.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Send.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Send)
 `Send.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Send)
-`Send.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Send)
+`Send.UnicastCount_u64` | `number` (uint64) | Unicast count (Send)
 `UsePolicy_bool` | `boolean` | The flag whether to use security policy
 `policy:Access_bool` | `boolean` | Security policy: Allow Access. The users, which this policy value is true, have permission to make VPN connection to VPN Server.
 `policy:DHCPFilter_bool` | `boolean` | Security policy: Filter DHCP Packets (IPv4). All IPv4 DHCP packets in sessions defined this policy will be filtered.
@@ -4087,14 +4087,14 @@ Name | Type | Description
 `RadiusUsername_utf` | `string` (UTF8) | Username in RADIUS server, optional, valid only if AuthType_u32 == Radius(4).
 `NtUsername_utf` | `string` (UTF8) | Username in NT Domain server, optional, valid only if AuthType_u32 == NT(5).
 `NumLogin_u32` | `number` (uint32) | Number of total logins of the user
-`Recv.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Recv)
-`Recv.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Recv)
-`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast count (Recv)
-`Recv.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Recv)
-`Send.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Send)
-`Send.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Recv.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Recv)
+`Recv.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Recv)
+`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Recv)
+`Recv.UnicastCount_u64` | `number` (uint64) | Unicast count (Recv)
+`Send.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Send.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Send)
 `Send.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Send)
-`Send.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Send)
+`Send.UnicastCount_u64` | `number` (uint64) | Unicast count (Send)
 `UsePolicy_bool` | `boolean` | The flag whether to use security policy
 `policy:Access_bool` | `boolean` | Security policy: Allow Access. The users, which this policy value is true, have permission to make VPN connection to VPN Server.
 `policy:DHCPFilter_bool` | `boolean` | Security policy: Filter DHCP Packets (IPv4). All IPv4 DHCP packets in sessions defined this policy will be filtered.
@@ -4425,14 +4425,14 @@ Name | Type | Description
 `Name_str` | `string` (ASCII) | The group name
 `Realname_utf` | `string` (UTF8) | Optional real name (full name) of the group, allow using any Unicode characters
 `Note_utf` | `string` (UTF8) | Optional, specify a description of the group
-`Recv.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Recv)
-`Recv.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Recv)
-`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast count (Recv)
-`Recv.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Recv)
-`Send.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Send)
-`Send.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Recv.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Recv)
+`Recv.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Recv)
+`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Recv)
+`Recv.UnicastCount_u64` | `number` (uint64) | Unicast count (Recv)
+`Send.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Send.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Send)
 `Send.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Send)
-`Send.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Send)
+`Send.UnicastCount_u64` | `number` (uint64) | Unicast count (Send)
 `UsePolicy_bool` | `boolean` | The flag whether to use security policy
 `policy:Access_bool` | `boolean` | Security policy: Allow Access. The users, which this policy value is true, have permission to make VPN connection to VPN Server.
 `policy:DHCPFilter_bool` | `boolean` | Security policy: Filter DHCP Packets (IPv4). All IPv4 DHCP packets in sessions defined this policy will be filtered.
@@ -4605,14 +4605,14 @@ Name | Type | Description
 `Name_str` | `string` (ASCII) | The group name
 `Realname_utf` | `string` (UTF8) | Optional real name (full name) of the group, allow using any Unicode characters
 `Note_utf` | `string` (UTF8) | Optional, specify a description of the group
-`Recv.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Recv)
-`Recv.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Recv)
-`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast count (Recv)
-`Recv.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Recv)
-`Send.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Send)
-`Send.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Recv.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Recv)
+`Recv.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Recv)
+`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Recv)
+`Recv.UnicastCount_u64` | `number` (uint64) | Unicast count (Recv)
+`Send.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Send.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Send)
 `Send.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Send)
-`Send.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Send)
+`Send.UnicastCount_u64` | `number` (uint64) | Unicast count (Send)
 `UsePolicy_bool` | `boolean` | The flag whether to use security policy
 `policy:Access_bool` | `boolean` | Security policy: Allow Access. The users, which this policy value is true, have permission to make VPN connection to VPN Server.
 `policy:DHCPFilter_bool` | `boolean` | Security policy: Filter DHCP Packets (IPv4). All IPv4 DHCP packets in sessions defined this policy will be filtered.
@@ -4743,14 +4743,14 @@ Name | Type | Description
 `Name_str` | `string` (ASCII) | The group name
 `Realname_utf` | `string` (UTF8) | Optional real name (full name) of the group, allow using any Unicode characters
 `Note_utf` | `string` (UTF8) | Optional, specify a description of the group
-`Recv.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Recv)
-`Recv.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Recv)
-`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast count (Recv)
-`Recv.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Recv)
-`Send.BroadcastBytes_u64` | `number` (uint64) | Number of broadcast packets (Send)
-`Send.BroadcastCount_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Recv.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Recv)
+`Recv.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Recv)
+`Recv.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Recv)
+`Recv.UnicastCount_u64` | `number` (uint64) | Unicast count (Recv)
+`Send.BroadcastBytes_u64` | `number` (uint64) | Broadcast bytes (Send)
+`Send.BroadcastCount_u64` | `number` (uint64) | Number of broadcast packets (Send)
 `Send.UnicastBytes_u64` | `number` (uint64) | Unicast bytes (Send)
-`Send.UnicastCount_u64` | `number` (uint64) | Unicast bytes (Send)
+`Send.UnicastCount_u64` | `number` (uint64) | Unicast count (Send)
 `UsePolicy_bool` | `boolean` | The flag whether to use security policy
 `policy:Access_bool` | `boolean` | Security policy: Allow Access. The users, which this policy value is true, have permission to make VPN connection to VPN Server.
 `policy:DHCPFilter_bool` | `boolean` | Security policy: Filter DHCP Packets (IPv4). All IPv4 DHCP packets in sessions defined this policy will be filtered.


### PR DESCRIPTION
Fix the packet count and bytes descriptions being mismatched in the JSON-RPC documentation.
For example the description for `Recv.BroadcastBytes_u64` should be 'Broadcast bytes (Recv)' instead of 'Number of broadcast packets (Recv)' in the sections 'GetServerStatus', 'SetHubOnline', 'CreateUser', 'SetUser', 'GetUser', 'CreateGroup', 'SetGroup' and 'GetGroup'.