### PR TITLE
Fixed setting change trigger of keepalive function

### DIFF
--- a/src/Cedar/Connection.c
+++ b/src/Cedar/Connection.c
@@ -337,7 +337,7 @@ WAIT_FOR_ENABLE:
 				{
 					if (StrCmpi(k->ServerName, server_name) != 0 ||
 						k->ServerPort != server_port || k->Enable == false ||
-						k->UdpMode)
+						k->UdpMode == false)
 					{
 						changed = true;
 					}


### PR DESCRIPTION
To solve the problem that the escape condition of the loop that tries name resolution in UDP mode was reversed in the keep-alive function of the Internet connection, so the name resolution retry is set to 250 msec interval instead of the normal 60 second interval.

