### PR TITLE
Mayaqua/Network.c: Fix race condition in TUBE operation

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -16732,8 +16732,12 @@ bool TubeSendEx2(TUBE *t, void *data, UINT size, void *header, bool no_flush, UI
 
 	if (no_flush == false)
 	{
-		Set(t->Event);
-		SetSockEvent(t->SockEvent);
+		Lock(t->Lock);
+		{
+			Set(t->Event);
+			SetSockEvent(t->SockEvent);
+		}
+		Unlock(t->Lock);
 	}
 
 	return true;
@@ -16765,8 +16769,12 @@ void TubeFlushEx(TUBE *t, bool force)
 		}
 	}
 
-	Set(t->Event);
-	SetSockEvent(t->SockEvent);
+	Lock(t->Lock);
+	{
+		Set(t->Event);
+		SetSockEvent(t->SockEvent);
+	}
+	Unlock(t->Lock);
 }
 
 // Receive the data from the tube (asynchronous)


### PR DESCRIPTION
As discussed in https://github.com/SoftEtherVPN/SoftEtherVPN/issues/1436 , there is race condition between the two ends of a `TUBE` object.

One end sends an IPC packet to tube and flushes it:
https://github.com/SoftEtherVPN/SoftEtherVPN/blob/bf14817f1f09f8b8107b13add08f483ad99abb7c/src/Cedar/Connection.c#L1295-L1313

The flush operation races with the receive end (OpenVPN server) calling `IPCSetSockEventWhenRecvL2Packet` and eventually `SetTubeSockEvent`.
https://github.com/SoftEtherVPN/SoftEtherVPN/blob/bf14817f1f09f8b8107b13add08f483ad99abb7c/src/Cedar/Proto_OpenVPN.c#L2530-L2542

There is tube locking mechanism in `SetTubeSockEvent` but not in `TubeSendEx2` and `TubeFlushEx`.

---

﻿Changes proposed in this pull request:
 - Fix race condition in TUBE operation

