### PR TITLE
Use "%S" instead of "%s" for LA_SET_PORTS_UDP and LA_SET_PROTO_OPTIONS

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -10077,8 +10077,7 @@ UINT StSetPortsUDP(ADMIN *a, RPC_PORTS *t)
 
 	LockList(server_ports);
 	{
-		char tmp[MAX_SIZE];
-		wchar_t str[MAX_SIZE];
+		char str[MAX_SIZE];
 
 		for (i = 0; i < LIST_NUM(server_ports); ++i)
 		{
@@ -10094,8 +10093,7 @@ UINT StSetPortsUDP(ADMIN *a, RPC_PORTS *t)
 
 		ProtoSetUdpPorts(a->Server->Proto, server_ports);
 
-		IntListToStr(tmp, sizeof(tmp), server_ports, ", ");
-		StrToUni(str, sizeof(str), tmp);
+		IntListToStr(str, sizeof(str), server_ports, ", ");
 		ALog(a, NULL, "LA_SET_PORTS_UDP", str);
 	}
 	UnlockList(server_ports);

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -2018,8 +2018,8 @@ LA_CREATE_LISTENER			已建立新 TCP 监听器 (端口号 %u)。
 LA_DELETE_LISTENER			已删除 TCP 监听器 (端口号 %u)。
 LA_ENABLE_LISTENER			已启用 TCP 监听器 (端口号 %u)。
 LA_DISABLE_LISTENER			已禁用 TCP 监听器 (端口号 %u)。
-LA_SET_PORTS_UDP			UDP ports have been set: %s.
-LA_SET_PROTO_OPTIONS		%s options have been set.
+LA_SET_PORTS_UDP			UDP ports have been set: %S.
+LA_SET_PROTO_OPTIONS		%S options have been set.
 LA_SET_SERVER_PASSWORD		服务端管理员密码设置完成。
 LA_SET_FARM_SETTING			群集设置变更完成。
 LA_SET_SERVER_CERT			服务端证书设定完成。

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -2002,8 +2002,8 @@ LA_CREATE_LISTENER		A new TCP listener (port number %u) has been created.
 LA_DELETE_LISTENER		TCP listener (port number %u) has been deleted.
 LA_ENABLE_LISTENER		TCP listener (port number %u) has been enabled.
 LA_DISABLE_LISTENER		TCP listener (port number %u) has been disabled.
-LA_SET_PORTS_UDP		UDP ports have been set: %s.
-LA_SET_PROTO_OPTIONS	%s options have been set.
+LA_SET_PORTS_UDP		UDP ports have been set: %S.
+LA_SET_PROTO_OPTIONS	%S options have been set.
 LA_SET_SERVER_PASSWORD	The server administrator password has been set.
 LA_SET_FARM_SETTING		The clustering setting has been changed.
 LA_SET_SERVER_CERT		The server certificates have been set.

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -2007,8 +2007,8 @@ LA_CREATE_LISTENER		新しい TCP リスナー (ポート番号 %u) を作成し
 LA_DELETE_LISTENER		TCP リスナー (ポート番号 %u) を削除しました。
 LA_ENABLE_LISTENER		TCP リスナー (ポート番号 %u) を有効化しました。
 LA_DISABLE_LISTENER		TCP リスナー (ポート番号 %u) を無効化しました。
-LA_SET_PORTS_UDP		UDP ポートの一覧が設定されました: %s.
-LA_SET_PROTO_OPTIONS	オプション %s が設定されました。
+LA_SET_PORTS_UDP		UDP ポートの一覧が設定されました: %S.
+LA_SET_PROTO_OPTIONS	オプション %S が設定されました。
 LA_SET_SERVER_PASSWORD	サーバー管理者パスワードを設定しました。
 LA_SET_FARM_SETTING		クラスタリング設定を変更しました。
 LA_SET_SERVER_CERT		サーバー証明書を設定しました。

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -1985,8 +1985,8 @@ LA_CREATE_LISTENER 새로운 TCP 리스너 (포트 번호 %u)를 만들었습니
 LA_DELETE_LISTENER TCP 리스너 (포트 번호 %u)을 삭제했습니다.
 LA_ENABLE_LISTENER TCP 리스너 (포트 번호 %u)를 활성화했습니다.
 LA_DISABLE_LISTENER TCP 리스너 (포트 번호 %u)를 비활성화했습니다.
-LA_SET_PORTS_UDP UDP ports have been set: %s.
-LA_SET_PROTO_OPTIONS %s options have been set.
+LA_SET_PORTS_UDP UDP ports have been set: %S.
+LA_SET_PROTO_OPTIONS %S options have been set.
 LA_SET_SERVER_PASSWORD 서버 관리자 암호를 설정했습니다.
 LA_SET_FARM_SETTING 클러스터링 설정을 변경했습니다.
 LA_SET_SERVER_CERT 서버 인증서를 설정했습니다.

--- a/src/bin/hamcore/strtable_pt_br.stb
+++ b/src/bin/hamcore/strtable_pt_br.stb
@@ -2003,8 +2003,8 @@ LA_CREATE_LISTENER	A new TCP listener (port number %u) has been created.
 LA_DELETE_LISTENER	TCP listener (port number %u) has been deleted.
 LA_ENABLE_LISTENER	TCP listener (port number %u) has been enabled.
 LA_DISABLE_LISTENER	TCP listener (port number %u) has been disabled.
-LA_SET_PORTS_UDP	UDP ports have been set: %s.
-LA_SET_PROTO_OPTIONS	%s options have been set.
+LA_SET_PORTS_UDP	UDP ports have been set: %S.
+LA_SET_PROTO_OPTIONS	%S options have been set.
 LA_SET_SERVER_PASSWORD	The server administrator password has been set.
 LA_SET_FARM_SETTING	The clustering setting has been changed.
 LA_SET_SERVER_CERT	The server certificates have been set.

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -2002,8 +2002,8 @@ LA_CREATE_LISTENER		A new TCP listener (port number %u) has been created.
 LA_DELETE_LISTENER		TCP listener (port number %u) has been deleted.
 LA_ENABLE_LISTENER		TCP listener (port number %u) has been enabled.
 LA_DISABLE_LISTENER		TCP listener (port number %u) has been disabled.
-LA_SET_PORTS_UDP		UDP ports have been set: %s.
-LA_SET_PROTO_OPTIONS	%s options have been set.
+LA_SET_PORTS_UDP		UDP ports have been set: %S.
+LA_SET_PROTO_OPTIONS	%S options have been set.
 LA_SET_SERVER_PASSWORD	The server administrator password has been set.
 LA_SET_FARM_SETTING		The clustering setting has been changed.
 LA_SET_SERVER_CERT		The server certificates have been set.

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -2021,8 +2021,8 @@ LA_CREATE_LISTENER		已建立新 TCP 監聽器 (埠號 %u)。
 LA_DELETE_LISTENER		已刪除 TCP 監聽器 (埠號 %u)。
 LA_ENABLE_LISTENER		已啟用 TCP 監聽器 (埠號 %u)。
 LA_DISABLE_LISTENER		已禁用 TCP 監聽器 (埠號 %u)。
-LA_SET_PORTS_UDP		UDP ports have been set: %s.
-LA_SET_PROTO_OPTIONS	%s options have been set.
+LA_SET_PORTS_UDP		UDP ports have been set: %S.
+LA_SET_PROTO_OPTIONS	%S options have been set.
 LA_SET_SERVER_PASSWORD	服務端管理員密碼設置完成。
 LA_SET_FARM_SETTING		群集設置變更完成。
 LA_SET_SERVER_CERT		服務端證書設定完成。


### PR DESCRIPTION
Turns out `%S` refers to ANSI/UTF-8 and `%s` to UTF-16.

This commit fixes a buffer overflow reported by AddressSanitizer and removes an unnecessary conversion to UTF-16.