### PR TITLE
Refactor Base64 functions, encode/decode using OpenSSL's EVP interface

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -939,30 +939,26 @@ bool HttpParseBasicAuthHeader(HTTP_HEADER *h, char *username, UINT username_size
 		{
 			if (StrCmpi(key, "Basic") == 0 && IsEmptyStr(value) == false)
 			{
-				UINT b64_dest_size = StrSize(value) * 2 + 256;
-				char *b64_dest = ZeroMalloc(b64_dest_size);
-
-				Decode64(b64_dest, value);
-
-				if (IsEmptyStr(b64_dest) == false)
+				char *str = Base64ToBin(NULL, value, StrLen(value));
+				if (str != NULL)
 				{
-					if (b64_dest[0] == ':')
+					if (str[0] == ':')
 					{
 						// Empty username
 						StrCpy(username, username_size, "");
-						StrCpy(password, password_size, b64_dest + 1);
+						StrCpy(password, password_size, str + 1);
 						ret = true;
 					}
 					else
 					{
-						if (GetKeyAndValue(b64_dest, username, username_size, password, password_size, ":"))
+						if (GetKeyAndValue(str, username, username_size, password, password_size, ":"))
 						{
 							ret = true;
 						}
 					}
-				}
 
-				Free(b64_dest);
+					Free(str);
+				}
 			}
 		}
 	}

