### PR TITLE
Fix IPv6 address display in session info dialog

### DIFF
--- a/src/Cedar/Command.c
+++ b/src/Cedar/Command.c
@@ -18969,7 +18969,7 @@ UINT PsSessionGet(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 		char str[MAX_SIZE];
 		CT *ct = CtNewStandard();
 
-		if (t.ClientIp != 0)
+		if (t.ClientIp != 0 || IsZero(t.ClientIp6, sizeof(t.ClientIp6)) == false)
 		{
 			IPToStr4or6(str, sizeof(str), t.ClientIp, t.ClientIp6);
 			StrToUni(tmp, sizeof(tmp), str);

--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -9614,7 +9614,7 @@ bool SmRefreshSessionStatus(HWND hWnd, SM_SERVER *s, void *param)
 
 	b = LvInsertStart();
 
-	if (t.ClientIp != 0)
+	if (t.ClientIp != 0 || IsZero(t.ClientIp6, sizeof(t.ClientIp6)) == false)
 	{
 		IPToStr4or6(str, sizeof(str), t.ClientIp, t.ClientIp6);
 		StrToUni(tmp, sizeof(tmp), str);

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -14861,7 +14861,7 @@ SOCK *NewSock()
 UINT IPToUINT(IP *ip)
 {
 	// Validate arguments
-	if (ip == NULL)
+	if (ip == NULL || IsIP6(ip))
 	{
 		return 0;
 	}


### PR DESCRIPTION
`IPToUINT(IP*)` is supposed to work on IPv4 addresses only but currently does not check the type of the input address. This leads to random outcome on IPv6 input and corrupts session info display like the one below.

```
Item                                      |Value
------------------------------------------+-------------------------------------------------------------
Client IP Address                         |61.84.206.189
Client Host Name                          |2600:1f13:559:8f00:6604:c537:3d54:cebd
```

This PR fixes both vpncmd and the server manager.