### PR TITLE
Azure Pipelines: Use "python3" instead of "python" on macOS, restore inline if statement in version.py

### DIFF
--- a/.ci/azure-pipelines/macos_build.sh
+++ b/.ci/azure-pipelines/macos_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ "${#SE_BUILD_NUMBER_TOKEN}" -eq 64 ]]; then
-	VERSION=$(python "version.py")
+	VERSION=$(python3 "version.py")
 	BUILD_NUMBER=$(curl "https://softether.network/get-build-number?commit=${BUILD_SOURCEVERSION}&version=${VERSION}&token=${SE_BUILD_NUMBER_TOKEN}")
 else
 	BUILD_NUMBER=0

--- a/version.py
+++ b/version.py
@@ -5,10 +5,7 @@ def main():
 	parser.add_argument('-n', '--newline', action = 'store_true', help = 'Break line after printing version')
 	args = parser.parse_args()
 
-	if args.newline:
-		end = None
-	else:
-		end = ''
+	end = None if args.newline else ''
 
 	version = None
 	with open('CMakeLists.txt', 'r') as file:


### PR DESCRIPTION
#1271 was not the solution, the error is the print statement itself.

Python 2 is probably used by default and thus `python` is an alias to it.