### PR TITLE
Mayaqua/Network.c: Create UDP listener for every interface if ListenIP is wildcard

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -17620,7 +17620,7 @@ void UdpListenerThread(THREAD *thread, void *param)
 				{
 					IP *ip = LIST_DATA(iplist, i);
 
-					if (CmpIpAddr(ip, &u->ListenIP) != 0 && (!IsZeroIP(ip) || !IsZeroIP(&u->ListenIP)))
+					if (CmpIpAddr(ip, &u->ListenIP) != 0 && IsZeroIP(&u->ListenIP) == false)
 					{
 						continue;
 					}
@@ -17633,10 +17633,10 @@ void UdpListenerThread(THREAD *thread, void *param)
 						UINT *port = LIST_DATA(u->PortList, j);
 						bool existing = false;
 
-						/*if (IsZeroIP(ip) && (IS_SPECIAL_PORT(*port)))
+						if (IsZeroIP(ip) && (IS_SPECIAL_PORT(*port)))
 						{
 							continue;
-						}*/
+						}
 
 
 						for (k = 0; k < LIST_NUM(u->SockList); k++)


### PR DESCRIPTION
Due to the fact that one UDP socket is handling multiple sessions, if the bind address is wildcard, we can't get the actual local address as in TCP. Therefore the return packet's source address will be determined by the routing table. 

It usually works fine but may have issues in multi-interface environment. That is to say, a return packet may have source address different with the destination of the incoming packet, leading to problem in policy-based routing.

This might be one reason why the original version (before the introduction of `ListenIP`) binds UDP listener on every interface but TCP on wildcard only. (Yeah there must be a reason...)

This PR restores the orginal behavior if `ListenIP` is either `0.0.0.0` or `::`. 
Also the fix in #1417 is no longer needed and thus reverted. 
Tested L2TP over IPv4 and IPv6 with policy-based routing.

---

Changes proposed in this pull request:
 - Create UDP listener for every interface if ListenIP is wildcard
