### PR TITLE
BUILD: use rpath for locating dynamic libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,12 @@ endif()
 if(UNIX)
   include(GNUInstallDirs)
 
+  #
+  # use rpath for locating installed libraries
+  #
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
   include(CheckIncludeFile)
   Check_Include_File(sys/auxv.h HAVE_SYS_AUXV)
   if(EXISTS "/lib/systemd/system")


### PR DESCRIPTION
@davidebeatrici , can you have a look please ?

this "works for me", however, I'm not sure I'm following best practices. I'm bit lost in various rpath/runpath options of CMake
