### PR TITLE
travis-ci: do not use aggressive LD_LIBRARY_PATH anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,8 @@ matrix:
         - |
           if [ ! -z ${COVERITY_SCAN_TOKEN+x} ]; then
             export OPENSSL_ROOT_DIR=${OPENSSL_INSTALL_DIR}
-            export LD_LIBRARY_PATH="${HOME}/opt/lib:${LD_LIBRARY_PATH:-}"
             export CFLAGS="-I${HOME}/opt/include"
-            export LDFLAGS="-L${HOME}/opt/lib"
-            echo "check_certificate = off" > ~/.wgetrc
+            export LDFLAGS="-L${HOME}/opt/lib -Wl,-rpath,${HOME}/opt/lib"
             curl -s "https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh" | bash || true
           fi
     - env: OPENSSL_VERSION="1.1.1c"
@@ -79,10 +77,8 @@ before_install:
 
 script:
   - export OPENSSL_ROOT_DIR=${OPENSSL_INSTALL_DIR}
-  - export LD_LIBRARY_PATH="${HOME}/opt/lib:${LD_LIBRARY_PATH:-}"
   - export CFLAGS="-I${HOME}/opt/include"
-  - export LDFLAGS="-L${HOME}/opt/lib"
-  - echo "check_certificate = off" > ~/.wgetrc
+  - export LDFLAGS="-L${HOME}/opt/lib -Wl,-rpath,${HOME}/opt/lib"
   - .ci/sonarcloud.sh
   - ./configure
   - make -j $(nproc || sysctl -n hw.ncpu || echo 4) -C build


### PR DESCRIPTION

rpath is more elegant way of linking libraries. maybe, we'll write a guide "how to install custom openssl and link against it"