### PR TITLE
Change default hub option to allow default router in IPv6 RA

### DIFF
--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -2320,7 +2320,7 @@ void SiSetDefaultHubOption(HUB_OPTION *o)
 	o->DefaultSubnet = SetIP32(255, 255, 255, 0);
 	o->MaxSession = 0;
 	o->VlanTypeId = MAC_PROTO_TAGVLAN;
-	o->NoIPv6DefaultRouterInRAWhenIPv6 = true;
+	o->NoIPv6DefaultRouterInRAWhenIPv6 = false;
 	o->ManageOnlyPrivateIP = true;
 	o->ManageOnlyLocalUnicastIPv6 = true;
 	o->NoMacAddressLog = true;


### PR DESCRIPTION
Hub option `NoIPv6DefaultRouterInRAWhenIPv6` controls whether the remote IPv6 default route is honored when the connection is made via IPv6. 
Since we didn't manage IPv6 routes in Client Manager before #1443, this option is defaulted to true to prevent the accidental override of the local IPv6 routes by the remote ones.

And now we have the feature, it's time to revert the default value to false, in order to allow remote IPv6 gateways to work. 
Otherwise users may find it strange that they can't route Internet traffic over IPv6 in the same way as IPv4.

Fix #1163
