### PR TITLE
CMake: Fix regular expression for BLAKE2 SSE2 source files selection

### DIFF
--- a/src/Cedar/CMakeLists.txt
+++ b/src/Cedar/CMakeLists.txt
@@ -21,10 +21,11 @@ set_target_properties(cedar
 
 cmake_host_system_information(RESULT HAS_SSE2 QUERY HAS_SSE2)
 
-set(BLAKE2_SRC_PATH $<IF:$<BOOL:HAS_SSE2>,${TOP_DIRECTORY}/3rdparty/BLAKE2/sse,${TOP_DIRECTORY}/3rdparty/BLAKE2/ref>)
+set(BLAKE2_SRC_PATH $<IF:$<BOOL:${HAS_SSE2}>,${TOP_DIRECTORY}/3rdparty/BLAKE2/sse,${TOP_DIRECTORY}/3rdparty/BLAKE2/ref>)
+set(BLAKE2_SRC $<IF:$<BOOL:${HAS_SSE2}>,${BLAKE2_SRC_PATH}/blake2s.c,${BLAKE2_SRC_PATH}/blake2s-ref.c>)
 
 target_include_directories(cedar PUBLIC ${BLAKE2_SRC_PATH})
-target_sources(cedar PRIVATE "${BLAKE2_SRC_PATH}/blake2s.c")
+target_sources(cedar PRIVATE ${BLAKE2_SRC})
 
 if(VCPKG_TARGET_TRIPLET)
   find_package(unofficial-sodium CONFIG REQUIRED)


### PR DESCRIPTION
The comparison was being made against the variable's name instead of its value, causing the result to always be true.
For reference: https://cmake.org/cmake/help/v3.10/manual/cmake-generator-expressions.7.html#genex:BOOL

In addition to that, this commit also fixes the source file name of the non-SSE2 code.