### PR TITLE
use SSL_SECOP_VERSION macro instead of OPENSSL_VERSION

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -5750,7 +5750,7 @@ SSL_PIPE *NewSslPipeEx(bool server_mode, X *x, K *k, DH_CTX *dh, bool verify_pee
 
 #if 0
 			// Cannot get config
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#ifdef SSL_SECOP_VERSION
 			if (sock->SslAcceptSettings.Override_Security_Level)
 			{
 				SSL_CTX_set_security_level(ssl_ctx, sock->SslAcceptSettings.Override_Security_Level_Value);


### PR DESCRIPTION
OPENSSL_VERSION is fragile in LibreSSL, BoringSSL.
security level manipulation is openssl specific defined in
https://github.com/openssl/openssl/commit/b362ccab5c1d52086f19d29a32f4acc11073b86b


