### PR TITLE
CI: Azure Pipelines: explicitly install liblz4-dev

### DIFF
--- a/.ci/azure-pipelines/linux.yml
+++ b/.ci/azure-pipelines/linux.yml
@@ -3,7 +3,7 @@ jobs:
   pool:
     vmImage: ubuntu-18.04
   steps:
-  - script: sudo apt update && sudo apt-get -y install cmake gcc g++ ninja-build libncurses5-dev libreadline-dev libsodium-dev libssl-dev make zlib1g-dev
+  - script: sudo apt update && sudo apt-get -y install cmake gcc g++ ninja-build libncurses5-dev libreadline-dev libsodium-dev libssl-dev make zlib1g-dev liblz4-dev
     displayName: 'Prepare environment'
   - script: "$(Build.SourcesDirectory)/.ci/azure-pipelines/linux_build.sh"
     env:


### PR DESCRIPTION
since https://github.com/OpenVPN/openvpn/commit/24596b258aa3a9c0bd79e7e7bd4753c48a435408
bundled lz4 was removed. openvpn (used for live tests) now relies on system lz4 lib.

