### PR TITLE
Implement EAP-MSCHAPv2

### DIFF
--- a/src/Cedar/Proto_PPP.h
+++ b/src/Cedar/Proto_PPP.h
@@ -337,7 +337,7 @@ bool PPPSendEchoRequest(PPP_SESSION *p);
 bool PPPProcessResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
 bool PPPProcessLCPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
 bool PPPProcessCHAPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
-bool PPPProcessCHAPResponsePacketEx(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req, PPP_LCP *chap, bool eap);
+bool PPPProcessCHAPResponsePacketEx(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req, PPP_LCP *chap, bool use_eap);
 bool PPPProcessIPCPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
 bool PPPProcessEAPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
 bool PPPProcessIPv6CPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
@@ -377,8 +377,8 @@ PPP_OPTION *NewPPPOption(UCHAR type, void *data, UINT size);
 // Packet parse utilities
 PPP_PACKET *ParsePPPPacket(void *data, UINT size);
 PPP_LCP *PPPParseLCP(USHORT protocol, void *data, UINT size);
-bool PPPParseMSCHAP2ResponsePacket(PPP_SESSION *p, PPP_PACKET *req);
-bool PPPParseMSCHAP2ResponsePacketEx(PPP_SESSION *p, PPP_LCP *lcp);
+bool PPPParseMSCHAP2ResponsePacket(PPP_SESSION *p, PPP_PACKET *pp);
+bool PPPParseMSCHAP2ResponsePacketEx(PPP_SESSION *p, PPP_LCP *lcp, bool use_eap);
 // Packet building utilities
 BUF *BuildPPPPacketData(PPP_PACKET *pp);
 BUF *BuildLCPData(PPP_LCP *c);

--- a/src/Cedar/Proto_PPP.h
+++ b/src/Cedar/Proto_PPP.h
@@ -111,6 +111,7 @@
 #define	PPP_EAP_TYPE_NOTIFICATION		2
 #define	PPP_EAP_TYPE_NAK				3
 #define	PPP_EAP_TYPE_TLS				13
+#define	PPP_EAP_TYPE_MSCHAPV2			26
 
 // EAP-TLS Flags
 #define	PPP_EAP_TLS_FLAG_NONE			0
@@ -336,6 +337,7 @@ bool PPPSendEchoRequest(PPP_SESSION *p);
 bool PPPProcessResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
 bool PPPProcessLCPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
 bool PPPProcessCHAPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
+bool PPPProcessCHAPResponsePacketEx(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req, PPP_LCP *chap, bool eap);
 bool PPPProcessIPCPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
 bool PPPProcessEAPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
 bool PPPProcessIPv6CPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
@@ -376,6 +378,7 @@ PPP_OPTION *NewPPPOption(UCHAR type, void *data, UINT size);
 PPP_PACKET *ParsePPPPacket(void *data, UINT size);
 PPP_LCP *PPPParseLCP(USHORT protocol, void *data, UINT size);
 bool PPPParseMSCHAP2ResponsePacket(PPP_SESSION *p, PPP_PACKET *req);
+bool PPPParseMSCHAP2ResponsePacketEx(PPP_SESSION *p, PPP_LCP *lcp);
 // Packet building utilities
 BUF *BuildPPPPacketData(PPP_PACKET *pp);
 BUF *BuildLCPData(PPP_LCP *c);

--- a/src/Cedar/Radius.c
+++ b/src/Cedar/Radius.c
@@ -1069,7 +1069,8 @@ RADIUS_PACKET *EapSendPacketAndRecvResponse(EAP_CLIENT *e, RADIUS_PACKET *r)
 															is_finish = true;
 
 															Free(rp->Parse_EapMessage);
-															rp->Parse_EapMessage = Clone(e->PEAP_CurrentReceivingMsg->Buf, e->PEAP_CurrentReceivingMsg->Size);
+															rp->Parse_EapMessage = ZeroMalloc(sizeof(EAP_MESSAGE));
+															Copy(rp->Parse_EapMessage, e->PEAP_CurrentReceivingMsg->Buf, e->PEAP_CurrentReceivingMsg->Size);
 															rp->Parse_EapMessage_DataSize = e->PEAP_CurrentReceivingMsg->Size;
 														}
 													}
@@ -1508,7 +1509,8 @@ RADIUS_PACKET *ParseRadiusPacket(void *data, UINT size)
 				{
 					if (p->Parse_EapMessage == NULL)
 					{
-						EAP_MESSAGE *eap = Clone(a.Data, a.DataSize);
+						EAP_MESSAGE *eap = ZeroMalloc(sizeof(EAP_MESSAGE));
+						Copy(eap, a.Data, a.DataSize);
 
 						p->Parse_EapMessage_DataSize = sz_tmp;
 
@@ -1603,7 +1605,8 @@ RADIUS_PACKET *ParseRadiusPacket(void *data, UINT size)
 
 				p->Parse_EapMessage_DataSize = b->Size;
 				p->Parse_EapMessage_DataSize = MIN(p->Parse_EapMessage_DataSize, 1500);
-				p->Parse_EapMessage = Clone(b->Buf, p->Parse_EapMessage_DataSize);
+				p->Parse_EapMessage = ZeroMalloc(sizeof(EAP_MESSAGE));
+				Copy(p->Parse_EapMessage, b->Buf, p->Parse_EapMessage_DataSize);
 			}
 
 			FreeBuf(b);


### PR DESCRIPTION
Currently Windows built-in SSTP and L2TP client cannot connect out of the box because our EAP implementation only supports certificates.
This PR adds EAP-MSCHAPv2 password support and an ordinary user can connect without any hassle now.

The only thing I am not sure is double MSCHAPv2, apparently used in RADIUS. 
Edited: I did it in the second commit but I have no RADIUS environment to test. 

Tested with Win 10, Android SSTP Client, and of course, **iOS SSTP Connect**. 😁

Fix #1169
Fix #1253

---

﻿Changes proposed in this pull request:
 - Implement EAP-MSCHAPv2

