### PR TITLE
Mayaqua/Network.c: Use int as boolean flags for socket options

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -10784,7 +10784,7 @@ UINT SendToEx(SOCK *sock, IP *dest_addr, UINT dest_port, void *data, UINT size, 
 	{
 		if (sock->UdpBroadcast == false)
 		{
-			bool yes = true;
+			UINT yes = 1;
 
 			sock->UdpBroadcast = true;
 
@@ -10883,7 +10883,7 @@ UINT SendTo6Ex(SOCK *sock, IP *dest_addr, UINT dest_port, void *data, UINT size,
 	{
 		if (sock->UdpBroadcast == false)
 		{
-			bool yes = true;
+			UINT yes = 1;
 
 			sock->UdpBroadcast = true;
 
@@ -11132,14 +11132,14 @@ SOCK *NewUDP4(UINT port, IP *ip)
 		// Failure
 		if (port != 0)
 		{
-			bool true_flag = true;
-			(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(bool));
+			UINT true_flag = 1;
+			(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(true_flag));
 			if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) != 0)
 			{
-				bool false_flag = false;
-				(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&false_flag, sizeof(bool));
+				UINT false_flag = 0;
+				(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&false_flag, sizeof(false_flag));
 #ifdef	SO_EXCLUSIVEADDRUSE
-				(void)setsockopt(s, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (char *)&true_flag, sizeof(bool));
+				(void)setsockopt(s, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (char *)&true_flag, sizeof(true_flag));
 #endif	// SO_EXCLUSIVEADDRUSE
 				if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) != 0)
 				{
@@ -11172,7 +11172,7 @@ SOCK *NewUDP4(UINT port, IP *ip)
 
 	if (IS_SPECIAL_PORT(port))
 	{
-		bool no = false;
+		UINT no = 0;
 		(void)setsockopt(sock->socket, IPPROTO_IP, IP_HDRINCL, (char *)&no, sizeof(no));
 
 		sock->IsRawSocket = true;
@@ -11229,14 +11229,14 @@ SOCK *NewUDP6(UINT port, IP *ip)
 		// Failure
 		if (port != 0)
 		{
-			bool true_flag = true;
-			(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(bool));
+			UINT true_flag = 1;
+			(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(true_flag));
 			if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) != 0)
 			{
-				bool false_flag = false;
-				(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&false_flag, sizeof(bool));
+				UINT false_flag = 0;
+				(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&false_flag, sizeof(false_flag));
 #ifdef	SO_EXCLUSIVEADDRUSE
-				(void)setsockopt(s, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (char *)&true_flag, sizeof(bool));
+				(void)setsockopt(s, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (char *)&true_flag, sizeof(true_flag));
 #endif	// SO_EXCLUSIVEADDRUSE
 				if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) != 0)
 				{
@@ -11270,7 +11270,7 @@ SOCK *NewUDP6(UINT port, IP *ip)
 
 	if (IS_SPECIAL_PORT(port))
 	{
-		bool no = false;
+		UINT no = 0;
 #ifdef	IPV6_HDRINCL
 		(void)setsockopt(sock->socket, IPPROTO_IP, IPV6_HDRINCL, (char *)&no, sizeof(no));
 #endif	// IPV6_HDRINCL
@@ -12612,7 +12612,7 @@ SOCK *Accept(SOCK *sock)
 	SOCKET s, new_socket;
 	int size;
 	struct sockaddr_in addr;
-	bool true_flag = true;
+	UINT true_flag = 1;
 	// Validate arguments
 	if (sock == NULL)
 	{
@@ -12699,7 +12699,7 @@ SOCK *Accept(SOCK *sock)
 	ret->SecureMode = false;
 
 	// Configuring the TCP options
-	(void)setsockopt(ret->socket, IPPROTO_TCP, TCP_NODELAY, (char *)&true_flag, sizeof(bool));
+	(void)setsockopt(ret->socket, IPPROTO_TCP, TCP_NODELAY, (char *)&true_flag, sizeof(true_flag));
 
 	// Initialization of the time-out value
 	SetTimeout(ret, TIMEOUT_INFINITE);
@@ -12811,8 +12811,8 @@ SOCK *Accept6(SOCK *sock)
 	ret->SecureMode = false;
 
 	// Configuring the TCP options
-	bool true_flag = true;
-	(void)setsockopt(ret->socket, IPPROTO_TCP, TCP_NODELAY, (char *)&true_flag, sizeof(bool));
+	UINT true_flag = 1;
+	(void)setsockopt(ret->socket, IPPROTO_TCP, TCP_NODELAY, (char *)&true_flag, sizeof(true_flag));
 
 	// Initialize the time-out value
 	SetTimeout(ret, TIMEOUT_INFINITE);
@@ -12883,13 +12883,13 @@ SOCK *ListenEx62(UINT port, bool local_only, bool enable_ca)
 		return NULL;
 	}
 
-	bool true_flag = true;
+	UINT true_flag = 1;
 #ifdef	OS_UNIX
 	// It is necessary to set the IPv6 Only flag on a UNIX system
 	(void)setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, &true_flag, sizeof(true_flag));
 	// This only have enabled for UNIX system since there is a bug
 	// in the implementation of REUSEADDR in Windows OS
-	(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(bool));
+	(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(true_flag));
 #endif	// OS_UNIX
 
 	if (bind(s, (struct sockaddr *)&addr, sizeof(struct sockaddr_in6)) != 0)
@@ -12902,7 +12902,7 @@ SOCK *ListenEx62(UINT port, bool local_only, bool enable_ca)
 #ifdef OS_WIN32
 	if (enable_ca)
 	{
-		setsockopt(s, SOL_SOCKET, SO_CONDITIONAL_ACCEPT, (char *)&true_flag, sizeof(bool));
+		setsockopt(s, SOL_SOCKET, SO_CONDITIONAL_ACCEPT, (char *)&true_flag, sizeof(true_flag));
 		backlog = 1;
 	}
 #endif
@@ -12984,11 +12984,11 @@ SOCK *ListenEx2(UINT port, bool local_only, bool enable_ca, IP *listen_ip)
 		return NULL;
 	}
 
-	bool true_flag = true;
+	UINT true_flag = 1;
 #ifdef	OS_UNIX
 	// This only have enabled for UNIX system since there is a bug
 	// in the implementation of REUSEADDR in Windows OS
-	(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(bool));
+	(void)setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(true_flag));
 #endif	// OS_UNIX
 
 	if (bind(s, (struct sockaddr *)&addr, sizeof(struct sockaddr_in)) != 0)
@@ -13001,7 +13001,7 @@ SOCK *ListenEx2(UINT port, bool local_only, bool enable_ca, IP *listen_ip)
 #ifdef	OS_WIN32
 	if (enable_ca)
 	{
-		setsockopt(s, SOL_SOCKET, SO_CONDITIONAL_ACCEPT, (char *)&true_flag, sizeof(bool));
+		setsockopt(s, SOL_SOCKET, SO_CONDITIONAL_ACCEPT, (char *)&true_flag, sizeof(true_flag));
 		backlog = 1;
 	}
 #endif	// OS_WIN32
@@ -13105,13 +13105,13 @@ void Disconnect(SOCK *sock)
 		{
 			// Forced disconnection flag
 #ifdef	SO_DONTLINGER
-			bool true_flag = true;
-			(void)setsockopt(sock->socket, SOL_SOCKET, SO_DONTLINGER, (char *)&true_flag, sizeof(bool));
+			UINT true_flag = 1;
+			(void)setsockopt(sock->socket, SOL_SOCKET, SO_DONTLINGER, (char *)&true_flag, sizeof(true_flag));
 #else	// SO_DONTLINGER
-			bool false_flag = false;
-			(void)setsockopt(sock->socket, SOL_SOCKET, SO_LINGER, (char *)&false_flag, sizeof(bool));
+			UINT false_flag = 0;
+			(void)setsockopt(sock->socket, SOL_SOCKET, SO_LINGER, (char *)&false_flag, sizeof(false_flag));
 #endif	// SO_DONTLINGER
-//			setsockopt(sock->socket, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(bool));
+//			setsockopt(sock->socket, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(true_flag));
 		}
 
 		// TCP socket
@@ -14339,18 +14339,18 @@ SOCK *ConnectEx4(char *hostname, UINT port, UINT timeout, bool *cancel_flag, cha
 
 	Zero(&ling, sizeof(ling));
 
-	bool true_flag = true;
+	UINT true_flag = 1;
 	// Forced disconnection flag
 #ifdef	SO_DONTLINGER
-	(void)setsockopt(sock->socket, SOL_SOCKET, SO_DONTLINGER, (char *)&true_flag, sizeof(bool));
+	(void)setsockopt(sock->socket, SOL_SOCKET, SO_DONTLINGER, (char *)&true_flag, sizeof(true_flag));
 #else	// SO_DONTLINGER
-	bool false_flag = false;
-	(void)setsockopt(sock->socket, SOL_SOCKET, SO_LINGER, (char *)&false_flag, sizeof(bool));
+	UINT false_flag = 0;
+	(void)setsockopt(sock->socket, SOL_SOCKET, SO_LINGER, (char *)&false_flag, sizeof(false_flag));
 #endif	// SO_DONTLINGER
-//	setsockopt(sock->socket, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(bool));
+//	setsockopt(sock->socket, SOL_SOCKET, SO_REUSEADDR, (char *)&true_flag, sizeof(true_flag));
 
 	// Configuring TCP options
-	(void)setsockopt(sock->socket, IPPROTO_TCP, TCP_NODELAY, (char *)&true_flag, sizeof(bool));
+	(void)setsockopt(sock->socket, IPPROTO_TCP, TCP_NODELAY, (char *)&true_flag, sizeof(true_flag));
 
 	// Initialization of the time-out value
 	SetTimeout(sock, TIMEOUT_INFINITE);


### PR DESCRIPTION
Before https://github.com/SoftEtherVPN/SoftEtherVPN/commit/914bfe7d44f8e693d21178055f0b845c613dc777, we defined our `bool` type as `int` and used it indifferently both internally and in socket options.
Now that we are using C99 `bool`, socket options needed to be explicitly set in `int`.

This fix restores TCP listeners in IPv6.

Close #1413

---

﻿Changes proposed in this pull request:
 - Use int type socket options as our bool type has changed

