### PR TITLE
Link to Windows libraries in CMake project, remove related #pragma directives

### DIFF
--- a/src/Cedar/CMakeLists.txt
+++ b/src/Cedar/CMakeLists.txt
@@ -27,6 +27,7 @@ if(WIN32)
   )
 
   target_include_directories(cedar PRIVATE winpcap)
+  target_link_libraries(cedar PRIVATE comctl32.lib urlmon.lib)
 endif()
 
 if(UNIX)

--- a/src/Cedar/Win32Com.h
+++ b/src/Cedar/Win32Com.h
@@ -14,11 +14,6 @@
 
 #endif	// WIN32COM_CPP
 
-// For external function
-
-#pragma comment(lib,"htmlhelp.lib")
-#pragma comment(lib,"Urlmon.lib")
-
 #if	defined(__cplusplus)
 extern "C"
 {

--- a/src/Cedar/WinJumpList.cpp
+++ b/src/Cedar/WinJumpList.cpp
@@ -80,9 +80,6 @@ extern "C"
 	//#include <propvarutil.h>
 	//#include <knownfolders.h>
 	//#include <shlobj.h>
-	//
-	//#pragma comment(lib, "propsys.lib")
-	//#pragma comment(lib, "shlwapi.lib")
 
 	#define CREATE_PROPERTYKEY(l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8, pid) { { l, w1, w2, { b1, b2,  b3,  b4,  b5,  b6,  b7,  b8 } }, pid }
 

--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -27,6 +27,8 @@ if(WIN32)
     COMPILE_PDB_NAME "mayaqua"
     COMPILE_PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
   )
+
+  target_link_libraries(mayaqua PRIVATE setupapi.lib winmm.lib)
 endif()
 
 if(UNIX)

--- a/src/Mayaqua/Mayaqua.h
+++ b/src/Mayaqua/Mayaqua.h
@@ -484,26 +484,6 @@ void WriteProbe(char *filename, UINT line, char *str);
 void WriteProbeData(char *filename, UINT line, char *str, void *data, UINT size);
 USHORT CalcChecksum16(void *buf, UINT size);
 
-
-#ifdef	OS_WIN32
-// Import library (for Win32)
-#pragma comment(lib, "Ws2_32.lib")
-#pragma comment(lib, "winmm.lib")
-#pragma comment(lib, "kernel32.lib")
-#pragma comment(lib, "user32.lib")
-#pragma comment(lib, "gdi32.lib")
-#pragma comment(lib, "shell32.lib")
-#pragma comment(lib, "comctl32.lib")
-#pragma comment(lib, "dbghelp.lib")
-#pragma comment(lib, "Iphlpapi.lib")
-#pragma comment(lib, "setupapi.lib")
-#pragma comment(lib, "version.lib")
-#pragma comment(lib, "Netapi32.lib")
-#pragma comment(lib, "shlwapi.lib")
-#pragma comment(lib, "crypt32.lib")
-#pragma warning( disable : 4099 )
-#endif	// OS_WIN32
-
 // For Debugging
 #ifndef	ENCRYPT_C
 //#define	Disconnect(s)		{Debug("Disconnect() Called: %s %u\n", __FILE__, __LINE__);Disconnect(s);}
@@ -511,5 +491,3 @@ USHORT CalcChecksum16(void *buf, UINT size);
 
 
 #endif	// MAYAQUA_H
-
-

--- a/src/vpninstall/vpninstall.c
+++ b/src/vpninstall/vpninstall.c
@@ -26,8 +26,6 @@
 #include "vpninstall.h"
 #include "resource.h"
 
-#pragma comment(lib, "wininet.lib")
-
 static bool is_debug = true;
 static LIST *string_table = NULL;
 static VI_SETTING setting;

--- a/src/vpnweb/vpnwebdlg.c
+++ b/src/vpnweb/vpnwebdlg.c
@@ -33,8 +33,6 @@
 #include "vpnwebdlg_inner.h"
 #include "resource.h"
 
-#pragma comment(lib, "wininet.lib")
-
 static VPNWEBDLG_INIT data;
 static bool inited = false;
 static VW_TASK task;


### PR DESCRIPTION
In addition to making the code cleaner, this also prevents potential issues due to `#pragma` directives being in headers.