### PR TITLE
Fix use-after-free timeout issue for L2TP and SSTP

### DIFF
--- a/src/Cedar/Proto_L2TP.c
+++ b/src/Cedar/Proto_L2TP.c
@@ -2008,7 +2008,6 @@ UINT CalcL2TPMss(L2TP_SERVER *l2tp, L2TP_TUNNEL *t, L2TP_SESSION *s)
 // Start the L2TP thread
 void StartL2TPThread(L2TP_SERVER *l2tp, L2TP_TUNNEL *t, L2TP_SESSION *s)
 {
-	PPP_SESSION* underlyingSession;
 	// Validate arguments
 	if (l2tp == NULL || t == NULL || s == NULL)
 	{
@@ -2037,11 +2036,9 @@ void StartL2TPThread(L2TP_SERVER *l2tp, L2TP_TUNNEL *t, L2TP_SESSION *s)
 		}
 
 		// Create a PPP thread
-		underlyingSession = NewPPPSession(l2tp->Cedar, &t->ClientIp, t->ClientPort, &t->ServerIp, t->ServerPort,
+		s->Thread = NewPPPSession(l2tp->Cedar, &t->ClientIp, t->ClientPort, &t->ServerIp, t->ServerPort,
 			s->TubeSend, s->TubeRecv, L2TP_IPC_POSTFIX, tmp, t->HostName, l2tp->CryptName,
 			CalcL2TPMss(l2tp, t, s));
-		s->Thread = underlyingSession->SessionThread;
-		s->PPPSession = underlyingSession;
 	}
 }
 
@@ -2145,9 +2142,9 @@ void L2TPProcessInterrupts(L2TP_SERVER *l2tp)
 		{
 			L2TP_SESSION* s = LIST_DATA(t->SessionList, i);
 
-			if (s->PPPSession != NULL && s->PPPSession->DataTimeout > l2tpTimeout)
+			if (s->TubeRecv != NULL && s->TubeRecv->DataTimeout > l2tpTimeout)
 			{
-				l2tpTimeout = s->PPPSession->DataTimeout;
+				l2tpTimeout = s->TubeRecv->DataTimeout;
 			}
 		}
 

--- a/src/Cedar/Proto_L2TP.h
+++ b/src/Cedar/Proto_L2TP.h
@@ -171,7 +171,6 @@ struct L2TP_SESSION
 	UINT64 DisconnectTimeout;					// Disconnection completion time-out
 	bool HasThread;								// Whether have a thread
 	THREAD *Thread;								// Thread
-	PPP_SESSION* PPPSession;						// Underlying PPP session
 	TUBE *TubeSend;								// Tube of PPP to L2TP direction
 	TUBE *TubeRecv;								// Tube of L2TP to PPP direction
 	UINT PseudowireType;						// Type of L2TPv3 virtual line

--- a/src/Cedar/Proto_PPP.h
+++ b/src/Cedar/Proto_PPP.h
@@ -313,8 +313,6 @@ struct PPP_SESSION
 	UINT64 DataTimeout;
 	UINT64 UserConnectionTimeout;
 	UINT64 UserConnectionTick;
-
-	THREAD *SessionThread;				// Thread of the PPP session
 };
 
 
@@ -325,7 +323,7 @@ struct PPP_SESSION
 void PPPThread(THREAD *thread, void *param);
 
 // Entry point
-PPP_SESSION *NewPPPSession(CEDAR *cedar, IP *client_ip, UINT client_port, IP *server_ip, UINT server_port, TUBE *send_tube, TUBE *recv_tube, char *postfix, char *client_software_name, char *client_hostname, char *crypt_name, UINT adjust_mss);
+THREAD *NewPPPSession(CEDAR *cedar, IP *client_ip, UINT client_port, IP *server_ip, UINT server_port, TUBE *send_tube, TUBE *recv_tube, char *postfix, char *client_software_name, char *client_hostname, char *crypt_name, UINT adjust_mss);
 
 // PPP processing functions
 bool PPPRejectUnsupportedPacket(PPP_SESSION *p, PPP_PACKET *pp);

