### PR TITLE
make connection timeouts 2FA friendly (Featrue Request Issue #80)

### DIFF
--- a/src/Cedar/Cedar.h
+++ b/src/Cedar/Cedar.h
@@ -186,7 +186,7 @@
 #define	TIMEOUT_MIN					(5 * 1000)	// Minimum timeout in seconds
 #define	TIMEOUT_MAX					(60 * 1000)	// Maximum timeout in seconds
 #define	TIMEOUT_DEFAULT				(30 * 1000) // Default number of seconds to timeout
-#define	CONNECTING_TIMEOUT			(15 * 1000)	// Timeout in seconds of being connected
+#define	CONNECTING_TIMEOUT			(120 * 1000)	// Timeout in seconds of being connected, make it 2FA friendly
 #define	CONNECTING_POOLING_SPAN		(3 * 1000) // Polling interval of connected
 #define	MIN_RETRY_INTERVAL			(5 * 1000)		// Minimum retry interval
 #define	MAX_RETRY_INTERVAL			(300 * 1000)	// Maximum retry interval

--- a/src/Cedar/Radius.h
+++ b/src/Cedar/Radius.h
@@ -14,7 +14,7 @@
 
 #define	RADIUS_DEFAULT_PORT		1812			// The default port number
 #define	RADIUS_RETRY_INTERVAL	1000				// Retransmission interval
-#define	RADIUS_RETRY_TIMEOUT	(15 * 1000)		// Time-out period, keep it 2FA friendly
+#define	RADIUS_RETRY_TIMEOUT	(120 * 1000)		// Time-out period, make it 2FA friendly
 #define	RADIUS_INITIAL_EAP_TIMEOUT	1600		// Initial timeout for EAP
 
 

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -33,7 +33,7 @@ struct DYN_VALUE
 
 #define	TIMEOUT_INFINITE			(0x7fffffff)
 #define	TIMEOUT_TCP_PORT_CHECK		(10 * 1000)
-#define	TIMEOUT_SSL_CONNECT			(15 * 1000)
+#define	TIMEOUT_SSL_CONNECT			(120 * 1000) //make it 2FA friendly
 
 #define	TIMEOUT_NETBIOS_HOSTNAME	(100)
 
@@ -821,7 +821,7 @@ struct CONNECT_TCP_RUDP_PARAM
 	bool Tcp_InNegotiation;
 };
 
-#define	SSL_DEFAULT_CONNECT_TIMEOUT		(15 * 1000)		// SSL default timeout
+#define	SSL_DEFAULT_CONNECT_TIMEOUT		(120 * 1000)		// SSL default timeout, make it 2FA friendly
 
 // Header for TCP Pair
 struct TCP_PAIR_HEADER


### PR DESCRIPTION
Changes proposed in this pull request:
 - change timeout values to make them really 2FA/MFA friendly
 - tested with Windows 10 SSTP client (after registry modification)
 - tested with AzureMFA Plugin on Windows 2016 NPS Server

