### PR TITLE
Cedar/Protocol.c: Use real server IP in creating node info under direct mode

### DIFF
--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -3826,7 +3826,18 @@ void CreateNodeInfo(NODE_INFO *info, CONNECTION *c)
 	// Server host name
 	StrCpy(info->ServerHostname, sizeof(info->ServerHostname), c->ServerName);
 	// Server IP address
-	if (GetIP(&ip, info->ServerHostname))
+	if (s->ClientOption->ProxyType == PROXY_DIRECT)
+	{
+		if (IsIP6(&c->FirstSock->RemoteIP) == false)
+		{
+			info->ServerIpAddress = IPToUINT(&c->FirstSock->RemoteIP);
+		}
+		else
+		{
+			Copy(info->ServerIpAddress6, c->FirstSock->RemoteIP.address, sizeof(info->ServerIpAddress6));
+		}
+	}
+	else if (GetIP(&ip, info->ServerHostname))
 	{
 		if (IsIP6(&ip) == false)
 		{


### PR DESCRIPTION
Currently when the client sends node info to the server, server IP is resolved again where the result may not be the actual one being used.
This is unnecessary in direct mode at least and may result in reporting incorrect server addresses.

---

﻿Changes proposed in this pull request:
 - Use real server IP in node info under direct connection

