### PR TITLE
Mayaqua/Network.h: Fix UDP acceleration under NAT-T connections

### DIFF
--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -87,7 +87,7 @@ struct IP
 
 #define	CmpIpAddr(ip1, ip2)			(Cmp((ip1)->address, (ip2)->address, sizeof((ip1)->address)))
 
-#define	IsIP6(ip)					(IsIP4(ip) == false)
+#define	IsIP6(ip)					(ip && IsIP4(ip) == false)
 #define	IsZeroIp(ip)				(IsZeroIP(ip))
 
 // IPv6 address (different format)


### PR DESCRIPTION
Missing argument check lead to wrong value of IsIPv6 of struct UDP_ACCEL in NewUdpAccel(),  eventually lead to UdpAccelInitClient() fail.

Changes proposed in this pull request:
 - 
 - 
 - 