--- a/src/Cedar/Proto_SSTP.c
+++ b/src/Cedar/Proto_SSTP.c
@@ -275,8 +275,6 @@ void SstpProcessControlPacket(SSTP_SERVER *s, SSTP_PACKET *p)
 // Process the SSTP received data packet
 void SstpProcessDataPacket(SSTP_SERVER *s, SSTP_PACKET *p)
 {
-	PPP_SESSION *underlyingSession;
-
 	// Validate arguments
 	if (s == NULL || p == NULL || p->IsControl)
 	{
@@ -288,11 +286,9 @@ void SstpProcessDataPacket(SSTP_SERVER *s, SSTP_PACKET *p)
 	if (s->PPPThread == NULL)
 	{
 		// Create a thread to initialize the new PPP module
-		underlyingSession = NewPPPSession(s->Cedar, &s->ClientIp, s->ClientPort, &s->ServerIp, s->ServerPort,
+		s->PPPThread = NewPPPSession(s->Cedar, &s->ClientIp, s->ClientPort, &s->ServerIp, s->ServerPort,
 			s->TubeSend, s->TubeRecv, SSTP_IPC_POSTFIX, SSTP_IPC_CLIENT_NAME,
 			s->ClientHostName, s->ClientCipherName, 0);
-		s->PPPSession = underlyingSession;
-		s->PPPThread = underlyingSession->SessionThread;
 	}
 
 	// Pass the received data to the PPP module
@@ -444,9 +440,9 @@ void SstpProcessInterrupt(SSTP_SERVER *s)
 		}
 	}
 
-	if (s->PPPSession != NULL && s->PPPSession->DataTimeout > sstpTimeout)
+	if (s->TubeRecv != NULL && s->TubeRecv->DataTimeout > sstpTimeout)
 	{
-		sstpTimeout = s->PPPSession->DataTimeout;
+		sstpTimeout = s->TubeRecv->DataTimeout;
 	}
 
 	if ((s->LastRecvTick + sstpTimeout) <= s->Now)

--- a/src/Cedar/Proto_SSTP.h
+++ b/src/Cedar/Proto_SSTP.h
@@ -119,7 +119,6 @@ struct SSTP_SERVER
 	UINT64 LastRecvTick;					// Tick when some data has received at the end
 	bool FlushRecvTube;						// Flag whether to flush the reception tube
 	UINT EstablishedCount;					// Number of session establishment
-	PPP_SESSION *PPPSession;				// Underlying PPP Session
 };
 
 

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -16899,6 +16899,7 @@ TUBE *NewTube(UINT size_of_header)
 	t->SockEvent = NewSockEvent();
 
 	t->SizeOfHeader = size_of_header;
+	t->DataTimeout = 0;
 
 	return t;
 }

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -412,6 +412,7 @@ struct TUBE
 	bool IsInFlushList;					// Whether it is registered in the Tube Flush List
 	void *Param1, *Param2, *Param3;
 	UINT IntParam1, IntParam2, IntParam3;
+	UINT64 DataTimeout;
 };
 
 // Data that is to send and to receive in the tube


### PR DESCRIPTION
When a L2TP or SSTP session is terminated, use-after-free problem occurs very often, due to a insecure access to `DataTimeout` of a `PPP_SESSION` object.
This issue was introduced in https://github.com/SoftEtherVPN/SoftEtherVPN/commit/1bdd9a92bcd97b55d0863a01202d872e16c4b32d .

Before that commit, L2TP and SSTP sessions do not retain reference of `PPP_SESSION` directly because it is freed in Proto_PPP.
But in order to access the timeout value of the PPP session, a reference is retained and accessed in the interrupt process function.
Since the `PPPSession` object gets freed elsewhere, the current nullity check is useless:

https://github.com/SoftEtherVPN/SoftEtherVPN/blob/a2f30c8aadb544ff02a3eaaeb5dc7e4b518481b1/src/Cedar/Proto_SSTP.c#L447-L450

This fix reverts the practice and save the timeout in `TUBE` objects instead. The reason is that tubes are not freed on one end before the other end releases it:

https://github.com/SoftEtherVPN/SoftEtherVPN/blob/a2f30c8aadb544ff02a3eaaeb5dc7e4b518481b1/src/Mayaqua/Network.c#L16906-L16919

Currently only receive tube is used. If this approach makes sense, it can be expanded to do send / receive timeout separately.

I am no C expert and please do correct me if anything does not look right.

In addition to this issue, I also found that the timeout policy is only copied from IPC in PAP / MSCHAP authentication. It seems we forgot to do it in EAP-TLS. 
This is fixed as well.

---

﻿Changes proposed in this pull request:
 - Put timeout in tubes to fix use-after-free in L2TP and SSTP
 - Save timeout from IPC after EAP-TLS authentication

