### PR TITLE
Cedar/Command: Add GenX25519 and GetPublicX25519 commands

### DIFF
--- a/src/Cedar/CMakeLists.txt
+++ b/src/Cedar/CMakeLists.txt
@@ -19,6 +19,8 @@ set_target_properties(cedar
   RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
+target_link_libraries(cedar PUBLIC mayaqua)
+
 cmake_host_system_information(RESULT HAS_SSE2 QUERY HAS_SSE2)
 
 set(BLAKE2_SRC_PATH $<IF:$<BOOL:${HAS_SSE2}>,${TOP_DIRECTORY}/3rdparty/BLAKE2/sse,${TOP_DIRECTORY}/3rdparty/BLAKE2/ref>)

--- a/src/Cedar/Command.h
+++ b/src/Cedar/Command.h
@@ -307,6 +307,8 @@ UINT PtConnect(CONSOLE *c, wchar_t *cmdline);
 PT *NewPt(CONSOLE *c, wchar_t *cmdline);
 void FreePt(PT *pt);
 void PtMain(PT *pt);
+UINT PtGenX25519(CONSOLE *c, char *cmd_name, wchar_t *str, void *param);
+UINT PtGetPublicX25519(CONSOLE *c, char *cmd_name, wchar_t *str, void *param);
 UINT PtMakeCert(CONSOLE *c, char *cmd_name, wchar_t *str, void *param);
 UINT PtMakeCert2048(CONSOLE *c, char *cmd_name, wchar_t *str, void *param);
 UINT PtTrafficClient(CONSOLE *c, char *cmd_name, wchar_t *str, void *param);

--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -1,5 +1,5 @@
-file(GLOB SOURCES_MAYAQUA "*.c")
-file(GLOB HEADERS_MAYAQUA "*.h")
+file(GLOB SOURCES_MAYAQUA "*.c" "Crypto/*.c")
+file(GLOB HEADERS_MAYAQUA "*.h" "Crypto/*.h")
 
 if(WIN32)
   add_library(mayaqua STATIC ${SOURCES_MAYAQUA} ${HEADERS_MAYAQUA})

--- a/src/Mayaqua/Crypto/Key.c
+++ b/src/Mayaqua/Crypto/Key.c
@@ -1,0 +1,221 @@
+#include "Key.h"
+
+#include "Encrypt.h"
+#include "Memory.h"
+#include "Str.h"
+
+#include <openssl/evp.h>
+
+static int CryptoKeyTypeToID(const CRYPTO_KEY_TYPE type)
+{
+	switch (type)
+	{
+		case KEY_UNKNOWN:
+			break;
+		case KEY_X25519:
+			return EVP_PKEY_X25519;
+		case KEY_X448:
+			return EVP_PKEY_X448;
+		default:
+			Debug("CryptoKeyTypeToID(): Unhandled type %u!\n", type);
+	}
+
+	return EVP_PKEY_NONE;
+}
+
+UINT CryptoKeyTypeSize(const CRYPTO_KEY_TYPE type)
+{
+	switch (type)
+	{
+		case KEY_UNKNOWN:
+			break;
+		case KEY_X25519:
+			return KEY_X25519_SIZE;
+		case KEY_X448:
+			return KEY_X448_SIZE;
+		default:
+			Debug("CryptoKeyTypeSize(): Unhandled type %u!\n", type);
+	}
+
+	return 0;
+}
+
+CRYPTO_KEY_RAW *CryptoKeyRawNew(const void *data, const UINT size, const CRYPTO_KEY_TYPE type)
+{
+	if (size == 0 || size != CryptoKeyTypeSize(type))
+	{
+		return NULL;
+	}
+
+	CRYPTO_KEY_RAW *key = Malloc(sizeof(CRYPTO_KEY_RAW));
+	key->Data = MallocEx(size, true);
+	key->Size = size;
+	key->Type = type;
+
+	if (data == NULL)
+	{
+		Rand(key->Data, key->Size);
+	}
+	else
+	{
+		Copy(key->Data, data, key->Size);
+	}
+
+	return key;
+}
+
+void CryptoKeyRawFree(CRYPTO_KEY_RAW *key)
+{
+	if (key == NULL)
+	{
+		return;
+	}
+
+	Free(key->Data);
+	Free(key);
+}
+
+CRYPTO_KEY_RAW *CryptoKeyRawPublic(const CRYPTO_KEY_RAW *private)
+{
+	if (private == NULL)
+	{
+		return NULL;
+	}
+
+	void *opaque = CryptoKeyRawToOpaque(private, false);
+	if (opaque == NULL)
+	{
+		return NULL;
+	}
+
+	CRYPTO_KEY_RAW *public = NULL;
+	CryptoKeyOpaqueToRaw(opaque, NULL, &public);
+	CryptoKeyOpaqueFree(opaque);
+
+	return public;
+}
+
+void *CryptoKeyRawToOpaque(const CRYPTO_KEY_RAW *key, const bool public)
+{
+	if (key == NULL)
+	{
+		return NULL;
+	}
+
+	const int id = CryptoKeyTypeToID(key->Type);
+
+	if (public)
+	{
+		return EVP_PKEY_new_raw_public_key(id, NULL, key->Data, key->Size);
+	}
+	else
+	{
+		return EVP_PKEY_new_raw_private_key(id, NULL, key->Data, key->Size);
+	}
+}
+
+void *CryptoKeyOpaqueNew(const CRYPTO_KEY_TYPE type)
+{
+	EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(CryptoKeyTypeToID(type), NULL);
+	if (ctx == NULL)
+	{
+		Debug("CryptoKeyOpaqueNew(): EVP_PKEY_CTX_new_id() returned NULL!\n");
+		return false;
+	}
+
+	EVP_PKEY *key = NULL;
+
+	int ret = EVP_PKEY_keygen_init(ctx);
+	if (ret != 1)
+	{
+		Debug("CryptoKeyOpaqueNew(): EVP_PKEY_keygen_init() returned %d!\n", ret);
+		goto FINAL;
+	}
+
+	ret = EVP_PKEY_keygen(ctx, &key);
+	if (ret != 1)
+	{
+		Debug("CryptoKeyOpaqueNew(): EVP_PKEY_keygen() returned %d!\n", ret);
+	}
+FINAL:
+	EVP_PKEY_CTX_free(ctx);
+	return key;
+}
+
+void CryptoKeyOpaqueFree(void *key)
+{
+	if (key != NULL)
+	{
+		EVP_PKEY_free(key);
+	}
+}
+
+bool CryptoKeyOpaqueToRaw(const void *opaque, CRYPTO_KEY_RAW **private, CRYPTO_KEY_RAW **public)
+{
+	if (opaque == NULL || (private == NULL && public == NULL))
+	{
+		return false;
+	}
+
+	CRYPTO_KEY_TYPE type;
+
+	switch (EVP_PKEY_id(opaque))
+	{
+	case EVP_PKEY_X25519:
+		type = KEY_X25519;
+		break;
+	case EVP_PKEY_X448:
+		type = KEY_X448;
+		break;
+	default:
+		return false;
+	}
+
+	if (private != NULL)
+	{
+		size_t size;
+		int ret = EVP_PKEY_get_raw_private_key(opaque, NULL, &size);
+		if (ret != 1)
+		{
+			Debug("CryptoKeyOpaqueToRaw(): #1 EVP_PKEY_get_raw_private_key() returned %d!\n", ret);
+			return false;
+		}
+
+		CRYPTO_KEY_RAW *key = CryptoKeyRawNew(NULL, size, type);
+
+		ret = EVP_PKEY_get_raw_private_key(opaque, key->Data, &size);
+		if (ret != 1)
+		{
+			Debug("CryptoKeyOpaqueToRaw(): #2 EVP_PKEY_get_raw_private_key() returned %d!\n", ret);
+			CryptoKeyRawFree(key);
+			return false;
+		}
+
+		*private = key;
+	}
+
+	if (public != NULL)
+	{
+		size_t size;
+		int ret = EVP_PKEY_get_raw_public_key(opaque, NULL, &size);
+		if (ret != 1)
+		{
+			Debug("CryptoKeyOpaqueToRaw(): #1 EVP_PKEY_get_raw_public_key() returned %d!\n", ret);
+			return false;
+		}
+
+		CRYPTO_KEY_RAW *key = CryptoKeyRawNew(NULL, size, type);
+
+		ret = EVP_PKEY_get_raw_public_key(opaque, key->Data, &size);
+		if (ret != 1)
+		{
+			Debug("CryptoKeyOpaqueToRaw(): #2 EVP_PKEY_get_raw_public_key() returned %d!\n", ret);
+			CryptoKeyRawFree(key);
+			return false;
+		}
+
+		*public = key;
+	}
+
+	return true;
+}

--- a/src/Mayaqua/Crypto/Key.h
+++ b/src/Mayaqua/Crypto/Key.h
@@ -1,0 +1,36 @@
+#ifndef CRYPTO_KEY_H
+#define CRYPTO_KEY_H
+
+#include "MayaType.h"
+
+#define KEY_X25519_SIZE 32
+#define KEY_X448_SIZE   56
+
+enum CRYPTO_KEY_TYPE
+{
+	KEY_UNKNOWN,
+	KEY_X25519,
+	KEY_X448
+};
+
+struct CRYPTO_KEY_RAW
+{
+	BYTE *Data;
+	UINT Size;
+	CRYPTO_KEY_TYPE Type;
+};
+
+UINT CryptoKeyTypeSize(const CRYPTO_KEY_TYPE type);
+
+CRYPTO_KEY_RAW *CryptoKeyRawNew(const void *data, const UINT size, const CRYPTO_KEY_TYPE type);
+void CryptoKeyRawFree(CRYPTO_KEY_RAW *key);
+
+CRYPTO_KEY_RAW *CryptoKeyRawPublic(const CRYPTO_KEY_RAW *private);
+void *CryptoKeyRawToOpaque(const CRYPTO_KEY_RAW *key, const bool public);
+
+void *CryptoKeyOpaqueNew(const CRYPTO_KEY_TYPE type);
+void CryptoKeyOpaqueFree(void *key);
+
+bool CryptoKeyOpaqueToRaw(const void *opaque, CRYPTO_KEY_RAW **private, CRYPTO_KEY_RAW **public);
+
+#endif

--- a/src/Mayaqua/Crypto/Types.h
+++ b/src/Mayaqua/Crypto/Types.h
@@ -1,0 +1,8 @@
+#ifndef CRYPTO_TYPES_H
+#define CRYPTO_TYPES_H
+
+typedef enum CRYPTO_KEY_TYPE CRYPTO_KEY_TYPE;
+
+typedef struct CRYPTO_KEY_RAW CRYPTO_KEY_RAW;
+
+#endif

--- a/src/Mayaqua/MayaType.h
+++ b/src/Mayaqua/MayaType.h
@@ -466,4 +466,6 @@ typedef struct DNS_CACHE_REVERSE DNS_CACHE_REVERSE;
 typedef struct DNS_RESOLVER DNS_RESOLVER;
 typedef struct DNS_RESOLVER_REVERSE DNS_RESOLVER_REVERSE;
 
+#include "Crypto/Types.h"
+
 #endif	// MAYATYPE_H

--- a/src/PenCore/CMakeLists.txt
+++ b/src/PenCore/CMakeLists.txt
@@ -12,4 +12,4 @@ set_target_properties(PenCore
   PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
-target_link_libraries(PenCore cedar mayaqua)
+target_link_libraries(PenCore)

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -7003,6 +7003,23 @@ CMD_RemoteDisable_Args		RemoteDisable
 ###################################################
 
 
+# GenX25519 命令
+CMD_GenX25519				Create new X25519 keypair
+CMD_GenX25519_Help			Use this to create a new X25519 keypair, which can be used for WireGuard. \nBoth the private and public key will be shown. \nThe public key can be shared and is used to identify a peer. \nAlso, it can always be retrieved from the private key using the GetPublicX25519 command. \nThe private key should be kept in a secure place and never be shared. \nIt cannot be recovered once lost.
+CMD_GenX25519_ARGS			GenX25519
+CMD_GenX25519_PRIVATE_KEY	Private key: 
+CMD_GenX25519_PUBLIC_KEY	Public key: 
+
+
+# GetPublicX25519 命令
+CMD_GetPublicX25519				Retrieve public X25519 key from a private one
+CMD_GetPublicX25519_Help		Use this if you have a private X25519 key and want to get its corresponding public key.
+CMD_GetPublicX25519_ARGS    	GetPublicX25519 [private]
+CMD_GetPublicX25519_[private]	The private X25519 key you want to get the corresponding public key of.
+CMD_GetPublicX25519_PRIVATE_KEY	Private key: 
+CMD_GetPublicX25519_PUBLIC_KEY	Public key: 
+
+
 # MakeCert 命令
 CMD_MakeCert				创建新的 X.509 证书和密钥 (1024 位)
 CMD_MakeCert_Help			创建新的 X.509 证书和密钥，将其保存为一个文件。\n证书公共密钥和秘密密钥的生成算法使用 RSA 1024 位。\n作为证书类型，可以创建由根证书 (自签名证书) 和其他证书签名的某个证书。要创建由其他证书签名的证书，需要与用于签名的证书 (X.509格式文件) 相对应的密钥文件 (Base 64 编码)。\n\n创建的证书可以指定名称 (CN)，所属机构 (O)，组织单位 (OU)，国家 (C)，州 (ST)，当地 (L)，序列号，有效期限。\n创建的证书以 X.509 格式的文件，密钥文件以 RSA 1024 位的 Base 64 编码文件，被分别保存。\n\nMakeCert 指令是一个工具，它提供创建证书所需的最低功能。如果想创建一个真正的证书，建议使用 OpenSSL 等免费软件和出售的 CA (认证机构) 软件。\n\n※注意: 此指令可以从 SoftEther VPN 命令行管理工具调用。虽然目前以管理模式连接到 VPN Server 和 VPN Client 时可以运行，但要实际运行 RSA 演算，生成证书数据的，是运行此指令的计算机，和以管理模式连接的链接目标计算机没有任何关系。

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -6989,6 +6989,23 @@ CMD_RemoteDisable_Args	RemoteDisable
 ###################################################
 
 
+# GenX25519 command
+CMD_GenX25519				Create new X25519 keypair
+CMD_GenX25519_Help			Use this to create a new X25519 keypair, which can be used for WireGuard. \nBoth the private and public key will be shown. \nThe public key can be shared and is used to identify a peer. \nAlso, it can always be retrieved from the private key using the GetPublicX25519 command. \nThe private key should be kept in a secure place and never be shared. \nIt cannot be recovered once lost.
+CMD_GenX25519_ARGS			GenX25519
+CMD_GenX25519_PRIVATE_KEY	Private key: 
+CMD_GenX25519_PUBLIC_KEY	Public key: 
+
+
+# GetPublicX25519 command
+CMD_GetPublicX25519				Retrieve public X25519 key from a private one
+CMD_GetPublicX25519_Help		Use this if you have a private X25519 key and want to get its corresponding public key.
+CMD_GetPublicX25519_ARGS    	GetPublicX25519 [private]
+CMD_GetPublicX25519_[private]	The private X25519 key you want to get the corresponding public key of.
+CMD_GetPublicX25519_PRIVATE_KEY	Private key: 
+CMD_GetPublicX25519_PUBLIC_KEY	Public key: 
+
+
 # MakeCert command
 CMD_MakeCert			Create New X.509 Certificate and Private Key (1024 bit)
 CMD_MakeCert_Help		Use this to create a new X.509 certificate and private key and save it as a file. \nThe algorithm used to create the public key and private key of the certificate is RSA 1024 bit. \nYou can choose to create a root certificate (self-signed certificate) or a certificate signed by another certificate. To create a certificate that is signed by another certificate, you require a private key file (base 64 encoded) that is compatible with the certificate that uses the signature (X.509 format file). \n\nWhen creating a certificate, you can specify the following: Name (CN), Organization (O), Organization Unit (OU), Country (C), State (ST), Locale (L), Serial Number, and Expiration Date. \nThe created certificate will be saved as an X.509 format file and the private key file will be saved in a Base 64 encoded RSA 1024 bit format file. \n\nThe MakeCert command is a tool that provides the most rudimentary function for creating certificates. If you want to create a more substantial certificate, we recommend that you use either free software such as OpenSSL, or commercial CA (certificate authority) software. \n\nNote: This command can be called from the SoftEther VPN Command Line Management Utility. You can also execute this command while connected to the current VPN Server or VPN Client in Administration Mode but, what actually performs the RSA computation, generates the certificate data and saves it to file is the computer on which the command is running, and all this is executed in a context that has absolutely no relationship to the computer that is the destination of the Administration Mode connection.

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -6999,6 +6999,23 @@ CMD_RemoteDisable_Args	RemoteDisable
 ###################################################
 
 
+# GenX25519 コマンド
+CMD_GenX25519				Create new X25519 keypair
+CMD_GenX25519_Help			Use this to create a new X25519 keypair, which can be used for WireGuard. \nBoth the private and public key will be shown. \nThe public key can be shared and is used to identify a peer. \nAlso, it can always be retrieved from the private key using the GetPublicX25519 command. \nThe private key should be kept in a secure place and never be shared. \nIt cannot be recovered once lost.
+CMD_GenX25519_ARGS			GenX25519
+CMD_GenX25519_PRIVATE_KEY	Private key: 
+CMD_GenX25519_PUBLIC_KEY	Public key: 
+
+
+# GetPublicX25519 コマンド
+CMD_GetPublicX25519				Retrieve public X25519 key from a private one
+CMD_GetPublicX25519_Help		Use this if you have a private X25519 key and want to get its corresponding public key.
+CMD_GetPublicX25519_ARGS    	GetPublicX25519 [private]
+CMD_GetPublicX25519_[private]	The private X25519 key you want to get the corresponding public key of.
+CMD_GetPublicX25519_PRIVATE_KEY	Private key: 
+CMD_GetPublicX25519_PUBLIC_KEY	Public key: 
+
+
 # MakeCert コマンド
 CMD_MakeCert			新しい X.509 証明書と秘密鍵の作成 (1024 bit)
 CMD_MakeCert_Help		新しい X.509 証明書と秘密鍵を作成し、ファイルとして保存します。\n証明書の公開鍵と秘密鍵の生成アルゴリズムには、RSA 1024 bit が使用されます。\n証明書の種類として、ルート証明書 (自己署名証明書) と他の証明書によって署名された証明書のどちらでも作成することができます。他の証明書によって署名された証明書を作成するためには、署名に使用する証明書 (X.509 形式のファイル) と対応する秘密鍵ファイル (Base 64 エンコード) が必要です。\n\n作成する証明書には、名前 (CN)、所属機関 (O)、組織単位 (OU)、国 (C)、都道府県 (ST)、ローカル (L)、シリアル番号、有効期限を指定することができます。\n作成された証明書は X.509 形式のファイルとして、秘密鍵ファイルは RSA 1024 bit 形式の Base 64 エンコードされたファイルとしてそれぞれ保存されます。\n\nMakeCert コマンドは、証明書を作成するための必要最低限の機能を用意したツールです。本格的な証明書を作成したい場合は、OpenSSL などのフリーソフトや、市販の CA (証明機関) ソフトウェアを使用することを推奨します。\n\n※注意: このコマンドは SoftEther VPN コマンドライン管理ユーティリティから呼び出すことが可能です。現在 VPN Server や VPN Client に管理モードで接続している場合も実行できますが、実際に RSA 演算を行い、証明書データを生成しファイルに保存するのはこのコマンドを実行しているコンピュータであり、管理モードで接続先のコンピュータとは一切関係ないコンテキストで実行されます。

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -6973,6 +6973,23 @@ CMD_RemoteDisable_Args RemoteDisable
 ################################################## #
 
 
+# GenX25519 명령
+CMD_GenX25519				Create new X25519 keypair
+CMD_GenX25519_Help			Use this to create a new X25519 keypair, which can be used for WireGuard. \nBoth the private and public key will be shown. \nThe public key can be shared and is used to identify a peer. \nAlso, it can always be retrieved from the private key using the GetPublicX25519 command. \nThe private key should be kept in a secure place and never be shared. \nIt cannot be recovered once lost.
+CMD_GenX25519_ARGS			GenX25519
+CMD_GenX25519_PRIVATE_KEY	Private key: 
+CMD_GenX25519_PUBLIC_KEY	Public key: 
+
+
+# GetPublicX25519 명령
+CMD_GetPublicX25519				Retrieve public X25519 key from a private one
+CMD_GetPublicX25519_Help		Use this if you have a private X25519 key and want to get its corresponding public key.
+CMD_GetPublicX25519_ARGS    	GetPublicX25519 [private]
+CMD_GetPublicX25519_[private]	The private X25519 key you want to get the corresponding public key of.
+CMD_GetPublicX25519_PRIVATE_KEY	Private key: 
+CMD_GetPublicX25519_PUBLIC_KEY	Public key: 
+
+
 # MakeCert 명령
 CMD_MakeCert 새로운 X.509 인증서와 개인 키를 생성 (1024 bit)
 CMD_MakeCert_Help 새로운 X.509 인증서와 개인 키를 생성하고 파일로 저장합니다. \n 인증서의 공개 키와 비밀 키 생성 알고리즘은 RSA 1024 bit가 사용됩니다. \n 인증서 유형으로 루트 인증서 (자기 서명 증명서) 및 기타 인증서로 서명 된 인증서의 어디라도 만들 수 있습니다. 다른 인증서로 서명 된 인증서를 생성하기 위해서는 서명에 사용할 인증서 (X.509 형식의 파일)과 해당 개인 키 파일 (Base 64 인코딩)가 필요합니다. \n \n 만든 인증서에는 이름 (CN), 소속 기관 (O) 조직 단위 (OU) 국가 (C),도 (ST) 로컬 (L), 일련 번호, 유효 기간을 지정할 수 있습니다. \n 생성 된 인증서는 X.509 형식의 파일로 개인 키 파일은 RSA 1024 bit 형식의 Base 64로 인코딩 된 파일로 각각 저장됩니다. \n \nMakeCert 명령은 인증서를 만들기위한 최소한의 기능을 제공하는 도구입니다. 본격적인 인증서를 작성하려면 OpenSSL 등의 무료 소프트웨어와 상용 CA (인증 기관) 소프트웨어를 사용하는 것을 권장합니다. \n \n ※주의:이 명령은 SoftEther VPN 명령 줄 관리 유틸리티에서 호출 할 수 있습니다. 현재 VPN Server와 VPN Client에서 관리 모드로 접속하는 경우도 실행할 수 있지만 실제로 RSA 연산을 수행하고 인증서 데이터를 생성하고 파일에 저장하는 것은이 명령을 실행하는 컴퓨터입니다 관리 모드에 연결된 컴퓨터와도 관계없는 컨텍스트에서 실행됩니다.

--- a/src/bin/hamcore/strtable_pt_br.stb
+++ b/src/bin/hamcore/strtable_pt_br.stb
@@ -6728,6 +6728,23 @@ CMD_RemoteDisable_Args	RemoteDisable
 ###################################################
 
 
+# GenX25519 command
+CMD_GenX25519				Create new X25519 keypair
+CMD_GenX25519_Help			Use this to create a new X25519 keypair, which can be used for WireGuard. \nBoth the private and public key will be shown. \nThe public key can be shared and is used to identify a peer. \nAlso, it can always be retrieved from the private key using the GetPublicX25519 command. \nThe private key should be kept in a secure place and never be shared. \nIt cannot be recovered once lost.
+CMD_GenX25519_ARGS			GenX25519
+CMD_GenX25519_PRIVATE_KEY	Private key: 
+CMD_GenX25519_PUBLIC_KEY	Public key: 
+
+
+# GetPublicX25519 command
+CMD_GetPublicX25519				Retrieve public X25519 key from a private one
+CMD_GetPublicX25519_Help		Use this if you have a private X25519 key and want to get its corresponding public key.
+CMD_GetPublicX25519_ARGS    	GetPublicX25519 [private]
+CMD_GetPublicX25519_[private]	The private X25519 key you want to get the corresponding public key of.
+CMD_GetPublicX25519_PRIVATE_KEY	Private key: 
+CMD_GetPublicX25519_PUBLIC_KEY	Public key: 
+
+
 # MakeCert command
 CMD_MakeCert	Create New X.509 Certificate and Private Key (1024 bit)
 CMD_MakeCert_Help	Use this to create a new X.509 certificate and private key and save it as a file. \nThe algorithm used to create the public key and private key of the certificate is RSA 1024 bit. \nYou can choose to create a root certificate (self-signed certificate) or a certificate signed by another certificate. To create a certificate that is signed by another certificate, you require a private key file (base 64 encoded) that is compatible with the certificate that uses the signature (X.509 format file). \n\nWhen creating a certificate, you can specify the following: Name (CN), Organization (O), Organization Unit (OU), Country (C), State (ST), Locale (L), Serial Number, and Expiration Date. \nThe created certificate will be saved as an X.509 format file and the private key file will be saved in a Base 64 encoded RSA 1024 bit format file. \n\nThe MakeCert command is a tool that provides the most rudimentary function for creating certificates. If you want to create a more substantial certificate, we recommend that you use either free software such as OpenSSL, or commercial CA (certificate authority) software. \n\nNote: This command can be called from the SoftEther VPN Command Line Management Utility. You can also execute this command while connected to the current VPN Server or VPN Client in Administration Mode but, what actually performs the RSA computation, generates the certificate data and saves it to file is the computer on which the command is running, and all this is executed in a context that has absolutely no relationship to the computer that is the destination of the Administration Mode connection.

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -6976,6 +6976,23 @@ CMD_RemoteDisable_Args	RemoteDisable
 ###################################################
 
 
+# GenX25519 command
+CMD_GenX25519				Create new X25519 keypair
+CMD_GenX25519_Help			Use this to create a new X25519 keypair, which can be used for WireGuard. \nBoth the private and public key will be shown. \nThe public key can be shared and is used to identify a peer. \nAlso, it can always be retrieved from the private key using the GetPublicX25519 command. \nThe private key should be kept in a secure place and never be shared. \nIt cannot be recovered once lost.
+CMD_GenX25519_ARGS			GenX25519
+CMD_GenX25519_PRIVATE_KEY	Private key: 
+CMD_GenX25519_PUBLIC_KEY	Public key: 
+
+
+# GetPublicX25519 command
+CMD_GetPublicX25519				Retrieve public X25519 key from a private one
+CMD_GetPublicX25519_Help		Use this if you have a private X25519 key and want to get its corresponding public key.
+CMD_GetPublicX25519_ARGS    	GetPublicX25519 [private]
+CMD_GetPublicX25519_[private]	The private X25519 key you want to get the corresponding public key of.
+CMD_GetPublicX25519_PRIVATE_KEY	Private key: 
+CMD_GetPublicX25519_PUBLIC_KEY	Public key: 
+
+
 # MakeCert command
 CMD_MakeCert			Create New X.509 Certificate and Private Key (1024 bit)
 CMD_MakeCert_Help		Use this to create a new X.509 certificate and private key and save it as a file. \nThe algorithm used to create the public key and private key of the certificate is RSA 1024 bit. \nYou can choose to create a root certificate (self-signed certificate) or a certificate signed by another certificate. To create a certificate that is signed by another certificate, you require a private key file (base 64 encoded) that is compatible with the certificate that uses the signature (X.509 format file). \n\nWhen creating a certificate, you can specify the following: Name (CN), Organization (O), Organization Unit (OU), Country (C), State (ST), Locale (L), Serial Number, and Expiration Date. \nThe created certificate will be saved as an X.509 format file and the private key file will be saved in a Base 64 encoded RSA 1024 bit format file. \n\nThe MakeCert command is a tool that provides the most rudimentary function for creating certificates. If you want to create a more substantial certificate, we recommend that you use either free software such as OpenSSL, or commercial CA (certificate authority) software. \n\nNote: This command can be called from the SoftEther VPN Command Line Management Utility. You can also execute this command while connected to the current VPN Server or VPN Client in Administration Mode but, what actually performs the RSA computation, generates the certificate data and saves it to file is the computer on which the command is running, and all this is executed in a context that has absolutely no relationship to the computer that is the destination of the Administration Mode connection.

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -7005,6 +7005,23 @@ CMD_RemoteDisable_Args		RemoteDisable
 ###################################################
 
 
+# GenX25519 命令
+CMD_GenX25519				Create new X25519 keypair
+CMD_GenX25519_Help			Use this to create a new X25519 keypair, which can be used for WireGuard. \nBoth the private and public key will be shown. \nThe public key can be shared and is used to identify a peer. \nAlso, it can always be retrieved from the private key using the GetPublicX25519 command. \nThe private key should be kept in a secure place and never be shared. \nIt cannot be recovered once lost.
+CMD_GenX25519_ARGS			GenX25519
+CMD_GenX25519_PRIVATE_KEY	Private key: 
+CMD_GenX25519_PUBLIC_KEY	Public key: 
+
+
+# GetPublicX25519 命令
+CMD_GetPublicX25519				Retrieve public X25519 key from a private one
+CMD_GetPublicX25519_Help		Use this if you have a private X25519 key and want to get its corresponding public key.
+CMD_GetPublicX25519_ARGS    	GetPublicX25519 [private]
+CMD_GetPublicX25519_[private]	The private X25519 key you want to get the corresponding public key of.
+CMD_GetPublicX25519_PRIVATE_KEY	Private key: 
+CMD_GetPublicX25519_PUBLIC_KEY	Public key: 
+
+
 # MakeCert 命令
 CMD_MakeCert				創建新的 X.509 證書和金鑰 (1024 位)
 CMD_MakeCert_Help			創建新的 X.509 證書和金鑰，將其保存為一個檔。\n證書公共金鑰和秘密金鑰的生成演算法使用 RSA 1024 位元。\n作為證書類型，可以創建由根證書 (自簽章憑證) 和其他證書簽名的某個證書。要創建由其他證書簽名的證書，需要與用於簽名的證書 (X.509格式檔) 相對應的金鑰檔 (Base 64 編碼)。\n\n創建的證書可以指定名稱 (CN)，所屬機構 (O)，組織單位 (OU)，國家 (C)，州 (ST)，當地 (L)，序號，有效期限。\n創建的證書以 X.509 格式的檔，金鑰檔以 RSA 1024 位元的 Base 64 編碼檔，被分別保存。\n\nMakeCert 指令是一個工具，它提供創建證書所需的最低功能。如果想創建一個真正的證書，建議使用 OpenSSL 等免費軟體和出售的 CA (認證機構) 軟體。\n\n※注意: 此指令可以從 SoftEther VPN 命令列管理工具調用。雖然目前以管理模式連接到 VPN Server 和 VPN Client 時可以運行，但要實際運行 RSA 演算，生成證書資料的，是運行此指令的電腦，和以管理模式連接的連結目的電腦沒有任何關係。

--- a/src/vpnbridge/CMakeLists.txt
+++ b/src/vpnbridge/CMakeLists.txt
@@ -29,7 +29,7 @@ set_target_properties(vpnbridge
   RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
-target_link_libraries(vpnbridge cedar mayaqua)
+target_link_libraries(vpnbridge cedar)
 
 if(UNIX)
   # Copy binary and "hamcore.se2" to /usr/lib(exec)/softether/, install launch script and systemd service

--- a/src/vpnclient/CMakeLists.txt
+++ b/src/vpnclient/CMakeLists.txt
@@ -29,7 +29,7 @@ set_target_properties(vpnclient
   RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
-target_link_libraries(vpnclient cedar mayaqua)
+target_link_libraries(vpnclient cedar)
 
 if(UNIX)
   # Copy binary and "hamcore.se2" to /usr/lib(exec)/softether/, install launch script and systemd service

--- a/src/vpncmd/CMakeLists.txt
+++ b/src/vpncmd/CMakeLists.txt
@@ -29,7 +29,7 @@ if(WIN32)
   )
 endif()
 
-target_link_libraries(vpncmd cedar mayaqua)
+target_link_libraries(vpncmd cedar)
 
 if(UNIX)
   # Copy binary and "hamcore.se2" to /usr/lib(exec)/softether/, install launch script

--- a/src/vpncmgr/CMakeLists.txt
+++ b/src/vpncmgr/CMakeLists.txt
@@ -26,4 +26,4 @@ set_target_properties(vpncmgr
   PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
-target_link_libraries(vpncmgr cedar mayaqua)
+target_link_libraries(vpncmgr cedar)

--- a/src/vpnserver/CMakeLists.txt
+++ b/src/vpnserver/CMakeLists.txt
@@ -29,7 +29,7 @@ set_target_properties(vpnserver
   RUNTIME_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
-target_link_libraries(vpnserver cedar mayaqua)
+target_link_libraries(vpnserver cedar)
 
 if(UNIX)
   # Copy binary and "hamcore.se2" to /usr/lib(exec)/softether/, install launch script and systemd service

--- a/src/vpnsetup/CMakeLists.txt
+++ b/src/vpnsetup/CMakeLists.txt
@@ -26,4 +26,4 @@ set_target_properties(vpnsetup
   PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
-target_link_libraries(vpnsetup cedar mayaqua)
+target_link_libraries(vpnsetup cedar)

--- a/src/vpnsmgr/CMakeLists.txt
+++ b/src/vpnsmgr/CMakeLists.txt
@@ -26,4 +26,4 @@ set_target_properties(vpnsmgr
   PDB_OUTPUT_DIRECTORY "${BUILD_DIRECTORY}"
 )
 
-target_link_libraries(vpnsmgr cedar mayaqua)
+target_link_libraries(vpnsmgr cedar)

--- a/src/vpntest/CMakeLists.txt
+++ b/src/vpntest/CMakeLists.txt
@@ -29,4 +29,4 @@ if(WIN32)
   )
 endif()
 
-target_link_libraries(vpntest cedar mayaqua)
+target_link_libraries(vpntest cedar)


### PR DESCRIPTION
```
VPN Tools>GenX25519
GenX25519 command - Create new X25519 keypair

Private key: yH1560qrKTC17VRDxvhrz90WjMn2YpyxbPXkSH1OknM=
Public key: vpiJEOy7KYzZjbMNb9ycGJJzOFST6Y3pToWRKHTMOFw=

The command completed successfully.

VPN Tools>GetPublicX25519
GetPublicX25519 command - Retrieve public X25519 key from a private one
Private key: yH1560qrKTC17VRDxvhrz90WjMn2YpyxbPXkSH1OknM=


Public key: vpiJEOy7KYzZjbMNb9ycGJJzOFST6Y3pToWRKHTMOFw=

The command completed successfully.

VPN Tools>GetPublicX25519 yH1560qrKTC17VRDxvhrz90WjMn2YpyxbPXkSH1OknM=
GetPublicX25519 command - Retrieve public X25519 key from a private one

Public key: vpiJEOy7KYzZjbMNb9ycGJJzOFST6Y3pToWRKHTMOFw=

The command completed successfully.

VPN Tools>
```

---

```
GenX25519 command - Create new X25519 keypair
Help for command "GenX25519"

Purpose:
  Create new X25519 keypair

Description:
  Use this to create a new X25519 keypair, which can be used for WireGuard.
  Both the private and public key will be shown.
  The public key can be shared and is used to identify a peer.
  Also, it can always be retrieved from the private key using the GetPublicX25519 command.
  The private key should be kept in a secure place and never be shared.
  It cannot be recovered once lost.

Usage:
  GenX25519
```


```
GetPublicX25519 command - Retrieve public X25519 key from a private one
Help for command "GetPublicX25519"

Purpose:
  Retrieve public X25519 key from a private one

Description:
  Use this if you have a private X25519 key and want to get its corresponding public key.

Usage:
  GetPublicX25519 [private]

Parameters:
  private - The private X25519 key you want to get the corresponding public key of.
```