### PR TITLE
Password change from client increments config file revision

### DIFF
--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -940,6 +940,7 @@ UINT ChangePasswordAccept(CONNECTION *c, PACK *p)
 								{
 									Copy(pw->HashedKey, new_password, SHA1_SIZE);
 									Copy(pw->NtLmSecureHash, new_password_ntlm, MD5_SIZE);
+									IncrementServerConfigRevision(cedar->Server);
 								}
 								HLog(hub, "LH_CHANGE_PASSWORD_5", c->Name, username);
 							}


### PR DESCRIPTION
Changes proposed in this pull request:
 - Fixed an issue where changing the password from the client did not increment the revision of the server config file and the changes were not saved

https://www.vpnusers.com/viewtopic.php?f=15&t=67107
