### PR TITLE
Cedar: DHCP server now assigns static IPv4 address, if present in user note

### DIFF
--- a/AUTHORS.TXT
+++ b/AUTHORS.TXT
@@ -112,6 +112,7 @@ CONTRIBUTORS:
   - NV <nvsofts@gmail.com>
   - Olimjon <olim98@bk.ru>
   - parly <https://github.com/parly>
+  - PeTeeR <tom2pet@gmail.com>
   - Quantum <quantum2048@gmail.com>
   - Quintin <quintin@last.za.net>
   - Raymond Tau <raymondtau@gmail.com>

--- a/src/Cedar/Account.c
+++ b/src/Cedar/Account.c
@@ -1318,3 +1318,40 @@ bool GetUserMacAddressFromUserNote(UCHAR *mac, wchar_t *note)
 
 	return ret;
 }
+
+// Get the static IPv4 address from the user's note string
+UINT GetUserIPv4AddressFromUserNote32(wchar_t *note)
+{
+	bool ret = false;
+	UINT ip32 = 0;
+
+	UINT i = UniSearchStrEx(note, USER_IPV4_STR_PREFIX, 0, false);
+	if (i != INFINITE)
+	{
+		wchar_t *ipv4str_start = &note[i + UniStrLen(USER_IPV4_STR_PREFIX)];
+		wchar_t ipv4str2[MAX_SIZE];
+		UNI_TOKEN_LIST *tokens;
+		
+		UniStrCpy(ipv4str2, sizeof(ipv4str2), ipv4str_start);
+		UniTrim(ipv4str2);
+
+		tokens = UniParseToken(ipv4str2, L" ,/()[]");
+		if (tokens != NULL)
+		{
+			if (tokens->NumTokens >= 1)
+			{
+				wchar_t *ipv4str = tokens->Token[0];
+				if (UniIsEmptyStr(ipv4str) == false)
+				{
+					char ipv4str_a[MAX_SIZE];
+					UniToStr(ipv4str_a, sizeof(ipv4str_a), ipv4str);
+					ip32 = StrToIP32(ipv4str_a);
+				}
+			}
+
+			UniFreeToken(tokens);
+		}
+	}
+
+	return ip32;
+}

--- a/src/Cedar/Account.h
+++ b/src/Cedar/Account.h
@@ -9,6 +9,7 @@
 #define	ACCOUNT_H
 
 #define	USER_MAC_STR_PREFIX		L"MAC:"
+#define	USER_IPV4_STR_PREFIX		L"IPv4:"
 
 // Policy item
 struct POLICY_ITEM
@@ -205,7 +206,6 @@ POLICY_ITEM *GetPolicyItem(UINT id);
 void GetPolicyValueRangeStr(wchar_t *str, UINT size, UINT id);
 void FormatPolicyValue(wchar_t *str, UINT size, UINT id, UINT value);
 bool GetUserMacAddressFromUserNote(UCHAR *mac, wchar_t *note);
+UINT GetUserIPv4AddressFromUserNote32(wchar_t *note);
 
 #endif	// ACCOUNT_H
-
-

--- a/src/Cedar/Session.c
+++ b/src/Cedar/Session.c
@@ -33,6 +33,8 @@ void SessionMain(SESSION *s)
 	SOCK *nicinfo_sock = NULL;
 	bool is_server_session = false;
 	bool lock_receive_blocks_queue = false;
