### PR TITLE
Mayaqua/Network.c: Fix EAP-TLS chain certificate verification

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -5670,7 +5670,7 @@ int SslCertVerifyCallback(int preverify_ok, X509_STORE_CTX *ctx)
 			StrCpy(clientcert->PreverifyErrMessage, PREVERIFY_ERR_MESSAGE_SIZE, (char *)msg);
 			Debug("SslCertVerifyCallback preverify error: '%s'\n", msg);
 		}
-		else
+		else if (X509_STORE_CTX_get_error_depth(ctx) == 0)
 		{
 			cert = X509_STORE_CTX_get0_cert(ctx);
 			if (cert != NULL)
@@ -5736,6 +5736,13 @@ SSL_PIPE *NewSslPipeEx(bool server_mode, X *x, K *k, DH_CTX *dh, bool verify_pee
 		if (verify_peer)
 		{
 			SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, SslCertVerifyCallback);
+
+			if (server_mode)
+			{
+				// Allow incomplete client trust chain
+				X509_VERIFY_PARAM *vpm = SSL_CTX_get0_param(ssl_ctx);
+				X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_PARTIAL_CHAIN);
+			}
 		}
 
 		if (dh != NULL)
@@ -11610,16 +11617,7 @@ bool AddChainSslCert(struct ssl_ctx_st *ctx, X *x)
 
 	if (x_copy != NULL)
 	{
-		if (x_copy->root_cert)
-		{
-			X509_STORE *store = SSL_CTX_get_cert_store(ctx);
-			X509_STORE_add_cert(store, x_copy->x509);
-			X509_free(x_copy->x509);
-		}
-		else
-		{
-			SSL_CTX_add_extra_chain_cert(ctx, x_copy->x509);
-		}
+		SSL_CTX_add_extra_chain_cert(ctx, x_copy->x509);
 		x_copy->do_not_free = true;
 
 		ret = true;


### PR DESCRIPTION
As @Evengard said in #1109, for client certificates with CAs other than the server CA to work, one must manually add them to `chain_certs`.
Since `chain_certs` is supposed to contain server's trust chain, it doesn't make sense to put client CAs there. This approach is just a hack and may confuse many users.

Without the hack, server can't get client certificate from EAP-TLS process to continue its internal authentication. So I digged a little bit to understand why.

It turns out that only in TLS verification callbacks with `preverify_ok` being true we save the client certificate. 
Without trusting client CA beforehand, `preverify_ok` is never true and client certificate is never saved.

Since the callback is a pass-through which does not perform actual verification, I changed it to save client certificate as long as it's the leaf one (depth is 0). 
Now the hack is no longer needed and the function of `chain_certs` is reverted to storing server trust chain only.

---

﻿Changes proposed in this pull request:
 - Remove the hack that requires SSTP users doing certificate authentication to put client CAs in chain_certs

