### PR TITLE
Fix auto refreshing of client manager

### DIFF
--- a/src/Cedar/CM.c
+++ b/src/Cedar/CM.c
@@ -5450,8 +5450,6 @@ void CmMainWindowOnCommandEx(HWND hWnd, WPARAM wParam, LPARAM lParam, bool easy)
 			CmStopUacHelper(helper);
 
 			Free(name);
-
-			CmRefresh(hWnd);
 		}
 		break;
 	case CMD_DELETE_VLAN:
@@ -5480,8 +5478,6 @@ void CmMainWindowOnCommandEx(HWND hWnd, WPARAM wParam, LPARAM lParam, bool easy)
 				}
 				Free(s);
 			}
-
-			CmRefresh(hWnd);
 		}
 		break;
 	case CMD_ENABLE_VLAN:
@@ -5501,8 +5497,6 @@ void CmMainWindowOnCommandEx(HWND hWnd, WPARAM wParam, LPARAM lParam, bool easy)
 					CALL(hWnd, CcEnableVLan(cm->Client, &c));
 				}
 				Free(s);
-
-				CmRefresh(hWnd);
 			}
 		}
 		break;
@@ -5523,8 +5517,6 @@ void CmMainWindowOnCommandEx(HWND hWnd, WPARAM wParam, LPARAM lParam, bool easy)
 					CALL(hWnd, CcDisableVLan(cm->Client, &c));
 				}
 				Free(s);
-
-				CmRefresh(hWnd);
 			}
 		}
 		break;
@@ -5560,8 +5552,6 @@ void CmMainWindowOnCommandEx(HWND hWnd, WPARAM wParam, LPARAM lParam, bool easy)
 					CmStopUacHelper(helper);
 				}
 				Free(s);
-
-				CmRefresh(hWnd);
 			}
 		}
 		break;

--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -5410,7 +5410,7 @@ NOTIFY_CLIENT *CcConnectNotify(REMOTE_CLIENT *rc)
 	NOTIFY_CLIENT *n;
 	SOCK *s;
 	char tmp[MAX_SIZE];
-	bool rpc_mode = false;
+	UINT rpc_mode = 0;
 	UINT port;
 	// Validate arguments
 	if (rc == NULL || rc->Rpc == NULL || rc->Rpc->Sock == NULL)


### PR DESCRIPTION
Now Windows client manager properly refreshes when connection status changes, new adapter is added etc.

It seems to also fix #1444, which is unexpected.