+	UINT static_ip = 0;
+
 	// Validate arguments
 	if (s == NULL)
 	{
@@ -300,6 +302,13 @@ void SessionMain(SESSION *s)
 
 				if (b->Size >= 14)
 				{
+					UINT ip;
+					if( (ip = PrepareDHCPRequestForStaticIPv4( s, b )) != 0 )
+					{
+						// Remember the static IP address to remove it from the leased IP address list later
+						static_ip = ip;
+					}
+
 					if (b->Buf[0] & 0x01)
 					{
 						if (is_server_session == false)
@@ -602,6 +611,9 @@ CLEANUP:
 	{
 		// Update the user information
 		IncrementUserTraffic(s->Hub, s->UserNameReal, s);
+
+		// Clear the DHCP lease record if assigned as a static client IP address
+		ClearDHCPLeaseRecordForIPv4(s, static_ip);
 
 		DelSession(s->Hub, s);
 	}
@@ -2309,3 +2321,140 @@ void Notify(SESSION *s, UINT code)
 }
 
 
+UINT PrepareDHCPRequestForStaticIPv4(SESSION *s, BLOCK *b)
+{
+	PKT *pkt = NULL;
+	DHCPV4_HEADER *dhcp = NULL;
+	UCHAR *data = NULL;
+	UINT size = 0;
+	UINT dhcp_header_size = 0;
+	UINT dhcp_data_offset = 0;
+	UINT magic_cookie = Endian32(DHCP_MAGIC_COOKIE);
+	DHCP_OPTION_LIST *opt = NULL;
+	USER *user = NULL;
+	UINT ret_ip = 0;
+
+	if ((s->Username == NULL) || (StrLen(s->Username) == 0) || (StrCmpi(s->Username, SNAT_USER_NAME_PRINT) == 0) ||
+		(StrCmpi( s->Username, BRIDGE_USER_NAME_PRINT) == 0) || (StrCmpi(s->Username, LINK_USER_NAME_PRINT) == 0))
+	{
+		return ret_ip;
+	}
+
+	pkt = ParsePacket(b->Buf, b->Size);
+	if (pkt == NULL)
+	{
+		return ret_ip;
+	}
+
+	if (pkt->TypeL3 == L3_IPV4 && pkt->TypeL4 == L4_UDP && pkt->TypeL7 == L7_DHCPV4)
+	{
+		if (pkt->L7.DHCPv4Header->OpCode != 1)
+		{
+			goto CLEANUP_TP;
+		}
+
+		dhcp = pkt->L7.DHCPv4Header;
+		dhcp_header_size = sizeof(DHCPV4_HEADER);
+		dhcp_data_offset = (UINT)(((UCHAR *)pkt->L7.DHCPv4Header) - ((UCHAR *)pkt->MacHeader) + dhcp_header_size);
+		data = ((UCHAR *)dhcp) + dhcp_header_size;
+		size = pkt->PacketSize - dhcp_data_offset;
+
+		if (dhcp_header_size < 5)
+		{
+			goto CLEANUP_TP;
+		}
+
+		// Search for Magic Cookie
+		while (size >= 5)
+		{
+			if (Cmp(data, &magic_cookie, sizeof(magic_cookie)) == 0)
+			{
+				// Found
+				data += 4;
+				size -= 4;
+				opt = ParseDhcpOptionList(data, size);
+				break;
+			}
+
+			++data;
+			--size;
+		}
+
+		if (opt == NULL)
+		{
+			goto CLEANUP_TP;
+		}
+
+		if (opt->Opcode == DHCP_DISCOVER || opt->Opcode == DHCP_REQUEST)
+		{
+			if (s->Hub != NULL)
+			{
+				user = AcGetUser( s->Hub, s->Username );
+				if (user != NULL)
+				{
+					dhcp->ServerIP = GetUserIPv4AddressFromUserNote32(user->Note);
+					ReleaseUser(user);
+					if (s->Hub->SecureNAT != NULL && s->Hub->SecureNAT->Nat != NULL)
+					{
+						VH *v = s->Hub->SecureNAT->Nat->Virtual;
+						if (v != NULL && v->UseDhcp == true && v->DhcpLeaseList != NULL)
+						{
+							DHCP_LEASE *d = SearchDhcpLeaseByIp(v, dhcp->ServerIP);
+
+							// The given static IP address is not used - it's OK
+							if (d == NULL)
+							{
+								ret_ip = dhcp->ServerIP;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+CLEANUP_TP:
+	if (opt != NULL)
+	{
+		Free(opt);
+	}
+
+	if (pkt != NULL)
+	{
+		FreePacket(pkt);
+	}
+
+	return ret_ip;
+}
+
+void ClearDHCPLeaseRecordForIPv4(SESSION *s, UINT static_ip)
+{
+	if (s == NULL || static_ip == 0)
+	{
+		return;
+	}
+
+	if (s->Hub == NULL || s->Hub->SecureNAT == NULL || s->Hub->SecureNAT->Nat == NULL)
+	{
+		return;
+	}
+
+	VH *v = s->Hub->SecureNAT->Nat->Virtual;
+	if (v == NULL || v->DhcpLeaseList == NULL)
+	{
+		return;
+	}
+
+	DHCP_LEASE *d = SearchDhcpLeaseByIp(v, static_ip);
+	if (d == NULL)
+	{
+		return;
+	}
+
+	LockList(v->DhcpLeaseList);
+	{
+		FreeDhcpLease(d);
+		Delete(v->DhcpLeaseList, d);
+	}
+	UnlockList( v->DhcpLeaseList);
+}

--- a/src/Cedar/Session.h
+++ b/src/Cedar/Session.h
@@ -339,6 +339,9 @@ void CancelList(LIST *o);
 bool IsPriorityHighestPacketForQoS(void *data, UINT size);
 UINT GetNextDelayedPacketTickDiff(SESSION *s);
 
+UINT PrepareDHCPRequestForStaticIPv4(SESSION *s, BLOCK *b);
+void ClearDHCPLeaseRecordForIPv4(SESSION *s, UINT static_ip);
+
 #endif	// SESSION_H
 
 

--- a/src/Cedar/Virtual.h
+++ b/src/Cedar/Virtual.h
@@ -514,9 +514,11 @@ DHCP_LEASE *SearchDhcpPendingLeaseByMac(VH *v, UCHAR *mac);
 DHCP_LEASE *SearchDhcpLeaseByIp(VH *v, UINT ip);
 DHCP_LEASE *SearchDhcpPendingLeaseByIp(VH *v, UINT ip);
 UINT ServeDhcpDiscover(VH *v, UCHAR *mac, UINT request_ip);
+UINT ServeDhcpDiscoverEx(VH *v, UCHAR *mac, UINT request_ip, bool is_static_ip);
 UINT GetFreeDhcpIpAddress(VH *v);
 UINT GetFreeDhcpIpAddressByRandom(VH *v, UCHAR *mac);
 UINT ServeDhcpRequest(VH *v, UCHAR *mac, UINT request_ip);
+UINT ServeDhcpRequestEx(VH *v, UCHAR *mac, UINT request_ip, bool is_static_ip);
 void VirtualDhcpSend(VH *v, UINT tran_id, UINT dest_ip, UINT dest_port,
 					 UINT new_ip, UCHAR *client_mac, BUF *b, UINT hw_type, UINT hw_addr_size);
 void VLog(VH *v, char *str);
@@ -587,7 +589,4 @@ void NnDeleteOldestNatSessionIfNecessary(NATIVE_NAT *t, UINT ip, UINT protocol);
 
 void NnSetSecureNatTargetHostname(char *name);
 
-
 #endif	// VIRTUAL_H
-
-


### PR DESCRIPTION
Feature proposed in this pull request:
assigning a static IP address to the user by the internal DHCP server.
It is independent of the client software.
How it works:
A)  in the SessionMain() function: 
1) check incomming frames 
2) for DHCPDISCOVER and DHCPREQUEST frames, write down the static IP address 
   ( which is readed form user's note ) in the SIADDR field of the DHCPHEADER
3) process the modified frame like the others

B) in the VirtualDhcpServer() function:
- for the DHCPDISCOVER and DHCPREQUEST frames, read the static IP address 
  from the SIADDR field of the DHCPHEADER and treat it as the required IP address
