### PR TITLE
Cedar/IPC.c: Add hub release in NewIPC()

### DIFF
--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -497,6 +497,8 @@ IPC *NewIPC(CEDAR *cedar, char *client_name, char *postfix, char *hubname, char 
 		ZeroIP4(&ipc->BroadcastAddress);
 	}
 
+	ReleaseHub(hub);
+
 	ZeroIP4(&ipc->ClientIPAddress);
 
 	MacToStr(macstr, sizeof(macstr), ipc->MacAddress);


### PR DESCRIPTION
Many of you might have noticed that since the implementation of Wireguard, the server cannot exit normally sometimes.
It turns out that the issue is not directly related to Wireguard, but due to a hub reference not released in `NewIPC()`. It affects all protocols that use IPC.

#1307

---

﻿Changes proposed in this pull request:
 - Fix hub release in NewIPC()

