### PR TITLE
Mayaqua/Network.c: Fix L2TP/IPsec over IPv6 when listening on ::

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -17632,10 +17632,10 @@ void UdpListenerThread(THREAD *thread, void *param)
 						UINT *port = LIST_DATA(u->PortList, j);
 						bool existing = false;
 
-						if (IsZeroIP(ip) && (IS_SPECIAL_PORT(*port)))
+						/*if (IsZeroIP(ip) && (IS_SPECIAL_PORT(*port)))
 						{
 							continue;
-						}
+						}*/
 
 
 						for (k = 0; k < LIST_NUM(u->SockList); k++)


### PR DESCRIPTION
Currently L2TP/IPsec connects over IPv6 only if the server listens on some interface. It does not work if `ListenIP` is `::`.
The probable reason is that zero IP with special ports (used by ESP, for example) are skipped in the listener thread.

I have tested on Win 10 client and now it works. However I am not sure why there is such check. Please correct me if it's improper.

Stable version does not have the issue since it creates listeners on every interface.

---

﻿Changes proposed in this pull request:
 - Comment out checking zero IP with special ports to restore L2TP/IPsec connectivity over IPv6

