### PR TITLE
Mayaqua: Fix UDP send error when used with reverse proxy

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -11226,7 +11226,7 @@ UINT SendToEx(SOCK *sock, IP *dest_addr, UINT dest_port, void *data, UINT size, 
 			Debug("SendTo Error; %u\n", e);
 		}
 #else	// OS_WIN32
-		if (errno == ECONNREFUSED || errno == ECONNRESET || errno == EMSGSIZE || errno == ENOBUFS || errno == ENOMEM || errno == EINTR)
+		if (errno == ECONNREFUSED || errno == ECONNRESET || errno == EMSGSIZE || errno == ENOBUFS || errno == ENOMEM || errno == EINTR || errno == EINVAL)
 		{
 			sock->IgnoreSendErr = true;
 		}


### PR DESCRIPTION
This bug was originally reported by crow31415 on VPN User Forum.
https://www.vpnusers.com/viewtopic.php?f=15&p=93014

### Description
```
Client (172.20.x.x) --- (Internet) --- Reverse proxy (port 443) --- (forwards to 127.0.0.1:5555) --- SE server (port 5555)
                                          |----------                    server                    -----------|
```
A reverse proxy (sslh) has been set up on the server for multiplexing.

From the server's point of view, the session is a local one (from 127.0.0.1 to 127.0.0.1). So it creates UDP socket at 127.0.0.1:40000. However, the client who is not aware of the reverse proxy puts its local IP (172.20.x.x) in the authentication message.

Later when the server tries to send UDP packets to that address (127.0.0.1 -> 172.20.x.x), SendToEx reports EINVAL (22) error, which is not captured by the if clause and causes the session to be forcibly disconnected.

### Environment

This bug has been confirmed on both stable build 9745 and developer build as of 2021/3/23. It only affects Unix platform (originally reported from CentOS 7, also confirmed on Debian 10).

### Suggestion

Ignore `EINVAL` error returned by `sendto`

### Debug output (build 9745)
```
Accepted.
Connection CID-1 Inserted to Cedar.
LOG: On the TCP Listener (Port 5555), a Client (IP address 127.0.0.1, Host name "localhost", Port number 53452) has connected.
ConnectionAccept()
LOG: For the client (IP address: 127.0.0.1, host name: "localhost", port number: 53452), connection "CID-1" has been created.
Accept()
StartSSL()
SSL connected with TLSv1.3
LOG: SSL communication for connection "CID-1" has been started. The encryption algorithm name is "TLS_AES_256_GCM_SHA384".
Downloading Signature...
Uploading Hello...
Auth...
Login...
Username = test, HubName = DEFAULT
use_udp_acceleration_client = 1
use_hmac_on_udp_acceleration = 1
LOG: [HUB "DEFAULT"] The connection "CID-1" (IP address: 127.0.0.1, Host name: localhost, Port number: 53452, Client name: "SoftEther VPN Client", Version: 4.34, Build: 9745) is attempting to connect to the Virtual Hub. The auth type provided is "Password authentication" and the user name is "test".
LOG: [HUB "DEFAULT"] Connection "CID-1": Successfully authenticated as user "test".
Connection CID-1 Deleted from Cedar.
Session SID-TEST-2 Inserted to DEFAULT.
UseUdpAcceleration = 1
UseHMacOnUdpAcceleration = 1
UdpAccelerationVersion = 0
Udp Accel My Port = 40000
UdpAccelInitServer: ver=2, client_ip=172.20.10.2, client_port=54612, server_cookie=2458817696, client_cookie=2654946928
L/OG: [HUB "DEFAULT"] Connection "CID-1": The new session "SID-TEST-2" has been created. (IP address: 127.0.0.1, Port number: 53452, Physical underlying protocol: "Standard TCP/IP (IPv4)")
LOG: [HUB "DEFAULT"] Session "SID-TEST-2": The parameter has been set. Max number of TCP connections: 4, Use of encryption: Yes, Use of compression: No, Use of Half duplex communication: No, Timeout: 20 seconds.
LOG: [HUB "DEFAULT"] Session "SID-TEST-2": VPN Client details: (Client product name: "SoftEther VPN Client", Client version: 434, Client build number: 9745, Server product name: "SoftEther VPN Server (64 bit) (Open Source)", Server version: 434, Server build number: 9745, Client OS name: "Windows 10", Client OS version: "Build 19042, Multiprocessor Free (19041.vb_release.191206-1406)", Client product ID: "--", Client host name: "DESKTOP-FFFFFFF", Client IP address: "172.20.10.2", Client port number: 61721, Server host name: "example.com", Server IP address: "100.1.1.1", Server port number: 443, Proxy host name: "", Proxy IP address: "0.0.0.0", Proxy port number: 0, Virtual Hub name: "DEFAULT", Client unique ID: "53E7BA8EC0CF49D987F5E606C14C7205")
SessionMain()
SessionMain: SID-TEST-2
NAT-T IP Address Resolved: xc.x4.servers.nat-traversal.softether-network.net. = 130.158.6.111
Error: SendTo: 172.20.10.2 54612 61  ←HERE
src/Cedar/UdpAccel.c: 606
src/Cedar/UdpAccel.c: 656
Session SID-TEST-2 Finishing...
Session SID-TEST-2 was Deleted from DEFAULT.
```

---
Changes proposed in this pull request:
 - Ignore EINVAL errors that occur in Linux when server is used with a reverse proxy

