### PR TITLE
Change IP structure so that IPv4 addresses are stored in RFC3493 format

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -5431,7 +5431,7 @@ UINT StGetSessionStatus(ADMIN *a, RPC_SESSION_STATUS *t)
 				t->ClientIp = IPToUINT(&s->Connection->ClientIp);
 				if (IsIP6(&s->Connection->ClientIp))
 				{
-					Copy(&t->ClientIp6, &s->Connection->ClientIp.ipv6_addr, sizeof(t->ClientIp6));
+					Copy(&t->ClientIp6, &s->Connection->ClientIp.address, sizeof(t->ClientIp6));
 				}
 
 				CopyIP(&t->ClientIpAddress, &s->Connection->ClientIp);
@@ -9200,7 +9200,7 @@ UINT StSetHub(ADMIN *a, RPC_CREATE_HUB *t)
 
 		if (Cmp(t->HashedPassword, hash2, SHA1_SIZE) == 0 || Cmp(t->SecurePassword, hash1, SHA1_SIZE) == 0)
 		{
-			if (a->ServerAdmin == false && a->Rpc->Sock->RemoteIP.addr[0] != 127)
+			if (a->ServerAdmin == false && IsLocalHostIP(&a->Rpc->Sock->RemoteIP) == false)
 			{
 				// Refuse to set a blank password to hub admin from remote host
 				ReleaseHub(h);
@@ -15370,7 +15370,7 @@ UINT AdminAccept(CONNECTION *c, PACK *p)
 
 	if (Cmp(secure_null_password, secure_password, SHA1_SIZE) == 0)
 	{
-		if (sock->RemoteIP.addr[0] != 127)
+		if (IsLocalHostIP(&sock->RemoteIP) == false)
 		{
 			// The client tried to use blank password for hub admin mode from remote
 			if (StrLen(hubname) != 0)

--- a/src/Cedar/CM.c
+++ b/src/Cedar/CM.c
@@ -10041,7 +10041,7 @@ bool CmIsEnabled(HWND hWnd, UINT id)
 		}
 	case CMD_SHORTCUT:
 		// Create a shortcut
-		if (cm->Client->Rpc->Sock->RemoteIP.addr[0] != 127)
+		if (IsLocalHostIP(&cm->Client->Rpc->Sock->RemoteIP) == false)
 		{
 			return false;
 		}

--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -1535,7 +1535,7 @@ void CnListenerProc(THREAD *thread, void *param)
 	AddRef(s->ref);
 	NoticeThreadInit(thread);
 
-	if (s->LocalIP.addr[0] == 127)
+	if (IsLocalHostIP(&s->LocalIP))
 	{
 		p = RecvPack(s);
 
@@ -5110,7 +5110,7 @@ void CiRpcAccepted(CLIENT *c, SOCK *s)
 		retcode = 1;
 	}
 
-	if (c->PasswordRemoteOnly && s->RemoteIP.addr[0] == 127)
+	if (c->PasswordRemoteOnly && IsLocalHostIP(&s->RemoteIP))
 	{
 		// If in a mode that requires a password only remote,
 		// the password sent from localhost is considered to be always correct
@@ -5123,7 +5123,7 @@ void CiRpcAccepted(CLIENT *c, SOCK *s)
 		{
 			// If the remote control is prohibited,
 			// identify whether this connection is from remote
-			if (s->RemoteIP.addr[0] != 127)
+			if (IsLocalHostIP(&s->RemoteIP) == false)
 			{
 				retcode = 2;
 			}

--- a/src/Cedar/EM.c
+++ b/src/Cedar/EM.c
@@ -1156,7 +1156,7 @@ void EMMain(RPC *r)
 
 		if (t.IsWinPcapNeeded)
 		{
-			if (r->Sock->RemoteIP.addr[0] != 127)
+			if (IsLocalHostIP(&r->Sock->RemoteIP) == false)
 			{
 				// WinPcap is required, but can not do anything because it is in remote management mode
 				MsgBox(NULL, MB_ICONINFORMATION, _UU("EM_WPCAP_REMOTE"));

--- a/src/Cedar/Hub.c
+++ b/src/Cedar/Hub.c
@@ -6752,11 +6752,13 @@ bool IsHubIpAddress(IP *ip)
 		return false;
 	}
 
-	if (ip->addr[0] == 172 && ip->addr[1] == 31)
+	const BYTE *ipv4 = IPV4(ip->address);
+
+	if (ipv4[0] == 172 && ipv4[1] == 31)
 	{
-		if (ip->addr[2] >= 1 && ip->addr[2] <= 254)
+		if (ipv4[2] >= 1 && ipv4[2] <= 254)
 		{
-			if (ip->addr[3] >= 1 && ip->addr[3] <= 254)
+			if (ipv4[3] >= 1 && ipv4[3] <= 254)
 			{
 				return true;
 			}
@@ -6810,11 +6812,7 @@ void GenHubIpAddress(IP *ip, char *name)
 
 	Sha0(hash, tmp2, StrLen(tmp2));
 
-	Zero(ip, sizeof(IP));
-	ip->addr[0] = 172;
-	ip->addr[1] = 31;
-	ip->addr[2] = hash[0] % 254 + 1;
-	ip->addr[3] = hash[1] % 254 + 1;
+	SetIP(ip, 172, 31, hash[0] % 254 + 1, hash[0] % 254 + 1);
 }
 
 // Generate a MAC address for the Virtual HUB

--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -425,14 +425,14 @@ IPC *NewIPC(CEDAR *cedar, char *client_name, char *postfix, char *hubname, char 
 	info.ServerIpAddress = IPToUINT(&s->RemoteIP);
 	info.ServerPort = Endian32(s->RemotePort);
 	StrCpy(info.HubName, sizeof(info.HubName), hubname);
-	Copy(info.UniqueId, unique, 16);
+	Copy(info.UniqueId, unique, sizeof(info.UniqueId));
 	if (IsIP6(&s->LocalIP))
 	{
-		Copy(info.ClientIpAddress6, s->LocalIP.ipv6_addr, 16);
+		Copy(info.ClientIpAddress6, s->LocalIP.address, sizeof(info.ClientIpAddress6));
 	}
 	if (IsIP6(&s->RemoteIP))
 	{
-		Copy(info.ServerIpAddress6, s->RemoteIP.ipv6_addr, 16);
+		Copy(info.ServerIpAddress6, s->RemoteIP.address, sizeof(info.ServerIpAddress6));
 	}
 	OutRpcNodeInfo(p, &info);
 
@@ -488,7 +488,16 @@ IPC *NewIPC(CEDAR *cedar, char *client_name, char *postfix, char *hubname, char 
 	{
 		UINTToIP(&ipc->DefaultGateway, hub->Option->DefaultGateway);
 		UINTToIP(&ipc->SubnetMask, hub->Option->DefaultSubnet);
+		GetBroadcastAddress4(&ipc->BroadcastAddress, &ipc->DefaultGateway, &ipc->SubnetMask);
 	}
+	else
+	{
+		ZeroIP4(&ipc->DefaultGateway);
+		ZeroIP4(&ipc->SubnetMask);
+		ZeroIP4(&ipc->BroadcastAddress);
+	}
+
+	ZeroIP4(&ipc->ClientIPAddress);
 
 	MacToStr(macstr, sizeof(macstr), ipc->MacAddress);
 
@@ -1401,23 +1410,23 @@ void IPCProcessL3EventsEx(IPC *ipc, UINT64 now)
 							{
 								ok = true;
 							}
-							else if (ip_dst.addr[0] == 255 && ip_dst.addr[1] == 255 &&
-							         ip_dst.addr[2] == 255 && ip_dst.addr[3] == 255)
-							{
-								ok = true;
-							}
-							else if (ip_dst.addr[0] >= 224 && ip_dst.addr[0] <= 239)
-							{
-								ok = true;
-							}
 							else
 							{
-								if (CmpIpAddr(&ipc->BroadcastAddress, &ip_dst) == 0)
+								const BYTE *ipv4 = IPV4(ip_dst.address);
+
+								if (ipv4[0] == 255 && ipv4[1] == 255 && ipv4[2] == 255 && ipv4[3] == 255)
 								{
 									ok = true;
 								}
-
-								if (IsZeroIP(&ipc->ClientIPAddress))
+								else if (ipv4[0] >= 224 && ipv4[1] <= 239)
+								{
+									ok = true;
+								}
+								else if (CmpIpAddr(&ipc->BroadcastAddress, &ip_dst) == 0)
+								{
+									ok = true;
+								}
+								else if (IsZeroIP(&ipc->ClientIPAddress))
 								{
 									// Client IP address is undetermined
 									ok = true;
@@ -1663,17 +1672,20 @@ void IPCSendIPv4(IPC *ipc, void *data, UINT size)
 		// Local Broadcast
 		is_broadcast = true;
 	}
-
-	if (ip_dst.addr[0] == 255 && ip_dst.addr[1] == 255 && ip_dst.addr[2] == 255 && ip_dst.addr[3] == 255)
+	else
 	{
-		// Global Broadcast
-		is_broadcast = true;
-	}
+		const BYTE *ipv4 = IPV4(ip_dst.address);
 
-	if (ip_dst.addr[0] >= 224 && ip_dst.addr[0] <= 239)
-	{
-		// IPv4 Multicast
-		is_broadcast = true;
+		if (ipv4[0] == 255 && ipv4[1] == 255 && ipv4[2] == 255 && ipv4[3] == 255)
+		{
+			// Global Broadcast
+			is_broadcast = true;
+		}
+		else if (ipv4[0] >= 224 && ipv4[0] <= 239)
+		{
+			// IPv4 Multicast
+			is_broadcast = true;
+		}
 	}
 
 	if (is_broadcast)
@@ -2204,10 +2216,10 @@ bool IPCIPv6CheckExistingLinkLocal(IPC *ipc, UINT64 eui)
 	t.Name = ipc->HubName;
 
 	// Construct link local from eui
-	ZeroIP6(&i.Ip);
-	i.Ip.ipv6_addr[0] = 0xFE;
-	i.Ip.ipv6_addr[1] = 0x80;
-	Copy(&i.Ip.ipv6_addr[8], &eui, sizeof(UINT64));
+	Zero(&i.Ip, sizeof(i.Ip));
+	i.Ip.address[0] = 0xfe;
+	i.Ip.address[1] = 0x80;
+	Copy(&i.Ip.address[8], &eui, sizeof(eui));
 
 	h = Search(ipc->Cedar->HubList, &t);
 
@@ -2235,7 +2247,7 @@ void IPCIPv6AddRouterPrefixes(IPC *ipc, ICMPV6_OPTION_LIST *recvPrefix, UCHAR *m
 			for (j = 0; j < LIST_NUM(ipc->IPv6RouterAdvs); j++)
 			{
 				IPC_IPV6_ROUTER_ADVERTISEMENT *existingRA = LIST_DATA(ipc->IPv6RouterAdvs, j);
-				if (Cmp(&recvPrefix->Prefix[i]->Prefix, &existingRA->RoutedPrefix.ipv6_addr, sizeof(IPV6_ADDR)) == 0)
+				if (Cmp(&recvPrefix->Prefix[i]->Prefix, &existingRA->RoutedPrefix.address, sizeof(IPV6_ADDR)) == 0)
 				{
 					foundPrefix = true;
 					break;
@@ -2321,7 +2333,7 @@ UINT64 IPCIPv6GetServerEui(IPC *ipc)
 		// Generate the MAC address from the multicast address
 		destMacAddress[0] = 0x33;
 		destMacAddress[1] = 0x33;
-		Copy(&destMacAddress[2], &destIP.ipv6_addr[12], sizeof(UINT));
+		Copy(&destMacAddress[2], &destIP.address[12], sizeof(UINT));
 
 		IPToIPv6Addr(&destV6, &destIP);
 
@@ -2355,7 +2367,7 @@ UINT64 IPCIPv6GetServerEui(IPC *ipc)
 	if (LIST_NUM(ipc->IPv6RouterAdvs) > 0)
 	{
 		IPC_IPV6_ROUTER_ADVERTISEMENT *ra = LIST_DATA(ipc->IPv6RouterAdvs, 0);
-		Copy(&ipc->IPv6ServerEUI, &ra->RouterAddress.ipv6_addr[8], sizeof(UINT64));
+		Copy(&ipc->IPv6ServerEUI, &ra->RouterAddress.address[8], sizeof(ipc->IPv6ServerEUI));
 	}
 
 	// If it is still not defined, let's just generate something random
@@ -2408,10 +2420,10 @@ void IPCIPv6Send(IPC *ipc, void *data, UINT size)
 		// Constructing multicast MAC address based on destination IP address, then just fire and forget
 		destMac[0] = 0x33;
 		destMac[1] = 0x33;
-		destMac[2] = destAddr.ipv6_addr[12];
-		destMac[3] = destAddr.ipv6_addr[13];
-		destMac[4] = destAddr.ipv6_addr[14];
-		destMac[5] = destAddr.ipv6_addr[15];
+		destMac[2] = destAddr.address[12];
+		destMac[3] = destAddr.address[13];
+		destMac[4] = destAddr.address[14];
+		destMac[5] = destAddr.address[15];
 		IPCIPv6SendWithDestMacAddr(ipc, data, size, destMac);
 		return;
 	}

--- a/src/Cedar/NativeStack.c
+++ b/src/Cedar/NativeStack.c
@@ -683,30 +683,26 @@ UINT GenerateDummyMark(PRAND *p)
 // Generate a dummy IP
 void GenerateDummyIp(PRAND *p, IP *ip)
 {
-	UINT i;
 	if (p == NULL || ip == NULL)
 	{
 		return;
 	}
 
-	Zero(ip, sizeof(IP));
+	ZeroIP4(ip);
+	BYTE *ipv4 = IPV4(ip->address);
 
-	for (i = 1;i < 4;i++)
+	for (BYTE i = 1; i < IPV4_SIZE; ++i)
 	{
-		UINT v = 0;
-		while (true)
+		BYTE v = 0;
+		while (v == 0 || v > 254)
 		{
 			v = PRandInt(p) % 256;
-			if (v >= 1 && v <= 254)
-			{
-				break;
-			}
 		}
 
-		ip->addr[i] = (UCHAR)v;
+		IPV4(ip->address)[i] = v;
 	}
 
-	ip->addr[0] = 127;
+	IPV4(ip->address)[0] = 127;
 }
 
 // Search an entry

--- a/src/Cedar/Proto.c
+++ b/src/Cedar/Proto.c
@@ -134,47 +134,21 @@ UINT ProtoSessionHash(void *p)
 	}
 
 	ip = &session->SrcIp;
-	if (IsIP6(ip))
+	for (BYTE i = 0; i < sizeof(ip->address); ++i)
 	{
-		UINT i;
-		for (i = 0; i < sizeof(ip->ipv6_addr); ++i)
-		{
-			ret += ip->ipv6_addr[i];
-		}
-
-		ret += ip->ipv6_scope_id;
-	}
-	else
-	{
-		UINT i;
-		for (i = 0; i < sizeof(ip->addr); ++i)
-		{
-			ret += ip->addr[i];
-		}
+		ret += ip->address[i];
 	}
 
+	ret += ip->ipv6_scope_id;
 	ret += session->SrcPort;
 
 	ip = &session->DstIp;
-	if (IsIP6(ip))
+	for (BYTE i = 0; i < sizeof(ip->address); ++i)
 	{
-		UINT i;
-		for (i = 0; i < sizeof(ip->ipv6_addr); ++i)
-		{
-			ret += ip->ipv6_addr[i];
-		}
-
-		ret += ip->ipv6_scope_id;
-	}
-	else
-	{
-		UINT i;
-		for (i = 0; i < sizeof(ip->addr); ++i)
-		{
-			ret += ip->addr[i];
-		}
+		ret += ip->address[i];
 	}
 
+	ret += ip->ipv6_scope_id;
 	ret += session->DstPort;
 
 	return ret;

--- a/src/Cedar/Proto_IKE.c
+++ b/src/Cedar/Proto_IKE.c
@@ -143,8 +143,8 @@ void IPsecSendPacketByIPsecSa(IKE_SERVER *ike, IPSECSA *sa, UCHAR *data, UINT da
 				h.PayloadLength = Endian16(data_size);
 				h.NextHeader = protocol_id;
 				h.HopLimit = 64;
-				Copy(h.SrcAddress.Value, c->TunnelModeServerIP.ipv6_addr, 16);
-				Copy(h.DestAddress.Value, c->TunnelModeClientIP.ipv6_addr, 16);
+				Copy(h.SrcAddress.Value, c->TunnelModeServerIP.address, sizeof(h.SrcAddress.Value));
+				Copy(h.DestAddress.Value, c->TunnelModeClientIP.address, sizeof(h.DestAddress.Value));
 
 				WriteBuf(b, &h, sizeof(IPV6_HEADER));
 
@@ -359,16 +359,16 @@ void IPsecSendUdpPacket(IKE_SERVER *ike, IKE_CLIENT *c, UINT src_port, UINT dst_
 	{
 		if (IsIPsecSaTunnelMode(c->CurrentIpSecSaSend) == false)
 		{
-			u->Checksum = CalcChecksumForIPv6((IPV6_ADDR *)c->TransportModeServerIP.ipv6_addr,
-				(IPV6_ADDR *)c->TransportModeClientIP.ipv6_addr,
+			u->Checksum = CalcChecksumForIPv6((IPV6_ADDR *)c->TransportModeServerIP.address,
+				(IPV6_ADDR *)c->TransportModeClientIP.address,
 				IP_PROTO_UDP,
 				u,
 				udp_size, 0);
 		}
 		else
 		{
-			u->Checksum = CalcChecksumForIPv6((IPV6_ADDR *)c->TunnelModeServerIP.ipv6_addr,
-				(IPV6_ADDR *)c->TunnelModeClientIP.ipv6_addr,
+			u->Checksum = CalcChecksumForIPv6((IPV6_ADDR *)c->TunnelModeServerIP.address,
+				(IPV6_ADDR *)c->TunnelModeClientIP.address,
 				IP_PROTO_UDP,
 				u,
 				udp_size, 0);
@@ -2907,12 +2907,12 @@ void ProcIkeAggressiveModePacketRecv(IKE_SERVER *ike, UDPPACKET *p, IKE_PACKET *
 								if (IsIP6(&sa->IkeClient->ServerIP))
 								{
 									// IPv6 address
-									my_id_payload = IkeNewIdPayload(IKE_ID_IPV6_ADDR, 0, 0, sa->IkeClient->ServerIP.ipv6_addr, 16);
+									my_id_payload = IkeNewIdPayload(IKE_ID_IPV6_ADDR, 0, 0, sa->IkeClient->ServerIP.address, 16);
 								}
 								else
 								{
 									// IPv4 address
-									my_id_payload = IkeNewIdPayload(IKE_ID_IPV4_ADDR, 0, 0, sa->IkeClient->ServerIP.addr, 4);
+									my_id_payload = IkeNewIdPayload(IKE_ID_IPV4_ADDR, 0, 0, IPV4(sa->IkeClient->ServerIP.address), IPV4_SIZE);
 								}
 
 								// Build the ID payload tentatively
@@ -3411,12 +3411,12 @@ void ProcIkeMainModePacketRecv(IKE_SERVER *ike, UDPPACKET *p, IKE_PACKET *header
 							if (IsIP6(&sa->IkeClient->ServerIP))
 							{
 								// IPv6 address
-								my_id_payload = IkeNewIdPayload(IKE_ID_IPV6_ADDR, 0, 0, sa->IkeClient->ServerIP.ipv6_addr, 16);
+								my_id_payload = IkeNewIdPayload(IKE_ID_IPV6_ADDR, 0, 0, sa->IkeClient->ServerIP.address, 16);
 							}
 							else
 							{
 								// IPv4 address
-								my_id_payload = IkeNewIdPayload(IKE_ID_IPV4_ADDR, 0, 0, sa->IkeClient->ServerIP.addr, 4);
+								my_id_payload = IkeNewIdPayload(IKE_ID_IPV4_ADDR, 0, 0, IPV4(sa->IkeClient->ServerIP.address), IPV4_SIZE);
 							}
 
 							// Build the ID payload tentatively
@@ -3687,11 +3687,11 @@ BUF *IkeCalcNatDetectHash(IKE_SERVER *ike, IKE_HASH *hash, UINT64 initiator_cook
 
 	if (IsIP6(ip))
 	{
-		WriteBuf(b, ip->ipv6_addr, sizeof(ip->ipv6_addr));
+		WriteBuf(b, ip->address, sizeof(ip->address));
 	}
 	else
 	{
-		WriteBuf(b, ip->addr, sizeof(ip->addr));
+		WriteBuf(b, IPV4(ip->address), IPV4_SIZE);
 	}
 
 	us = Endian16((USHORT)port);

--- a/src/Cedar/Proto_IkePacket.c
+++ b/src/Cedar/Proto_IkePacket.c
@@ -382,11 +382,11 @@ BUF *IkeBuildNatOaPayload(IKE_PACKET_NAT_OA_PAYLOAD *t)
 
 	if (IsIP6(&t->IpAddress))
 	{
-		WriteBuf(ret, t->IpAddress.ipv6_addr, 16);
+		WriteBuf(ret, t->IpAddress.address, sizeof(t->IpAddress.address));
 	}
 	else
 	{
-		WriteBuf(ret, t->IpAddress.addr, 4);
+		WriteBuf(ret, IPV4(t->IpAddress.address), IPV4_SIZE);
 	}
 
 	return ret;
@@ -1233,8 +1233,8 @@ bool IkeParseIdPayload(IKE_PACKET_ID_PAYLOAD *t, BUF *b)
 		return false;
 	}
 
-	Zero(&ip, sizeof(ip));
-	Zero(&subnet, sizeof(subnet));
+	ZeroIP4(&ip);
+	ZeroIP4(&subnet);
 
 	// Convert to string
 	Zero(t->StrData, sizeof(t->StrData));
@@ -1247,9 +1247,9 @@ bool IkeParseIdPayload(IKE_PACKET_ID_PAYLOAD *t, BUF *b)
 		break;
 
 	case IKE_ID_IPV4_ADDR:
-		if (t->IdData->Size == 4)
+		if (t->IdData->Size == IPV4_SIZE)
 		{
-			Copy(ip.addr, t->IdData->Buf, 4);
+			Copy(IPV4(ip.address), t->IdData->Buf, IPV4_SIZE);
 
 			IPToStr(t->StrData, sizeof(t->StrData), &ip);
 		}
@@ -1265,12 +1265,12 @@ bool IkeParseIdPayload(IKE_PACKET_ID_PAYLOAD *t, BUF *b)
 		break;
 
 	case IKE_ID_IPV4_ADDR_SUBNET:
-		if (t->IdData->Size == 8)
+		if (t->IdData->Size == IPV4_SIZE * 2)
 		{
 			char ipstr[MAX_SIZE];
 			char subnetstr[MAX_SIZE];
-			Copy(ip.addr, t->IdData->Buf, 4);
-			Copy(subnet.addr, ((UCHAR *)t->IdData->Buf) + 4, 4);
+			Copy(IPV4(ip.address), t->IdData->Buf, IPV4_SIZE);
+			Copy(IPV4(subnet.address), ((BYTE *)t->IdData->Buf) + IPV4_SIZE, IPV4_SIZE);
 
 			IPToStr(ipstr, sizeof(ipstr), &ip);
 			MaskToStr(subnetstr, sizeof(subnetstr), &subnet);

--- a/src/Cedar/Proto_OpenVPN.c
+++ b/src/Cedar/Proto_OpenVPN.c
@@ -2916,7 +2916,7 @@ int OvsCompareSessionList(void *p1, void *p2)
 		return 0;
 	}
 
-	i = CmpIpAddr(&s1->Protocol, &s2->Protocol);
+	i = Cmp(&s1->Protocol, &s2->Protocol, sizeof(s1->Protocol));
 	if (i != 0)
 	{
 		return i;

--- a/src/Cedar/Proto_Win7.c
+++ b/src/Cedar/Proto_Win7.c
@@ -155,12 +155,12 @@ void IPsecWin7UpdateHostIPAddressList(IPSEC_WIN7 *w)
 			if (IsIP4(ip))
 			{
 				a.IpVersion = 4;
-				Copy(a.IpAddress.IPv4Address, ip->addr, 4);
+				Copy(a.IpAddress.IPv4Address, IPV4(ip->address), sizeof(a.IpAddress.IPv4Address));
 			}
 			else
 			{
 				a.IpVersion = 6;
-				Copy(a.IpAddress.IPv6Address, ip->ipv6_addr, 16);
+				Copy(a.IpAddress.IPv6Address, ip->address, sizeof(a.IpAddress.IPv6Address));
 			}
 
 			WriteBuf(buf, &a, sizeof(WFP_LOCAL_IP));

--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -8267,7 +8267,7 @@ void SmBridgeDlg(HWND hWnd, SM_SERVER *s)
 
 	if (t.IsWinPcapNeeded)
 	{
-		if (s->Rpc->Sock->RemoteIP.addr[0] != 127)
+		if (IsLocalHostIP(&s->Rpc->Sock->RemoteIP) == false)
 		{
 			// WinPcap is required, but can not do anything because it is in remote control mode
 			MsgBox(hWnd, MB_ICONINFORMATION, _UU("SM_BRIDGE_WPCAP_REMOTE"));

--- a/src/Cedar/Virtual.c
+++ b/src/Cedar/Virtual.c
@@ -2255,15 +2255,14 @@ bool NnParseDnsResponsePacket(UCHAR *data, UINT size, IP *ret_ip)
 
 			if (r != NULL)
 			{
-				if (tp == 0x0001 && cl == 0x0001 && r->Size == 4)
+				if (tp == 0x0001 && cl == 0x0001 && r->Size == IPV4_SIZE)
 				{
 					ret = true;
 
 					if (ret_ip != NULL)
 					{
-						Zero(ret_ip, sizeof(IP));
-
-						Copy(ret_ip->addr, r->Buf, 4);
+						ZeroIP4(ret_ip);
+						Copy(IPV4(ret_ip->address), r->Buf, IPV4_SIZE);
 					}
 				}
 
@@ -3708,10 +3707,10 @@ bool ArpaToIP(IP *ip, char *str)
 	{
 		// Convert the token [0, 1, 2, 3] to IP
 		UINT i;
-		Zero(ip, sizeof(IP));
-		for (i = 0; i < 4; i++)
+		ZeroIP4(ip);
+		for (i = 0; i < IPV4_SIZE; ++i)
 		{
-			ip->addr[i] = (UCHAR)ToInt(token->Token[3 - i]);
+			IPV4(ip->address)[i] = (UCHAR)ToInt(token->Token[3 - i]);
 		}
 		ret = true;
 	}
@@ -5536,7 +5535,7 @@ void VirtualTcpReceived(VH *v, UINT src_ip, UINT dest_ip, void *data, UINT size,
 	}
 	UINTToIP(&ip1, src_ip);
 	UINTToIP(&ip2, dest_ip);
-	if (ip1.addr[0] == 127 || ip2.addr[0] == 127)
+	if (IsLocalHostIP4(&ip1) || IsLocalHostIP4(&ip2))
 	{
 		// Loopback IP address can not be specified
 		return;

--- a/src/Cedar/WinUi.c
+++ b/src/Cedar/WinUi.c
@@ -1207,7 +1207,7 @@ void NicInfoRefresh(HWND hWnd, UI_NICINFO *info)
 		{
 			Copy(&ip, &a->IpAddresses[i], sizeof(IP));
 
-			if (!(ip.addr[0] == 169 && ip.addr[1] == 254))
+			if (!(IPV4(ip.address)[0] == 169 && IPV4(ip.address)[1] == 254))
 			{
 				has_ip = true;
 			}

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -85,16 +85,18 @@ struct DYN_VALUE
 // IP address
 struct IP
 {
-	UCHAR addr[4];					// IPv4 address, (meaning that 192.0.2.254 = IPv6)
-	UCHAR ipv6_addr[16];			// IPv6 address
-	UINT ipv6_scope_id;				// IPv6 scope ID
+	BYTE address[16];   // IP address (RFC 3493 format used for IPv4)
+	UINT ipv6_scope_id; // IPv6 scope ID
 };
 
-// Size when comparing the IP structures only in the address part
-#define	SIZE_OF_IP_FOR_ADDR			(sizeof(UCHAR) * 20)
+// Pointer to the beginning of the IPv4 address
+#define	IPV4(address)				(&address[12])
+#define	IPV4_SIZE					(4)
 
-// Compare the IP address part
-#define	CmpIpAddr(ip1, ip2)			(Cmp((ip1), (ip2), SIZE_OF_IP_FOR_ADDR))
+#define	CmpIpAddr(ip1, ip2)			(Cmp((ip1)->address, (ip2)->address, sizeof((ip1)->address)))
+
+#define	IsIP6(ip)					(IsIP4(ip) == false)
+#define	IsZeroIp(ip)				(IsZeroIP(ip))
 
 // IPv6 address (different format)
 struct IPV6_ADDR
@@ -1084,7 +1086,6 @@ bool StrToIP(IP *ip, char *str);
 UINT StrToIP32(char *str);
 UINT UniStrToIP32(wchar_t *str);
 void IPToStr(char *str, UINT size, IP *ip);
-void IPToStr4(char *str, UINT size, IP *ip);
 void IPToStr32(char *str, UINT size, UINT ip);
 void IPToStr4or6(char *str, UINT size, UINT ip_4_uint, UCHAR *ip_6_bytes);
 void IPToUniStr(wchar_t *str, UINT size, IP *ip);
@@ -1223,7 +1224,6 @@ bool IsNetworkAddress4(IP *ip, IP *mask);
 bool IsNetworkAddress32(UINT ip, UINT mask);
 bool IsHostIPAddress4(IP *ip);
 bool IsHostIPAddress32(UINT ip);
-bool IsZeroIp(IP *ip);
 bool IsZeroIP(IP *ip);
 bool IsZeroIP6Addr(IPV6_ADDR *addr);
 UINT IntToSubnetMask32(UINT i);
@@ -1270,7 +1270,6 @@ SOCKET_TIMEOUT_PARAM *NewSocketTimeout(SOCK *sock);
 void FreeSocketTimeout(SOCKET_TIMEOUT_PARAM *ttp);
 
 void CopyIP(IP *dst, IP *src);
-bool IsIP6(IP *ip);
 bool IsIP4(IP *ip);
 void IPv6AddrToIP(IP *ip, IPV6_ADDR *addr);
 bool IPToIPv6Addr(IPV6_ADDR *addr, IP *ip);
@@ -1280,7 +1279,6 @@ void GetLocalHostIP4(IP *ip);
 bool IsLocalHostIP6(IP *ip);
 bool IsLocalHostIP4(IP *ip);
 bool IsLocalHostIP(IP *ip);
-void ZeroIP6(IP *ip);
 void ZeroIP4(IP *ip);
 bool CheckIPItemStr6(char *str);
 void IPItemStrToChars6(UCHAR *chars, char *str);

--- a/src/Mayaqua/Pack.c
+++ b/src/Mayaqua/Pack.c
@@ -1183,7 +1183,6 @@ void PackAddIpEx(PACK *p, char *name, IP *ip, UINT index, UINT total)
 void PackAddIpEx2(PACK *p, char *name, IP *ip, UINT index, UINT total, bool is_single)
 {
 	UINT i;
-	bool b = false;
 	char tmp[MAX_PATH];
 	ELEMENT *e;
 	// Validate arguments
@@ -1196,44 +1195,20 @@ void PackAddIpEx2(PACK *p, char *name, IP *ip, UINT index, UINT total, bool is_s
 		is_single = false;
 	}
 
-	b = IsIP6(ip);
-
 	Format(tmp, sizeof(tmp), "%s@ipv6_bool", name);
-	e = PackAddBoolEx(p, tmp, b, index, total);
+	e = PackAddBoolEx(p, tmp, IsIP6(ip), index, total);
 	if (e != NULL && is_single) e->JsonHint_IsArray = false;
 	if (e != NULL) e->JsonHint_IsIP = true;
 
 	Format(tmp, sizeof(tmp), "%s@ipv6_array", name);
-	if (b)
-	{
-		e = PackAddDataEx(p, tmp, ip->ipv6_addr, sizeof(ip->ipv6_addr), index, total);
-		if (e != NULL && is_single) e->JsonHint_IsArray = false;
-		if (e != NULL) e->JsonHint_IsIP = true;
-	}
-	else
-	{
-		UCHAR dummy[16];
-
-		Zero(dummy, sizeof(dummy));
-
-		e = PackAddDataEx(p, tmp, dummy, sizeof(dummy), index, total);
-		if (e != NULL && is_single) e->JsonHint_IsArray = false;
-		if (e != NULL) e->JsonHint_IsIP = true;
-	}
+	e = PackAddDataEx(p, tmp, ip->address, sizeof(ip->address), index, total);
+	if (e != NULL && is_single) e->JsonHint_IsArray = false;
+	if (e != NULL) e->JsonHint_IsIP = true;
 
 	Format(tmp, sizeof(tmp), "%s@ipv6_scope_id", name);
-	if (b)
-	{
-		e = PackAddIntEx(p, tmp, ip->ipv6_scope_id, index, total);
-		if (e != NULL && is_single) e->JsonHint_IsArray = false;
-		if (e != NULL) e->JsonHint_IsIP = true;
-	}
-	else
-	{
-		e = PackAddIntEx(p, tmp, 0, index, total);
-		if (e != NULL && is_single) e->JsonHint_IsArray = false;
-		if (e != NULL) e->JsonHint_IsIP = true;
-	}
+	e = PackAddIntEx(p, tmp, ip->ipv6_scope_id, index, total);
+	if (e != NULL && is_single) e->JsonHint_IsArray = false;
+	if (e != NULL) e->JsonHint_IsIP = true;
 
 	i = IPToUINT(ip);
 

--- a/src/Mayaqua/Proxy.c
+++ b/src/Mayaqua/Proxy.c
@@ -384,27 +384,27 @@ UINT ProxySocks5Connect(PROXY_PARAM_OUT *out, PROXY_PARAM_IN *in, volatile bool 
 	StrToIP(&target_ip, in->TargetHostname);
 
 	// If the IP structure doesn't contain an IP address, the string should be an hostname
-	if (IsZeroIp(&target_ip))
+	if (IsZeroIP(&target_ip))
 	{
 		UCHAR dest_length = StrLen(in->TargetHostname);
 		tmp = 3;
-		WriteBuf(b, &tmp, sizeof(tmp));										// Destination type (hostname)
-		WriteBuf(b, &dest_length, sizeof(dest_length));						// Destination hostname length
-		WriteBuf(b, in->TargetHostname, dest_length);						// Destination hostname
+		WriteBuf(b, &tmp, sizeof(tmp));									// Destination type (hostname)
+		WriteBuf(b, &dest_length, sizeof(dest_length));					// Destination hostname length
+		WriteBuf(b, in->TargetHostname, dest_length);					// Destination hostname
 	}
 	else
 	{
 		if (IsIP6(&target_ip))
 		{
 			tmp = 4;
-			WriteBuf(b, &tmp, sizeof(tmp));									// Destination type (IPv6)
-			WriteBuf(b, target_ip.ipv6_addr, sizeof(target_ip.ipv6_addr));	// Destination IPv6 address
+			WriteBuf(b, &tmp, sizeof(tmp));								// Destination type (IPv6)
+			WriteBuf(b, target_ip.address, sizeof(target_ip.address));	// Destination IPv6 address
 		}
 		else
 		{
 			tmp = 1;
-			WriteBuf(b, &tmp, sizeof(tmp));									// Destination type (IPv4)
-			WriteBuf(b, target_ip.addr, sizeof(target_ip.addr));			// Destination IPv4 address
+			WriteBuf(b, &tmp, sizeof(tmp));								// Destination type (IPv4)
+			WriteBuf(b, IPV4(target_ip.address), IPV4_SIZE);			// Destination IPv4 address
 		}
 	}
 
@@ -573,7 +573,7 @@ UINT ProxySocks4Connect(PROXY_PARAM_OUT *out, PROXY_PARAM_IN *in, volatile bool 
 	WriteBuf(b, &tmp, sizeof(tmp));
 	target_port = Endian16(in->TargetPort);
 	WriteBuf(b, &target_port, sizeof(target_port));
-	WriteBuf(b, target_ip.addr, sizeof(target_ip.addr));
+	WriteBuf(b, IPV4(target_ip.address), IPV4_SIZE);
 	WriteBuf(b, in->Username, StrLen(in->Username) + 1);
 
 	ret = SendAll(s, b->Buf, b->Size, false);

--- a/src/Mayaqua/TcpIp.c
+++ b/src/Mayaqua/TcpIp.c
@@ -3861,7 +3861,7 @@ void DhcpParseClasslessRouteData(DHCP_CLASSLESS_ROUTE_TABLE *t, void *data, UINT
 		UCHAR c;
 		UINT subnet_mask_len;
 		UINT data_len;
-		UCHAR tmp[4];
+		BYTE tmp[IPV4_SIZE];
 		IP ip;
 		IP mask;
 		IP gateway;
@@ -3889,8 +3889,8 @@ void DhcpParseClasslessRouteData(DHCP_CLASSLESS_ROUTE_TABLE *t, void *data, UINT
 		}
 
 		// IP address body
-		Zero(&ip, sizeof(IP));
-		Copy(ip.addr, tmp, data_len);
+		ZeroIP4(&ip);
+		Copy(IPV4(ip.address), tmp, sizeof(tmp));
 
 		Zero(&mask, sizeof(mask));
 		IntToSubnetMask4(&mask, subnet_mask_len);


### PR DESCRIPTION
In addition to saving 4 bytes for each instantiation, this change makes IP-related operations faster and clearer.

https://tools.ietf.org/html/rfc3493.html#section-3.7