### PR TITLE
Cedar/SM.c: Fix pointer usage before initialization

### DIFF
--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -17176,7 +17176,7 @@ UINT SmSslDlgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, void *param
 	SM_SSL *s = (SM_SSL *)param;
 	X *x;
 	K *k;
-	LIST *chain;
+	LIST *chain = NULL;
 	// Validate arguments
 	if (hWnd == NULL)
 	{


### PR DESCRIPTION
When user regenerates server certificates from the Server Manager, `chain` is not initialized because the regeneration function does not offer a chain, causing uninitialized `chain` be used.

Fix #1433