### PR TITLE
Fix DNS resolution when no IPv6 address is configured on any interface

### DIFF
--- a/src/Mayaqua/DNS.c
+++ b/src/Mayaqua/DNS.c
@@ -405,8 +405,16 @@ void DnsResolver(THREAD *t, void *param)
 	struct addrinfo hints;
 	Zero(&hints, sizeof(hints));
 
-	hints.ai_family = AF_INET6;
-	hints.ai_flags = AI_ALL | AI_ADDRCONFIG | AI_V4MAPPED;
+	if (HasIPv6Address())
+	{
+		hints.ai_family = AF_INET6;
+		hints.ai_flags = AI_ALL | AI_ADDRCONFIG | AI_V4MAPPED;
+	}
+	else
+	{
+		hints.ai_family = AF_INET;
+		hints.ai_flags = AI_ADDRCONFIG;
+	}
 
 	struct addrinfo *results;
 	const int ret = getaddrinfo(resolver->Hostname, NULL, &hints, &results);
@@ -417,18 +425,31 @@ void DnsResolver(THREAD *t, void *param)
 		for (struct addrinfo *result = results; result != NULL; result = result->ai_next)
 		{
 			IP ip;
-			const struct sockaddr_in6 *in = (struct sockaddr_in6 *)result->ai_addr;
-			InAddrToIP6(&ip, &in->sin6_addr);
-			if (IsIP6(&ip) && ipv6_ok == false)
+			if (hints.ai_family == AF_INET6)
 			{
-				Copy(&resolver->IPv6, &ip, sizeof(resolver->IPv6));
-				resolver->IPv6.ipv6_scope_id = in->sin6_scope_id;
-				ipv6_ok = true;
+				const struct sockaddr_in6 *in = (struct sockaddr_in6 *)result->ai_addr;
+				InAddrToIP6(&ip, &in->sin6_addr);
+				if (IsIP6(&ip) && ipv6_ok == false)
+				{
+					Copy(&resolver->IPv6, &ip, sizeof(resolver->IPv6));
+					resolver->IPv6.ipv6_scope_id = in->sin6_scope_id;
+					ipv6_ok = true;
+				}
+				else if (IsIP4(&ip) && ipv4_ok == false)
+				{
+					Copy(&resolver->IPv4, &ip, sizeof(resolver->IPv4));
+					ipv4_ok = true;
+				}
 			}
-			else if (IsIP4(&ip) && ipv4_ok == false)
+			else
 			{
-				Copy(&resolver->IPv4, &ip, sizeof(resolver->IPv4));
-				ipv4_ok = true;
+				const struct sockaddr_in *in = (struct sockaddr_in *)result->ai_addr;
+				InAddrToIP(&ip, &in->sin_addr);
+				if (IsIP4(&ip) && ipv4_ok == false)
+				{
+					Copy(&resolver->IPv4, &ip, sizeof(resolver->IPv4));
+					ipv4_ok = true;
+				}
 			}
 		}
 

--- a/src/Mayaqua/DNS.c
+++ b/src/Mayaqua/DNS.c
@@ -413,7 +413,6 @@ void DnsResolver(THREAD *t, void *param)
 	else
 	{
 		hints.ai_family = AF_INET;
-		hints.ai_flags = AI_ADDRCONFIG;
 	}
 
 	struct addrinfo *results;
@@ -434,21 +433,30 @@ void DnsResolver(THREAD *t, void *param)
 					Copy(&resolver->IPv6, &ip, sizeof(resolver->IPv6));
 					resolver->IPv6.ipv6_scope_id = in->sin6_scope_id;
 					ipv6_ok = true;
+					if (ipv4_ok)
+					{
+						break;
+					}
 				}
 				else if (IsIP4(&ip) && ipv4_ok == false)
 				{
 					Copy(&resolver->IPv4, &ip, sizeof(resolver->IPv4));
 					ipv4_ok = true;
+					if (ipv6_ok)
+					{
+						break;
+					}
 				}
 			}
 			else
 			{
 				const struct sockaddr_in *in = (struct sockaddr_in *)result->ai_addr;
 				InAddrToIP(&ip, &in->sin_addr);
-				if (IsIP4(&ip) && ipv4_ok == false)
+				if (IsIP4(&ip))
 				{
 					Copy(&resolver->IPv4, &ip, sizeof(resolver->IPv4));
 					ipv4_ok = true;
+					break;
 				}
 			}
 		}

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -9871,6 +9871,36 @@ bool IsIPv6Supported()
 #endif	// NO_IPV6
 }
 
+// Check whether an IPv6 address is configured on any interface
+bool HasIPv6Address()
+{
+	LIST *o;
+	UINT i;
+	bool ret = false;
+
+	o = GetHostIPAddressList();
+
+	ret = false;
+
+	for (i = 0; i < LIST_NUM(o); i++)
+	{
+		IP *p = LIST_DATA(o, i);
+
+		if (IsIP6(p))
+		{
+			UINT type = GetIPAddrType6(p);
+			if ((type & IPV6_ADDR_GLOBAL_UNICAST) && ((type & IPV6_ADDR_ZERO) == 0) && ((type & IPV6_ADDR_LOOPBACK) == 0))
+			{
+				ret = true;
+			}
+		}
+	}
+
+	FreeHostIPAddressList(o);
+
+	return ret;
+}
+
 // Add the thread to the thread waiting list
 void AddWaitThread(THREAD *t)
 {

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -9892,7 +9892,9 @@ bool HasIPv6Address()
 			if ((type & IPV6_ADDR_GLOBAL_UNICAST) && ((type & IPV6_ADDR_ZERO) == 0) && ((type & IPV6_ADDR_LOOPBACK) == 0))
 			{
 				ret = true;
+				break;
 			}
+
 		}
 	}
 

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -1164,6 +1164,7 @@ SOCKLIST *NewSockList();
 void StopSockList(SOCKLIST *sl);
 void FreeSockList(SOCKLIST *sl);
 bool IsIPv6Supported();
+bool HasIPv6Address();
 void SetSockTos(SOCK *s, int tos);
 void SetSockHighPriority(SOCK *s, bool flag);
 void InitIpClientList();


### PR DESCRIPTION
Our current DNS resolver requests IPv4-mapped IPv6 addresses from the system resolver. It aims to get both IPv4 and IPv6 addresses in a single run. 
However on hosts where no IPv6 address is configured (including local unicast addresses), IPv4 results will not be returned due to flag option `AI_ADDRCONFIG`.
This PR detects the existence of IPv6 addresses and requests IPv4 result only if not detected.

Fix #1428 