--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -806,9 +806,6 @@ static UINT SmDdnsGetKey(char *key, SM_DDNS *d){
 
 void SmDDnsDlgInit(HWND hWnd, SM_DDNS *d)
 {
-	char key[20];
-	char encodedkey[20 * 4 + 32];
-
 	// Validate arguments
 	if (hWnd == NULL || d == NULL)
 	{
@@ -845,10 +842,15 @@ void SmDDnsDlgInit(HWND hWnd, SM_DDNS *d)
 
 	Hide(hWnd, B_PROXY);
 
-	if(SmDdnsGetKey(key, d) == ERR_NO_ERROR){
-		encodedkey[ B64_Encode(encodedkey, key, 20) ] = 0;
-		SetTextA(hWnd, E_KEY, encodedkey);
-	}else{
+	char key[20];
+	if (SmDdnsGetKey(key, d) == ERR_NO_ERROR)
+	{
+		char *encoded_key = Base64FromBin(NULL, key, sizeof(key));
+		SetTextA(hWnd, E_KEY, encoded_key);
+		Free(encoded_key);
+	}
+	else
+	{
 		SetText(hWnd, E_KEY, _UU("SM_DDNS_KEY_ERR"));
 	}
 

--- a/src/Cedar/Wpc.h
+++ b/src/Cedar/Wpc.h
@@ -84,10 +84,10 @@ struct WPC_PACKET
 typedef bool (WPC_RECV_CALLBACK)(void *param, UINT total_size, UINT current_size, BUF *recv_buf);
 
 // Function prototype
-void EncodeSafe64(char *dst, void *src, UINT src_size);
-UINT DecodeSafe64(void *dst, char *src, UINT src_strlen);
-void Base64ToSafe64(char *str);
-void Safe64ToBase64(char *str);
+void Base64ToSafe64(char *str, const UINT size);
+void Safe64ToBase64(char *str, const UINT size);
+UINT DecodeSafe64(void *dst, const char *src, UINT size);
+void EncodeSafe64(char *dst, const void *src, const UINT size);
 bool ParseUrl(URL_DATA *data, char *str, bool is_post, char *referrer);
 void CreateUrl(char *url, UINT url_size, URL_DATA *data);
 void GetSystemInternetSetting(INTERNET_SETTING *setting);

--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -57,9 +57,16 @@ if(UNIX)
   # In some cases libiconv is not included in libc
   find_library(LIB_ICONV iconv)
 
+  find_library(LIB_M m)
   find_library(LIB_RT rt)
 
-  target_link_libraries(mayaqua PRIVATE Threads::Threads)
+  target_link_libraries(mayaqua
+    PRIVATE
+      Threads::Threads
+      $<$<BOOL:${LIB_ICONV}>:${LIB_ICONV}>
+      $<$<BOOL:${LIB_M}>:${LIB_M}>
+      $<$<BOOL:${LIB_RT}>:${LIB_RT}>
+  )
 
   if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7l|aarch64|s390x)$" OR NOT HAVE_SYS_AUXV OR SKIP_CPU_FEATURES)
     add_definitions(-DSKIP_CPU_FEATURES)
@@ -67,14 +74,6 @@ if(UNIX)
     add_subdirectory(3rdparty/cpu_features)
     set_property(TARGET cpu_features PROPERTY POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(mayaqua PRIVATE cpu_features)
-  endif()
-
-  if(LIB_RT)
-    target_link_libraries(mayaqua PRIVATE rt)
-  endif()
-
-  if(LIB_ICONV)
-    target_link_libraries(mayaqua PRIVATE ${LIB_ICONV})
   endif()
 
   if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")

--- a/src/Mayaqua/Encoding.c
+++ b/src/Mayaqua/Encoding.c
@@ -1,0 +1,64 @@
+#include "Encoding.h"
+
+#include <math.h>
+
+#include <openssl/evp.h>
+
+UINT Base64Decode(void *dst, const void *src, const UINT size)
+{
+	if (dst == NULL)
+	{
+		// 4 input bytes = max. 3 output bytes.
+		//
+		// EVP_DecodeUpdate() ignores:
+		// - Leading/trailing whitespace.
+		// - Trailing newlines, carriage returns or EOF characters.
+		//
+		// EVP_DecodeFinal() fails if the input is not divisible by 4.
+		return size / 4 * 3;
+	}
+
+	// We don't use EVP_DecodeBlock() because it adds padding if the output is not divisible by 3.
+	EVP_ENCODE_CTX *ctx = EVP_ENCODE_CTX_new();
+	if (ctx == NULL)
+	{
+		return 0;
+	}
+
+	int ret = 0;
+	if (EVP_DecodeUpdate(ctx, dst, &ret, src, size) < 0)
+	{
+		goto FINAL;
+	}
+
+	int dummy;
+	if (EVP_DecodeFinal(ctx, dst, &dummy) < 0)
+	{
+		ret = 0;
+	}
+FINAL:
+	EVP_ENCODE_CTX_free(ctx);
+	return ret;
+}
+
+UINT Base64Encode(void *dst, const void *src, const UINT size)
+{
+	if (dst == NULL)
+	{
+		// 3 input bytes = 4 output bytes.
+		// +1 for the NUL terminator.
+		//
+		// EVP_EncodeBlock() adds padding when the input is not divisible by 3.
+		return ceilf((float)size / 3) * 4 + 1;
+	}
+
+	const int ret = EVP_EncodeBlock(dst, src, size);
+	if (ret > 0)
+	{
+		// EVP_EncodeBlock() returns the length of the string without the NUL terminator.
+		// We, instead, want to return the amount of bytes written into the output buffer.
+		return ret + 1;
+	}
+
+	return 0;
+}

--- a/src/Mayaqua/Encoding.h
+++ b/src/Mayaqua/Encoding.h
@@ -1,0 +1,9 @@
+#ifndef ENCODING_H
+#define ENCODING_H
+
+#include "MayaType.h"
+
+UINT Base64Decode(void *dst, const void *src, const UINT size);
+UINT Base64Encode(void *dst, const void *src, const UINT size);
+
+#endif

--- a/src/Mayaqua/Memory.h
+++ b/src/Mayaqua/Memory.h
@@ -190,12 +190,8 @@ void Zero(void *addr, UINT size);
 void *Clone(void *addr, UINT size);
 void *AddHead(void *src, UINT src_size, void *head, UINT head_size);
 
-char B64_CodeToChar(BYTE c);
-char B64_CharToCode(char c);
-int B64_Encode(char *set, char *source, int len);
-int B64_Decode(char *set, char *source, int len);
-UINT Encode64(char *dst, char *src);
-UINT Decode64(char *dst, char *src);
+void *Base64FromBin(UINT *out_size, const void *src, const UINT size);
+void *Base64ToBin(UINT *out_size, const void *src, const UINT size);
 
 USHORT Swap16(USHORT value);
 UINT Swap32(UINT value);

--- a/src/Mayaqua/Pack.c
+++ b/src/Mayaqua/Pack.c
@@ -2239,10 +2239,9 @@ bool JsonTryParseValueAddToPack(PACK *p, JSON_VALUE *v, char *v_name, UINT index
 	{
 		if (v->type == JSON_TYPE_STRING)
 		{
-			UINT len = StrLen(v->value.string);
-			UCHAR *data = ZeroMalloc(len * 4 + 64);
-			UINT size = B64_Decode(data, v->value.string, len);
-			ElementNullSafe(PackAddDataEx(p, name, data, size, index, total))->JsonHint_IsArray = !is_single;
+			UINT data_size;
+			void *data = Base64ToBin(&data_size, v->value.string, StrLen(v->value.string));
+			ElementNullSafe(PackAddDataEx(p, name, data, data_size, index, total))->JsonHint_IsArray = !is_single;
 			Free(data);
 			ok = true;
 		}

--- a/src/Mayaqua/Proxy.c
+++ b/src/Mayaqua/Proxy.c
@@ -129,17 +129,12 @@ UINT ProxyHttpConnect(PROXY_PARAM_OUT *out, PROXY_PARAM_IN *in, volatile bool *c
 
 	if (use_auth && GetHttpValue(h, "Proxy-Authorization") == NULL)
 	{
-		char auth_str[MAX_SIZE * 2], auth_b64_str[MAX_SIZE * 2];
-
-		// Generate the authentication string
+		char auth_str[MAX_SIZE * 2];
 		Format(auth_str, sizeof(auth_str), "%s:%s", in->Username, in->Password);
 
-		// Base64 encode
-		Zero(auth_b64_str, sizeof(auth_b64_str));
-		Encode64(auth_b64_str, auth_str);
-
-		// Generate final string
-		Format(auth_str, sizeof(auth_str), "Basic %s", auth_b64_str);
+		char *base64 = Base64FromBin(NULL, auth_str, StrLen(auth_str));
+		Format(auth_str, sizeof(auth_str), "Basic %s", base64);
+		Free(base64);
 
 		AddHttpValue(h, NewHttpValue("Proxy-Authorization", auth_str));
 	}

--- a/src/Mayaqua/Str.c
+++ b/src/Mayaqua/Str.c
@@ -4667,12 +4667,11 @@ UINT JsonArrayAddNumber(JSON_ARRAY *array, UINT64 number) {
 UINT JsonArrayAddData(JSON_ARRAY *array, void *data, UINT size)
 {
 	UINT ret;
-	char *b64 = ZeroMalloc(size * 4 + 32);
-	B64_Encode(b64, data, size);
+	char *base64 = Base64FromBin(NULL, data, size);
 
-	ret = JsonArrayAddStr(array, b64);
+	ret = JsonArrayAddStr(array, base64);
 
-	Free(b64);
+	Free(base64);
 	return ret;
 }
 
@@ -4724,12 +4723,11 @@ UINT JsonSet(JSON_OBJECT *object, char *name, JSON_VALUE *value) {
 UINT JsonSetData(JSON_OBJECT *object, char *name, void *data, UINT size)
 {
 	UINT ret;
-	char *b64 = ZeroMalloc(size * 4 + 32);
-	B64_Encode(b64, data, size);
+	char *base64 = Base64FromBin(NULL, data, size);
 
-	ret = JsonSetStr(object, name, b64);
+	ret = JsonSetStr(object, name, base64);
 
-	Free(b64);
+	Free(base64);
 	return ret;
 }
 


### PR DESCRIPTION
Our own implementation works fine, however we should use OpenSSL's one since we already link to the library.

`Base64Decode()` and `Base64Encode()` return the required buffer size when `dst` is `NULL`.

This allows to efficiently allocate a buffer, without wasting memory or risking an overflow.

`Base64FromBin()` and `Base64ToBin()` perform all steps, returning a heap-allocated buffer with the data in it.