### PR TITLE
Separate NAT-T hint string from hostname internally

### DIFF
--- a/src/Cedar/CM.c
+++ b/src/Cedar/CM.c
@@ -6649,6 +6649,7 @@ void CmEditAccountDlgUpdate(HWND hWnd, CM_ACCOUNT *a)
 	// Host name
 	GetTxtA(hWnd, E_HOSTNAME, a->ClientOption->Hostname, sizeof(a->ClientOption->Hostname));
 	Trim(a->ClientOption->Hostname);
+	a->ClientOption->HintStr[0] = 0;
 
 	if (InStr(a->ClientOption->Hostname, "/tcp"))
 	{
@@ -7091,10 +7092,17 @@ void CmEditAccountDlgInit(HWND hWnd, CM_ACCOUNT *a)
 	SetText(hWnd, E_ACCOUNT_NAME, a->ClientOption->AccountName);
 
 	// Host name
-	SetTextA(hWnd, E_HOSTNAME, a->ClientOption->Hostname);
-	StrCpy(a->old_server_name, sizeof(a->old_server_name), a->ClientOption->Hostname);
+	char hostname[MAX_SIZE];
+	StrCpy(hostname, sizeof(hostname), a->ClientOption->Hostname);
+	if (IsEmptyStr(a->ClientOption->HintStr) == false)
+	{
+		StrCat(hostname, sizeof(hostname), "/");
+		StrCat(hostname, sizeof(hostname), a->ClientOption->HintStr);
+	}
+	SetTextA(hWnd, E_HOSTNAME, hostname);
+	StrCpy(a->old_server_name, sizeof(a->old_server_name), hostname);
 
-	if (InStr(a->ClientOption->Hostname, "/tcp"))
+	if (InStr(hostname, "/tcp"))
 	{
 		Check(hWnd, R_DISABLE_NATT, true);
 	}

--- a/src/Cedar/Command.c
+++ b/src/Cedar/Command.c
@@ -2071,7 +2071,7 @@ void TtcThread(THREAD *thread, void *param)
 			IPToStr(target_host, sizeof(target_host), &ip_ret);
 		}
 
