### PR TITLE
Mayaqua/TcpIp.c: Fix building DHCP static routes in new format

### DIFF
--- a/src/Mayaqua/TcpIp.c
+++ b/src/Mayaqua/TcpIp.c
@@ -3846,7 +3846,7 @@ BUF *DhcpBuildClasslessRouteData(DHCP_CLASSLESS_ROUTE_TABLE *t)
 			// Number of significant octets
 			data_len = (r->SubnetMaskLen + 7) / 8;
 			Zero(tmp, sizeof(tmp));
-			Copy(tmp, &r->Network, data_len);
+			Copy(tmp, IPV4(r->Network.address), data_len);
 			WriteBuf(b, tmp, data_len);
 
 			// Gateway


### PR DESCRIPTION
Fix wire format of DHCP Classless Route Option after the refactor of IP.
Address #1399

---

﻿Changes proposed in this pull request:
 - Fix wire format of DHCP Classless Route Option

