### PR TITLE
version.py: Fix CI failure on macOS by avoiding inline if statement

### DIFF
--- a/version.py
+++ b/version.py
@@ -5,7 +5,10 @@ def main():
 	parser.add_argument('-n', '--newline', action = 'store_true', help = 'Break line after printing version')
 	args = parser.parse_args()
 
-	end = None if args.newline else ''
+	if args.newline:
+		end = None
+	else:
+		end = ''
 
 	version = None
 	with open('CMakeLists.txt', 'r') as file:


### PR DESCRIPTION
```python
  File "version.py", line 25
    print(version, end = end)
                       ^
SyntaxError: invalid syntax
```