-		s = ConnectEx4(target_host, ttc->Port, 0, ttc->Cancel, NULL, NULL, false, true, &ip_ret);
+		s = ConnectEx4(target_host, ttc->Port, 0, ttc->Cancel, NULL, NULL, false, true, NULL, &ip_ret);
 
 		if (s == NULL)
 		{
@@ -4333,6 +4333,7 @@ UINT PcAccountSet(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 		// Success
 		t.ClientOption->Port = port;
 		StrCpy(t.ClientOption->Hostname, sizeof(t.ClientOption->Hostname), host);
+		t.ClientOption->HintStr[0] = 0;
 		StrCpy(t.ClientOption->HubName, sizeof(t.ClientOption->HubName), GetParamStr(o, "HUB"));
 
 		Zero(&c, sizeof(c));
@@ -4400,7 +4401,18 @@ UINT PcAccountGet(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 		CtInsert(ct, _UU("CMD_ACCOUNT_COLUMN_NAME"), t.ClientOption->AccountName);
 
 		// Host name of the destination VPN Server
-		StrToUni(tmp, sizeof(tmp), t.ClientOption->Hostname);
+		if (IsEmptyStr(t.ClientOption->HintStr))
+		{
+			StrToUni(tmp, sizeof(tmp), t.ClientOption->Hostname);
+		}
+		else
+		{
+			char hostname[MAX_SIZE];
+			StrCpy(hostname, sizeof(hostname), t.ClientOption->Hostname);
+			StrCat(hostname, sizeof(hostname), "/");
+			StrCat(hostname, sizeof(hostname), t.ClientOption->HintStr);
+			StrToUni(tmp, sizeof(tmp), hostname);
+		}
 		CtInsert(ct, _UU("CMD_ACCOUNT_COLUMN_HOSTNAME"), tmp);
 
 		// The port number to connect to VPN Server
@@ -13117,6 +13129,7 @@ UINT PsCascadeSet(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 
 	t.ClientOption->Port = port;
 	StrCpy(t.ClientOption->Hostname, sizeof(t.ClientOption->Hostname), host);
+	t.ClientOption->HintStr[0] = 0;
 	StrCpy(t.ClientOption->HubName, sizeof(t.ClientOption->HubName), GetParamStr(o, "HUB"));
 
 	Free(host);
@@ -13223,7 +13236,18 @@ UINT PsCascadeGet(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 		CtInsert(ct, _UU("CMD_ACCOUNT_COLUMN_NAME"), t.ClientOption->AccountName);
 
 		// Host name of the destination VPN Server
-		StrToUni(tmp, sizeof(tmp), t.ClientOption->Hostname);
+		if (IsEmptyStr(t.ClientOption->HintStr))
+		{
+			StrToUni(tmp, sizeof(tmp), t.ClientOption->Hostname);
+		}
+		else
+		{
+			char hostname[MAX_SIZE];
+			StrCpy(hostname, sizeof(hostname), t.ClientOption->Hostname);
+			StrCat(hostname, sizeof(hostname), "/");
+			StrCat(hostname, sizeof(hostname), t.ClientOption->HintStr);
+			StrToUni(tmp, sizeof(tmp), hostname);
+		}
 		CtInsert(ct, _UU("CMD_ACCOUNT_COLUMN_HOSTNAME"), tmp);
 
 		// The port number to connect to VPN Server

--- a/src/Cedar/Connection.h
+++ b/src/Cedar/Connection.h
@@ -64,6 +64,7 @@ struct CLIENT_OPTION
 {
 	wchar_t AccountName[MAX_ACCOUNT_NAME_LEN + 1];			// Connection setting name
 	char Hostname[MAX_HOST_NAME_LEN + 1];					// Host name
+	char HintStr[MAX_HOST_NAME_LEN + 1];					// Hint string for NAT-T
 	UINT Port;												// Port number
 	UINT PortUDP;											// UDP port number (0: Use only TCP)
 	UINT ProxyType;											// Type of proxy

--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -6308,7 +6308,7 @@ SOCK *ClientConnectGetSocket(CONNECTION *c, bool additional_connect)
 			// If additional_connect == true, follow the IsRUDPSession setting in this session
 			sock = TcpIpConnectEx(hostname, c->ServerPort,
 				(bool *)cancel_flag, c->hWndForUI, &nat_t_err, (additional_connect ? (!sess->IsRUDPSession) : false),
-				true, &resolved_ip);
+				true, o->HintStr, &resolved_ip);
 		}
 		else
 		{
@@ -6443,24 +6443,24 @@ UINT ProxyCodeToCedar(UINT code)
 }
 
 // TCP connection function
-SOCK *TcpConnectEx3(char *hostname, UINT port, UINT timeout, bool *cancel_flag, void *hWnd, bool no_nat_t, UINT *nat_t_error_code, bool try_start_ssl, IP *ret_ip)
+SOCK *TcpConnectEx3(char *hostname, UINT port, UINT timeout, bool *cancel_flag, void *hWnd, bool no_nat_t, UINT *nat_t_error_code, bool try_start_ssl, char *hint_str, IP *ret_ip)
 {
 #ifdef	OS_WIN32
 	if (hWnd == NULL)
 	{
 #endif	// OS_WIN32
-		return ConnectEx4(hostname, port, timeout, cancel_flag, (no_nat_t ? NULL : VPN_RUDP_SVC_NAME), nat_t_error_code, try_start_ssl, true, ret_ip);
+		return ConnectEx4(hostname, port, timeout, cancel_flag, (no_nat_t ? NULL : VPN_RUDP_SVC_NAME), nat_t_error_code, try_start_ssl, true, hint_str, ret_ip);
 #ifdef	OS_WIN32
 	}
 	else
 	{
-		return WinConnectEx3((HWND)hWnd, hostname, port, timeout, 0, NULL, NULL, nat_t_error_code, (no_nat_t ? NULL : VPN_RUDP_SVC_NAME), try_start_ssl);
+		return WinConnectEx3((HWND)hWnd, hostname, port, timeout, 0, NULL, NULL, nat_t_error_code, (no_nat_t ? NULL : VPN_RUDP_SVC_NAME), try_start_ssl, hint_str);
 	}
 #endif	// OS_WIN32
 }
 
 // Connect with TCP/IP
-SOCK *TcpIpConnectEx(char *hostname, UINT port, bool *cancel_flag, void *hWnd, UINT *nat_t_error_code, bool no_nat_t, bool try_start_ssl, IP *ret_ip)
+SOCK *TcpIpConnectEx(char *hostname, UINT port, bool *cancel_flag, void *hWnd, UINT *nat_t_error_code, bool no_nat_t, bool try_start_ssl, char *hint_str, IP *ret_ip)
 {
 	SOCK *s = NULL;
 	UINT dummy_int = 0;
@@ -6475,7 +6475,7 @@ SOCK *TcpIpConnectEx(char *hostname, UINT port, bool *cancel_flag, void *hWnd, U
 		return NULL;
 	}
 
-	s = TcpConnectEx3(hostname, port, 0, cancel_flag, hWnd, no_nat_t, nat_t_error_code, try_start_ssl, ret_ip);
+	s = TcpConnectEx3(hostname, port, 0, cancel_flag, hWnd, no_nat_t, nat_t_error_code, try_start_ssl, hint_str, ret_ip);
 	if (s == NULL)
 	{
 		return NULL;

--- a/src/Cedar/Protocol.h
+++ b/src/Cedar/Protocol.h
@@ -113,14 +113,14 @@ UINT64 ShortStrToDate64(char *str);
 bool ServerAccept(CONNECTION *c);
 bool ClientConnect(CONNECTION *c);
 SOCK *ClientConnectToServer(CONNECTION *c);
-SOCK *TcpIpConnectEx(char *hostname, UINT port, bool *cancel_flag, void *hWnd, UINT *nat_t_error_code, bool no_nat_t, bool try_start_ssl, IP *ret_ip);
+SOCK *TcpIpConnectEx(char *hostname, UINT port, bool *cancel_flag, void *hWnd, UINT *nat_t_error_code, bool no_nat_t, bool try_start_ssl, char *hint_str, IP *ret_ip);
 bool ClientUploadSignature(SOCK *s);
 bool ClientDownloadHello(CONNECTION *c, SOCK *s);
 bool ServerDownloadSignature(CONNECTION *c, char **error_detail_str);
 bool ServerUploadHello(CONNECTION *c);
 bool ClientUploadAuth(CONNECTION *c);
 SOCK *ClientConnectGetSocket(CONNECTION *c, bool additional_connect);
-SOCK *TcpConnectEx3(char *hostname, UINT port, UINT timeout, bool *cancel_flag, void *hWnd, bool no_nat_t, UINT *nat_t_error_code, bool try_start_ssl, IP *ret_ip);
+SOCK *TcpConnectEx3(char *hostname, UINT port, UINT timeout, bool *cancel_flag, void *hWnd, bool no_nat_t, UINT *nat_t_error_code, bool try_start_ssl, char *hint_str, IP *ret_ip);
 
 UINT ProxyCodeToCedar(UINT code);
 

--- a/src/Cedar/WinUi.c
+++ b/src/Cedar/WinUi.c
@@ -1329,7 +1329,7 @@ void WinConnectDlgThread(THREAD *thread, void *param)
 		nat_t_svc_name = d->nat_t_svc_name;
 	}
 
-	s = ConnectEx3(d->hostname, d->port, d->timeout, &d->cancel, nat_t_svc_name, &nat_t_error_code, d->try_start_ssl, false);
+	s = ConnectEx4(d->hostname, d->port, d->timeout, &d->cancel, nat_t_svc_name, &nat_t_error_code, d->try_start_ssl, false, d->hint_str, NULL);
 
 	d->ret_sock = s;
 	d->nat_t_error_code = nat_t_error_code;
@@ -1397,7 +1397,7 @@ UINT WinConnectDlgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, void *
 }
 
 // TCP connection with showing the UI
-SOCK *WinConnectEx3(HWND hWnd, char *server, UINT port, UINT timeout, UINT icon_id, wchar_t *caption, wchar_t *info, UINT *nat_t_error_code, char *nat_t_svc_name, bool try_start_ssl)
+SOCK *WinConnectEx3(HWND hWnd, char *server, UINT port, UINT timeout, UINT icon_id, wchar_t *caption, wchar_t *info, UINT *nat_t_error_code, char *nat_t_svc_name, bool try_start_ssl, char *hint_str)
 {
 	wchar_t tmp[MAX_SIZE];
 	wchar_t tmp2[MAX_SIZE];
@@ -1440,6 +1440,7 @@ SOCK *WinConnectEx3(HWND hWnd, char *server, UINT port, UINT timeout, UINT icon_
 	d.timeout = timeout;
 	d.hostname = server;
 	d.port = port;
+	d.hint_str = hint_str;
 	StrCpy(d.nat_t_svc_name, sizeof(d.nat_t_svc_name), nat_t_svc_name);
 
 	Dialog(hWnd, D_CONNECT, WinConnectDlgProc, &d);

--- a/src/Cedar/WinUi.h
+++ b/src/Cedar/WinUi.h
@@ -331,6 +331,7 @@ typedef struct WINCONNECT_DLG_DATA
 	char nat_t_svc_name[MAX_SIZE];
 	UINT nat_t_error_code;
 	bool try_start_ssl;
+	char *hint_str;
 } WINCONNECT_DLG_DATA;
 
 HBITMAP ResizeBitmap(HBITMAP hSrc, UINT src_x, UINT src_y, UINT dst_x, UINT dst_y);
@@ -693,7 +694,7 @@ HFONT GetMeiryoFont();
 HFONT GetMeiryoFontEx(UINT font_size);
 HFONT GetMeiryoFontEx2(UINT font_size, bool bold);
 bool ShowWindowsNetworkConnectionDialog();
-SOCK *WinConnectEx3(HWND hWnd, char *server, UINT port, UINT timeout, UINT icon_id, wchar_t *caption, wchar_t *info, UINT *nat_t_error_code, char *nat_t_svc_name, bool try_start_ssl);
+SOCK *WinConnectEx3(HWND hWnd, char *server, UINT port, UINT timeout, UINT icon_id, wchar_t *caption, wchar_t *info, UINT *nat_t_error_code, char *nat_t_svc_name, bool try_start_ssl, char *hint_str);
 UINT WinConnectDlgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, void *param);
 void WinConnectDlgThread(THREAD *thread, void *param);
 void NicInfo(UI_NICINFO *info);

--- a/src/Cedar/Wpc.c
+++ b/src/Cedar/Wpc.c
@@ -524,7 +524,7 @@ SOCK *WpcSockConnectEx(WPC_CONNECT *param, UINT *error_code, UINT timeout, bool 
 
 	if (param->ProxyType == PROXY_DIRECT)
 	{
-		sock = TcpConnectEx3(param->HostName, param->Port, timeout, cancel, NULL, true, NULL, false, NULL);
+		sock = TcpConnectEx3(param->HostName, param->Port, timeout, cancel, NULL, true, NULL, false, NULL, NULL);
 		*error_code = (sock != NULL ? ERR_NO_ERROR : ERR_CONNECT_FAILED);
 		return sock;
 	}
@@ -711,7 +711,7 @@ BUF *HttpRequestEx3(URL_DATA *data, INTERNET_SETTING *setting,
 	else
 	{
 		// If the connection is not SSL via HTTP Proxy
-		s = TcpConnectEx3(con.ProxyHostName, con.ProxyPort, timeout_connect, cancel, NULL, true, NULL, false, NULL);
+		s = TcpConnectEx3(con.ProxyHostName, con.ProxyPort, timeout_connect, cancel, NULL, true, NULL, false, NULL, NULL);
 		if (s == NULL)
 		{
 			*error_code = ERR_PROXY_CONNECT_FAILED;

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -13979,7 +13979,7 @@ void ConnectThreadForIPv4(THREAD *thread, void *param)
 			Zero(&p4, sizeof(p4));
 
 			// p1: TCP
-			StrCpy(p1.Hostname, sizeof(p1.Hostname), p->Hostname_Original);
+			StrCpy(p1.Hostname, sizeof(p1.Hostname), p->Hostname);
 			Copy(&p1.Ip, ip, sizeof(IP));
 			p1.Port = p->Port;
 			p1.Timeout = p->Timeout;
@@ -13989,7 +13989,7 @@ void ConnectThreadForIPv4(THREAD *thread, void *param)
 			p1.CancelLock = NewLock();
 
 			// p2: NAT-T
-			StrCpy(p2.Hostname, sizeof(p2.Hostname), p->Hostname_Original);
+			StrCpy(p2.Hostname, sizeof(p2.Hostname), p->Hostname);
 			Copy(&p2.Ip, ip, sizeof(IP));
 			p2.Port = p->Port;
 			p2.Timeout = p->Timeout;
@@ -14002,7 +14002,7 @@ void ConnectThreadForIPv4(THREAD *thread, void *param)
 			p2.Delay = 30;		// Delay by 30ms
 
 			// p3: over ICMP
-			StrCpy(p3.Hostname, sizeof(p3.Hostname), p->Hostname_Original);
+			StrCpy(p3.Hostname, sizeof(p3.Hostname), p->Hostname);
 			Copy(&p3.Ip, ip, sizeof(IP));
 			p3.Port = p->Port;
 			p3.Timeout = p->Timeout;
@@ -14013,7 +14013,7 @@ void ConnectThreadForIPv4(THREAD *thread, void *param)
 			p3.Delay = 200;		// Delay by 200ms
 
 			// p4: over DNS
-			StrCpy(p4.Hostname, sizeof(p4.Hostname), p->Hostname_Original);
+			StrCpy(p4.Hostname, sizeof(p4.Hostname), p->Hostname);
 			Copy(&p4.Ip, ip, sizeof(IP));
 			p4.Port = p->Port;
 			p4.Timeout = p->Timeout;
@@ -14221,7 +14221,7 @@ void ConnectThreadForIPv4(THREAD *thread, void *param)
 
 		if (s != INVALID_SOCKET)
 		{
-			p->Sock = CreateTCPSock(s, false, &current_ip, p->No_Get_Hostname, p->Hostname_Original);
+			p->Sock = CreateTCPSock(s, false, &current_ip, p->No_Get_Hostname, p->Hostname);
 			break;
 		}
 	}
@@ -14308,7 +14308,7 @@ void ConnectThreadForIPv6(THREAD *thread, void *param)
 
 		if (s != INVALID_SOCKET)
 		{
-			p->Sock = CreateTCPSock(s, true, &current_ip, p->No_Get_Hostname, p->Hostname_Original);
+			p->Sock = CreateTCPSock(s, true, &current_ip, p->No_Get_Hostname, p->Hostname);
 			break;
 		}
 	}
@@ -14407,14 +14407,12 @@ SOCK *ConnectEx2(char *hostname, UINT port, UINT timeout, bool *cancel_flag)
 }
 SOCK *ConnectEx3(char *hostname, UINT port, UINT timeout, bool *cancel_flag, char *nat_t_svc_name, UINT *nat_t_error_code, bool try_start_ssl, bool no_get_hostname)
 {
-	return ConnectEx4(hostname, port, timeout, cancel_flag, nat_t_svc_name, nat_t_error_code, try_start_ssl, no_get_hostname, NULL);
+	return ConnectEx4(hostname, port, timeout, cancel_flag, nat_t_svc_name, nat_t_error_code, try_start_ssl, no_get_hostname, NULL, NULL);
 }
-SOCK *ConnectEx4(char *hostname, UINT port, UINT timeout, bool *cancel_flag, char *nat_t_svc_name, UINT *nat_t_error_code, bool try_start_ssl, bool no_get_hostname, IP *ret_ip)
+SOCK *ConnectEx4(char *hostname, UINT port, UINT timeout, bool *cancel_flag, char *nat_t_svc_name, UINT *nat_t_error_code, bool try_start_ssl, bool no_get_hostname, char *hint_str, IP *ret_ip)
 {
 	bool dummy = false;
 	bool use_natt = false;
-	char hostname_original[MAX_SIZE];
-	char hint_str[MAX_SIZE];
 	bool force_use_natt = false;
 	UINT dummy_int = 0;
 	IP dummy_ret_ip;
@@ -14442,32 +14440,14 @@ SOCK *ConnectEx4(char *hostname, UINT port, UINT timeout, bool *cancel_flag, cha
 		ret_ip = &dummy_ret_ip;
 	}
 
-	Zero(hint_str, sizeof(hint_str));
-	StrCpy(hostname_original, sizeof(hostname_original), hostname);
-
 	use_natt = (IsEmptyStr(nat_t_svc_name) ? false : true);
 
 	if (use_natt)
 	{
-		// In case of using NAT-T, split host name if the '/' is included in the host name
-		UINT i = SearchStrEx(hostname, "/", 0, false);
-
-		if (i == INFINITE)
+		if (IsEmptyStr(hint_str) == false)
 		{
-			// Not included
-			StrCpy(hostname_original, sizeof(hostname_original), hostname);
-		}
-		else
-		{
-			// Included
-			StrCpy(hostname_original, sizeof(hostname_original), hostname);
-			hostname_original[i] = 0;
-
 			// Force to use the NAT-T
 			force_use_natt = true;
-
-			// Copy the hint string
-			StrCpy(hint_str, sizeof(hint_str), hostname + i + 1);
 
 			if (StrCmpi(hint_str, "tcp") == 0 || StrCmpi(hint_str, "disable") == 0
 			        || StrCmpi(hint_str, "disabled") == 0
@@ -14478,10 +14458,6 @@ SOCK *ConnectEx4(char *hostname, UINT port, UINT timeout, bool *cancel_flag, cha
 				use_natt = false;
 			}
 		}
-	}
-	else
-	{
-		StrCpy(hostname_original, sizeof(hostname_original), hostname);
 	}
 
 	LIST *iplist_v6 = NULL;
@@ -14506,7 +14482,7 @@ SOCK *ConnectEx4(char *hostname, UINT port, UINT timeout, bool *cancel_flag, cha
 	else
 	{
 		// Forward resolution
-		if (DnsResolveEx(&iplist_v6, &iplist_v4, hostname_original, 0, cancel_flag) == false)
+		if (DnsResolveEx(&iplist_v6, &iplist_v4, hostname, 0, cancel_flag) == false)
 		{
 			return NULL;
 		}
@@ -14532,7 +14508,6 @@ SOCK *ConnectEx4(char *hostname, UINT port, UINT timeout, bool *cancel_flag, cha
 		p6.Port = port;
 		p6.Timeout = timeout;
 		StrCpy(p6.Hostname, sizeof(p6.Hostname), hostname);
-		StrCpy(p6.Hostname_Original, sizeof(p6.Hostname_Original), hostname_original);
 		p6.No_Get_Hostname = no_get_hostname;
 		p6.CancelFlag = &cancel_flag2;
 		p6.NoDelayFlag = &no_delay_flag;
@@ -14551,7 +14526,6 @@ SOCK *ConnectEx4(char *hostname, UINT port, UINT timeout, bool *cancel_flag, cha
 		p4.Port = port;
 		p4.Timeout = timeout;
 		StrCpy(p4.Hostname, sizeof(p4.Hostname), hostname);
-		StrCpy(p4.Hostname_Original, sizeof(p4.Hostname_Original), hostname_original);
 		StrCpy(p4.HintStr, sizeof(p4.HintStr), hint_str);
 		p4.No_Get_Hostname = no_get_hostname;
 		p4.CancelFlag = &cancel_flag2;

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -802,7 +802,6 @@ struct CONNECT_SERIAL_PARAM
 	UINT Port;
 	UINT Timeout;
 	char Hostname[MAX_SIZE];
-	char Hostname_Original[MAX_SIZE];
 	char HintStr[MAX_SIZE];
 	bool No_Get_Hostname;
 	bool *CancelFlag;
@@ -1084,7 +1083,7 @@ SOCK *Connect(char *hostname, UINT port);
 SOCK *ConnectEx(char *hostname, UINT port, UINT timeout);
 SOCK *ConnectEx2(char *hostname, UINT port, UINT timeout, bool *cancel_flag);
 SOCK *ConnectEx3(char *hostname, UINT port, UINT timeout, bool *cancel_flag, char *nat_t_svc_name, UINT *nat_t_error_code, bool try_start_ssl, bool no_get_hostname);
-SOCK *ConnectEx4(char *hostname, UINT port, UINT timeout, bool *cancel_flag, char *nat_t_svc_name, UINT *nat_t_error_code, bool try_start_ssl, bool no_get_hostname, IP *ret_ip);
+SOCK *ConnectEx4(char *hostname, UINT port, UINT timeout, bool *cancel_flag, char *nat_t_svc_name, UINT *nat_t_error_code, bool try_start_ssl, bool no_get_hostname, char *hint_str, IP *ret_ip);
 SOCKET ConnectTimeoutIPv4(IP *ip, UINT port, UINT timeout, bool *cancel_flag);
 bool SetSocketBufferSize(SOCKET s, bool send, UINT size);
 UINT SetSocketBufferSizeWithBestEffort(SOCKET s, bool send, UINT size);

--- a/src/Mayaqua/Proxy.c
+++ b/src/Mayaqua/Proxy.c
@@ -12,11 +12,11 @@ SOCK *Internal_ProxyTcpConnect(PROXY_PARAM_IN *param, volatile bool *cancel_flag
 #ifdef OS_WIN32
 	if (param->Hwnd != NULL)
 	{
-		return WinConnectEx3((HWND)param->Hwnd, param->Hostname, param->Port, param->Timeout, 0, NULL, NULL, NULL, NULL, false);
+		return WinConnectEx3((HWND)param->Hwnd, param->Hostname, param->Port, param->Timeout, 0, NULL, NULL, NULL, NULL, false, NULL);
 	}
 #endif
 
-	return ConnectEx4(param->Hostname, param->Port, param->Timeout, (bool *)cancel_flag, NULL, NULL, false, true, resolved_ip);
+	return ConnectEx4(param->Hostname, param->Port, param->Timeout, (bool *)cancel_flag, NULL, NULL, false, true, NULL, resolved_ip);
 }
 
 // Connect to an HTTP proxy


### PR DESCRIPTION
Hint string is a "hack" used to provide additional information for NAT traversal. 
The common ones are:
- `example.com/tcp`
  Used to indicate no NAT-T should be used
- `example.com/<private ip>`
  Useful when multiple servers are under the same global address

However, since the internal process does not separate the real hostname from the hint string, it is necessary to consider the existence of the hint string everywhere the hostname is used. The current approach is cumbersome and error-prone.
For example, I have seen these strange behaviors:
- `example.com/tcp` is sent for DNS resolution
- `example.com/tcp` is present in TLS SNI

Changes proposed in this pull request:
 - Separate NAT-T hint string from hostname internally
 - User-facing interface is unchanged

