### PR TITLE
CI: AppVeyor: explicitly install liblz4-dev

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ build_script:
   - .ci/memory-leak-test.sh
 test_script:
   - .ci/appveyor-deb-install-test.sh
-  - sudo apt-get update && sudo apt-get -y install autoconf libtool liblzo2-dev libpam-dev fping unzip # openvpn build deps
+  - sudo apt-get update && sudo apt-get -y install autoconf libtool liblzo2-dev libpam-dev fping unzip liblz4-dev # openvpn build deps
   - sudo .ci/start-se-openvpn.sh
   - sudo .ci/run-openvpn-tests.sh
 


### PR DESCRIPTION
since https://github.com/OpenVPN/openvpn/commit/24596b258aa3a9c0bd79e7e7bd4753c48a435408
bundled lz4 was removed. openvpn (used for live tests) now relies on system
lz4 lib.