### PR TITLE
Fix IPv6 Neighbor Discovery for PPP based protocols

### DIFF
--- a/src/Cedar/Hub.c
+++ b/src/Cedar/Hub.c
@@ -1633,7 +1633,7 @@ void HubWatchDogThread(THREAD *t, void *param)
 								{
 									buf = BuildICMPv6NeighborSoliciation(&hub->HubIpV6,
 										&ip6addr,
-										hub->HubMacAddr, ++hub->HubIP6Id);
+										hub->HubMacAddr, ++hub->HubIP6Id, false);
 
 									if (buf != NULL)
 									{

--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -2109,13 +2109,12 @@ void IPCIPv6AssociateOnNDTEx(IPC *ipc, IP *ip, UCHAR *mac_address, bool isNeighb
 
 	addrType = GetIPAddrType6(ip);
 
-	if (addrType != IPV6_ADDR_LOCAL_UNICAST &&
-	        addrType != IPV6_ADDR_GLOBAL_UNICAST)
+	if (!(addrType & IPV6_ADDR_UNICAST))
 	{
 		return;
 	}
 
-	if (addrType == IPV6_ADDR_GLOBAL_UNICAST)
+	if (addrType & IPV6_ADDR_GLOBAL_UNICAST)
 	{
 		if (!IPCIPv6CheckUnicastFromRouterPrefix(ipc, ip, NULL))
 		{
@@ -2617,23 +2616,16 @@ void IPCIPv6SendUnicast(IPC *ipc, void *data, UINT size, IP *next_ip)
 			// Generate the MAC address from the multicast address
 			BUF *neighborSolicit;
 			UCHAR destMacAddress[6];
-			IPV6_ADDR solicitAddress;
 
 			char tmp[MAX_SIZE];
 			UCHAR *copy;
 			BLOCK *blk;
 
-			Zero(&solicitAddress, sizeof(IPV6_ADDR));
-			Copy(&solicitAddress.Value[13], &header->DestAddress.Value[13], 3);
-			solicitAddress.Value[0] = 0xFF;
-			solicitAddress.Value[1] = 0x02;
-			solicitAddress.Value[11] = 0x01;
-			solicitAddress.Value[12] = 0xFF;
-
-			neighborSolicit = BuildICMPv6NeighborSoliciation(&header->SrcAddress, &solicitAddress, ipc->MacAddress, 0);
+			neighborSolicit = BuildICMPv6NeighborSoliciation(&header->SrcAddress, &header->DestAddress, ipc->MacAddress, 0, true);
 			destMacAddress[0] = 0x33;
 			destMacAddress[1] = 0x33;
-			Copy(&destMacAddress[2], &solicitAddress.Value[12], sizeof(UINT));
+			destMacAddress[2] = 0xFF;
+			Copy(&destMacAddress[3], &header->DestAddress.Value[13], 3);
 			IPCIPv6SendWithDestMacAddr(ipc, neighborSolicit->Buf, neighborSolicit->Size, destMacAddress);
 
 			FreeBuf(neighborSolicit);

--- a/src/Mayaqua/TcpIp.h
+++ b/src/Mayaqua/TcpIp.h
@@ -792,7 +792,7 @@ BUF *BuildIPv6(IPV6_ADDR *dest_ip, IPV6_ADDR *src_ip, UINT id, UCHAR protocol, U
 BUF *BuildIPv6PacketHeader(IPV6_HEADER_PACKET_INFO *info, UINT *bytes_before_payload);
 UCHAR IPv6GetNextHeaderFromQueue(QUEUE *q);
 void BuildAndAddIPv6PacketOptionHeader(BUF *b, IPV6_OPTION_HEADER *opt, UCHAR next_header, UINT size);
-BUF *BuildICMPv6NeighborSoliciation(IPV6_ADDR *src_ip, IPV6_ADDR *target_ip, UCHAR *my_mac_address, UINT id);
+BUF *BuildICMPv6NeighborSoliciation(IPV6_ADDR *src_ip, IPV6_ADDR *target_ip, UCHAR *my_mac_address, UINT id, bool use_multicast);
 BUF *BuildICMPv6RouterSoliciation(IPV6_ADDR *src_ip, IPV6_ADDR *target_ip, UCHAR *my_mac_address, UINT id);
 BUF *BuildICMPv6(IPV6_ADDR *src_ip, IPV6_ADDR *dest_ip, UCHAR hop_limit, UCHAR type, UCHAR code, void *data, UINT size, UINT id);
 


### PR DESCRIPTION
IPv6 Neighbor Discovery (IPv6s equivalent to IPv4s ARP) currently isn't working for the PPP based protocols L2TP/IPsec and SSTP. Thus, clients connecting with one of these protocols are unable to communicate with other machines in their LAN over IPv6. (Routed IPv6 connections work fine, because the routers MAC address comes from Router Advertisements and is not affected by this bug.)

Changes proposed in this pull request:
 - Fix IPv6 Neighbor Discovery as described in #1250