### PR TITLE
Fix TCP and UDP listener behavior

### DIFF
--- a/src/Cedar/Listener.c
+++ b/src/Cedar/Listener.c
@@ -386,7 +386,14 @@ void ListenerTCPMainLoop(LISTENER *r)
 				}
 				else
 				{
-					s = ListenEx6(r->Port, r->LocalOnly);
+					if (r->Cedar->Server == NULL)
+					{
+						s = ListenEx6(r->Port, r->LocalOnly);
+					}
+					else
+					{
+						s = ListenEx63(r->Port, r->LocalOnly, false, &r->Cedar->Server->ListenIP);
+					}
 				}
 			}
 			else if (r->Protocol == LISTENER_INPROC)

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -1069,6 +1069,7 @@ SOCK *ListenEx(UINT port, bool local_only);
 SOCK *ListenEx2(UINT port, bool local_only, bool enable_ca, IP *listen_ip);
 SOCK *ListenEx6(UINT port, bool local_only);
 SOCK *ListenEx62(UINT port, bool local_only, bool enable_ca);
+SOCK *ListenEx63(UINT port, bool local_only, bool enable_ca, IP *listen_ip);
 SOCK *Accept(SOCK *sock);
 SOCK *Accept6(SOCK *sock);
 UINT Send(SOCK *sock, void *data, UINT size, bool secure);


### PR DESCRIPTION
### Problem

The listener function currently has these problems.
- TCP listener does not observe IPv6 `ListenIP`
- TCP listener always listens on `::` even `ListenIP` is set to a specific value
- UDP listener can't listen on both `0.0.0.0` and `::`
- L2TP/IPsec not working over IPv4 with default `ListenIP` config on dual-stack server

### Changes

This commit proposes these changes.
- Add ListenIP support to TCP listener in IPv6
- When ListenIP is set to either `0.0.0.0` or `::`, we will listen on the other address as well
  This special treatment is proposed due to backward compatibility consideration. (see below)

Now the problems above should be solved.

### Note

1. Backward compatibility
   At first I thought that we should treat `ListenIP 0.0.0.0` as IPv4 only and `ListenIP ::` as IPv6 only. If `ListenIP` is not present in the configuration, we listen on both.
   However, given the fact that most existing configuration files are already filled with a ListenIP value, doing this will cause malfunction.
   So I propose that we treat `0.0.0.0` and `::` as special cases where specifying one also includes the other.
   If we do need to separate them, additional switches might be added to do IPv4 or IPv6 only. (We do have a `DisableIPv6Listener` switch but it's troublesome.)

2. Conditional accept
   When we fire up a TCP listener in IPv4, we pass `EnableConditionalAccept` to `ListenEx2()` but we do not pass it in IPv6 case.
   I don't understand this but I just follow the current treatment in IPv6. Correct me if this should be changed.

---

﻿Changes proposed in this pull request:
 - Add ListenIP support to TCP listener in IPv6
 - Treat ListenIP value 0.0.0.0 and :: as the same

