### PR TITLE
Mayaqua/DNS.c: Fix DNS resolution in dual stack environment

### DIFF
--- a/src/Mayaqua/DNS.c
+++ b/src/Mayaqua/DNS.c
@@ -425,7 +425,7 @@ void DnsResolver(THREAD *t, void *param)
 				resolver->IPv6.ipv6_scope_id = in->sin6_scope_id;
 				ipv6_ok = true;
 			}
-			else if (ipv4_ok == false)
+			else if (IsIP4(&ip) && ipv4_ok == false)
 			{
 				Copy(&resolver->IPv4, &ip, sizeof(resolver->IPv4));
 				ipv4_ok = true;


### PR DESCRIPTION
Fix an issue that if both IPv6 and IPv4 addresses are resolved, IPv4 ones may not be saved or used at all.

---

﻿Changes proposed in this pull request:
 - Fix DNS resolution in dual stack environment

