### PR TITLE
update Install requirements on macOS

### DIFF
--- a/src/BUILD_UNIX.md
+++ b/src/BUILD_UNIX.md
@@ -43,7 +43,7 @@ sudo apt -y install cmake gcc g++ libncurses5-dev libreadline-dev libssl-dev mak
 
 ## Install requirements on macOS
 ```bash
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew install cmake openssl readline
 ```
 


### PR DESCRIPTION
Ruby-based Homebrew installer is deprecated by original authors, and replaced Bash-based Installer.
(ref1: https://github.com/Homebrew/install/blob/master/README.md )
(ref2: https://github.com/Homebrew/install/commit/26806377779aedfddcb1f0cbdf1416e865b9750a#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5 )

note: /Homebrew/install/master/install also runs Bash-based installer now.