### PR TITLE
Mayaqua/Network: Skip IPv6 nameservers for SecureNAT

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -8037,7 +8037,7 @@ bool UnixGetDefaultDns(IP *ip)
 					if (StrCmpi(t->Token[0], "nameserver") == 0)
 					{
 						StrToIP(ip, t->Token[1]);
-						f = true;
+						f = IsIP4(ip);
 					}
 				}
 				FreeToken(t);


### PR DESCRIPTION
SecureNAT is IPv4 only however it gets the default DNS server from the first nameserver in `resolv.conf` which might not always be IPv4.

For example, Vultr hosts have IPv6 DNS before IPv4 in the file, causing DNS lookup to fail.
```
root@vultr:~/SoftEtherVPN/build# cat /etc/resolv.conf
# Dynamic resolv.conf(5) file for glibc resolver(3) generated by resolvconf(8)
#     DO NOT EDIT THIS FILE BY HAND -- YOUR CHANGES WILL BE OVERWRITTEN
nameserver 2001:19f0:300:1704::6
nameserver 108.61.10.10
```

`GetDefaultDns()` is only used in SecureNAT so the change should be safe.

---

﻿Changes proposed in this pull request:
 - Skip IPv6 nameservers in resolv.conf for SecureNAT

