### PR TITLE
Cedar/Proto.c: fix crash in ProtoHandleConnection()

### DIFF
--- a/src/Cedar/Proto.c
+++ b/src/Cedar/Proto.c
@@ -510,7 +510,7 @@ bool ProtoHandleConnection(PROTO *proto, SOCK *sock, const char *protocol)
 				const PROTO_CONTAINER *tmp = LIST_DATA(proto->Containers, i);
 				if (StrCmp(tmp->Name, protocol) == 0)
 				{
-					impl = container->Impl;
+					container = tmp;
 					break;
 				}
 			}


### PR DESCRIPTION
The bug was introduced in #1177.