### PR TITLE
Fix compile errors on OpenBSD

### DIFF
--- a/src/Cedar/BridgeUnix.c
+++ b/src/Cedar/BridgeUnix.c
@@ -25,10 +25,13 @@
 #include <errno.h>
 #include <fcntl.h>
 
-#include <net/ethernet.h>
 #include <net/if.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+
+#ifndef UNIX_OPENBSD
+#include <net/ethernet.h>
+#endif
 
 #ifdef UNIX_SOLARIS
 #include <sys/sockio.h>

--- a/src/Mayaqua/DNS.c
+++ b/src/Mayaqua/DNS.c
@@ -13,6 +13,14 @@
 #include <sys/socket.h>
 #endif
 
+#ifndef AI_ALL
+#define AI_ALL 0
+#endif
+
+#ifndef AI_V4MAPPED
+#define AI_V4MAPPED 0
+#endif
+
 static bool cache_enabled;
 
 static LIST *cache;

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -13,6 +13,10 @@
 
 #ifdef OS_UNIX
 #include <netinet/in.h>
+
+#ifdef UNIX_OPENBSD
+#include <pthread.h>
+#endif
 #endif
 
 // Dynamic Value


### PR DESCRIPTION
- `<pthread.h>` included for the `pthread_t` type definition.
- `<net/ethernet.h>` include removed as the header doesn't exist.
- `AI_ALL` and `AI_V4MAPPED` defined to 0 as the options don't exist.
