### PR TITLE
Fix server manager setting compatibility since build 9658

### DIFF
--- a/src/Cedar/Connection.h
+++ b/src/Cedar/Connection.h
@@ -60,6 +60,8 @@ struct RC4_KEY_PAIR
 };
 
 // Client Options
+// Do not change item size or order and only add new items at the end!
+// See comments in struct SETTING (SMInner.h)
 struct CLIENT_OPTION
 {
 	wchar_t AccountName[MAX_ACCOUNT_NAME_LEN + 1];			// Connection setting name
@@ -71,26 +73,38 @@ struct CLIENT_OPTION
 	UINT ProxyPort;											// Port number of the proxy server
 	char ProxyUsername[PROXY_MAX_USERNAME_LEN + 1];			// Maximum user name length
 	char ProxyPassword[PROXY_MAX_PASSWORD_LEN + 1];			// Maximum password length
-	char CustomHttpHeader[HTTP_CUSTOM_HEADER_MAX_SIZE + 1];	// Custom HTTP proxy header
 	UINT NumRetry;											// Automatic retries
 	UINT RetryInterval;										// Retry interval
 	char HubName[MAX_HUBNAME_LEN + 1];						// HUB name
 	UINT MaxConnection;										// Maximum number of concurrent TCP connections
 	bool UseEncrypt;										// Use encrypted communication
+	char pad1[3];
 	bool UseCompress;										// Use data compression
+	char pad2[3];
 	bool HalfConnection;									// Use half connection in TCP
+	char pad3[3];
 	bool NoRoutingTracking;									// Disable the routing tracking
+	char pad4[3];
 	char DeviceName[MAX_DEVICE_NAME_LEN + 1];				// VLAN device name
 	UINT AdditionalConnectionInterval;						// Connection attempt interval when additional connection establish
 	UINT ConnectionDisconnectSpan;							// Disconnection interval
 	bool HideStatusWindow;									// Hide the status window
+	char pad5[3];
 	bool HideNicInfoWindow;									// Hide the NIC status window
+	char pad6[3];
 	bool RequireMonitorMode;								// Monitor port mode
+	char pad7[3];
 	bool RequireBridgeRoutingMode;							// Bridge or routing mode
+	char pad8[3];
 	bool DisableQoS;										// Disable the VoIP / QoS function
+	char pad9[3];
 	bool FromAdminPack;										// For Administration Pack
+	char pad10[3];
+	char pad11[4];											// Removed bool
 	bool NoUdpAcceleration;									// Do not use UDP acceleration mode
+	char pad12[3];
 	UCHAR HostUniqueKey[SHA1_SIZE];							// Host unique key
+	char CustomHttpHeader[HTTP_CUSTOM_HEADER_MAX_SIZE];		// Custom HTTP proxy header
 };
 
 // Client authentication data

--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -19957,6 +19957,215 @@ void SmWriteSettingList()
 	}
 }
 
+SETTING *LoadSetting9658(BUF *b)
+{
+	typedef struct OLD_CLIENT_OPTION
+	{
+		wchar_t AccountName[256];								// Connection setting name
+		char Hostname[256];										// Host name
+		UINT Port;												// Port number
+		UINT PortUDP;											// UDP port number (0: Use only TCP)
+		UINT ProxyType;											// Type of proxy
+		char ProxyName[256];									// Proxy server name
+		UINT ProxyPort;											// Port number of the proxy server
+		char ProxyUsername[256];								// Maximum user name length
+		char ProxyPassword[256];								// Maximum password length
+		UINT NumRetry;											// Automatic retries
+		UINT RetryInterval;										// Retry interval
+		char HubName[256];										// HUB name
+		UINT MaxConnection;										// Maximum number of concurrent TCP connections
+		UINT UseEncrypt;										// Use encrypted communication
+		UINT UseCompress;										// Use data compression
+		UINT HalfConnection;									// Use half connection in TCP
+		UINT NoRoutingTracking;									// Disable the routing tracking
+		char DeviceName[32];									// VLAN device name
+		UINT AdditionalConnectionInterval;						// Connection attempt interval when additional connection establish
+		UINT ConnectionDisconnectSpan;							// Disconnection interval
+		UINT HideStatusWindow;									// Hide the status window
+		UINT HideNicInfoWindow;									// Hide the NIC status window
+		UINT RequireMonitorMode;								// Monitor port mode
+		UINT RequireBridgeRoutingMode;							// Bridge or routing mode
+		UINT DisableQoS;										// Disable the VoIP / QoS function
+		UINT FromAdminPack;										// For Administration Pack
+		UINT NoUdpAcceleration;									// Do not use UDP acceleration mode
+		UCHAR HostUniqueKey[20];								// Host unique key
+	} OLD_CLIENT_OPTION;
+
+	typedef struct OLD_SETTING
+	{
+		wchar_t Title[512];				// Setting Name
+		UINT ServerAdminMode;			// Server management mode
+		char HubName[256];				// HUB name
+		UCHAR HashedPassword[20];		// Password
+		OLD_CLIENT_OPTION ClientOption;		// Client Option
+		UCHAR Reserved[10188];			// Reserved area
+	} OLD_SETTING;
+
+	if (b->Size != sizeof(OLD_SETTING))	// 13416
+	{
+		return NULL;
+	}
+
+	OLD_SETTING s0;
+	Copy(&s0, b->Buf, sizeof(OLD_SETTING));
+
+	SETTING *s = ZeroMalloc(sizeof(SETTING));
+	UniStrCpy(s->Title, sizeof(s->Title), s0.Title);
+	s->ServerAdminMode = s0.ServerAdminMode;
+	StrCpy(s->HubName, sizeof(s->HubName), s0.HubName);
+	Copy(s->HashedPassword, s0.HashedPassword, sizeof(s->HashedPassword));
+	UniStrCpy(s->ClientOption.AccountName, sizeof(s->ClientOption.AccountName), s0.ClientOption.AccountName);
+	StrCpy(s->ClientOption.Hostname, sizeof(s->ClientOption.Hostname), s0.ClientOption.Hostname);
+	s->ClientOption.Port = s0.ClientOption.Port;
+	s->ClientOption.ProxyType = s0.ClientOption.ProxyType;
+	StrCpy(s->ClientOption.ProxyName, sizeof(s->ClientOption.ProxyName), s0.ClientOption.ProxyName);
+	s->ClientOption.ProxyPort = s0.ClientOption.ProxyPort;
+	StrCpy(s->ClientOption.ProxyUsername, sizeof(s->ClientOption.ProxyUsername), s0.ClientOption.ProxyUsername);
+	StrCpy(s->ClientOption.ProxyPassword, sizeof(s->ClientOption.ProxyPassword), s0.ClientOption.ProxyPassword);
+
+	return s;
+}
+
+SETTING *LoadSetting9666(BUF *b)
+{
+	typedef struct OLD_CLIENT_OPTION
+	{
+		wchar_t AccountName[256];								// Connection setting name
+		char Hostname[256];										// Host name
+		UINT Port;												// Port number
+		UINT PortUDP;											// UDP port number (0: Use only TCP)
+		UINT ProxyType;											// Type of proxy
+		char ProxyName[256];									// Proxy server name
+		UINT ProxyPort;											// Port number of the proxy server
+		char ProxyUsername[256];								// Maximum user name length
+		char ProxyPassword[256];								// Maximum password length
+		char CustomHttpHeader[1025];							// Custom HTTP proxy header
+		UINT NumRetry;											// Automatic retries
+		UINT RetryInterval;										// Retry interval
+		char HubName[256];										// HUB name
+		UINT MaxConnection;										// Maximum number of concurrent TCP connections
+		UINT UseEncrypt;										// Use encrypted communication
+		UINT UseCompress;										// Use data compression
+		UINT HalfConnection;									// Use half connection in TCP
+		UINT NoRoutingTracking;									// Disable the routing tracking
+		char DeviceName[32];									// VLAN device name
+		UINT AdditionalConnectionInterval;						// Connection attempt interval when additional connection establish
+		UINT ConnectionDisconnectSpan;							// Disconnection interval
+		UINT HideStatusWindow;									// Hide the status window
+		UINT HideNicInfoWindow;									// Hide the NIC status window
+		UINT RequireMonitorMode;								// Monitor port mode
+		UINT RequireBridgeRoutingMode;							// Bridge or routing mode
+		UINT DisableQoS;										// Disable the VoIP / QoS function
+		UINT FromAdminPack;										// For Administration Pack
+		UINT NoUdpAcceleration;									// Do not use UDP acceleration mode
+		UCHAR HostUniqueKey[20];								// Host unique key
+	} OLD_CLIENT_OPTION;
+
+	typedef struct OLD_SETTING
+	{
+		wchar_t Title[512];				// Setting Name
+		UINT ServerAdminMode;			// Server management mode
+		char HubName[256];				// HUB name
+		UCHAR HashedPassword[20];		// Password
+		OLD_CLIENT_OPTION ClientOption;		// Client Option
+		UCHAR Reserved[10188];			// Reserved area
+	} OLD_SETTING;
+
+	if (b->Size != sizeof(OLD_SETTING))	// 14444
+	{
+		return NULL;
+	}
+
+	OLD_SETTING s0;
+	Copy(&s0, b->Buf, sizeof(OLD_SETTING));
+
+	SETTING *s = ZeroMalloc(sizeof(SETTING));
+	UniStrCpy(s->Title, sizeof(s->Title), s0.Title);
+	s->ServerAdminMode = s0.ServerAdminMode;
+	StrCpy(s->HubName, sizeof(s->HubName), s0.HubName);
+	Copy(s->HashedPassword, s0.HashedPassword, sizeof(s->HashedPassword));
+	UniStrCpy(s->ClientOption.AccountName, sizeof(s->ClientOption.AccountName), s0.ClientOption.AccountName);
+	StrCpy(s->ClientOption.Hostname, sizeof(s->ClientOption.Hostname), s0.ClientOption.Hostname);
+	s->ClientOption.Port = s0.ClientOption.Port;
+	s->ClientOption.ProxyType = s0.ClientOption.ProxyType;
+	StrCpy(s->ClientOption.ProxyName, sizeof(s->ClientOption.ProxyName), s0.ClientOption.ProxyName);
+	s->ClientOption.ProxyPort = s0.ClientOption.ProxyPort;
+	StrCpy(s->ClientOption.ProxyUsername, sizeof(s->ClientOption.ProxyUsername), s0.ClientOption.ProxyUsername);
+	StrCpy(s->ClientOption.ProxyPassword, sizeof(s->ClientOption.ProxyPassword), s0.ClientOption.ProxyPassword);
+
+	return s;
+}
+
+SETTING *LoadSetting502(BUF *b)
+{
+	typedef struct OLD_CLIENT_OPTION
+	{
+		wchar_t AccountName[256];								// Connection setting name
+		char Hostname[256];										// Host name
+		UINT Port;												// Port number
+		UINT PortUDP;											// UDP port number (0: Use only TCP)
+		UINT ProxyType;											// Type of proxy
+		char ProxyName[256];									// Proxy server name
+		UINT ProxyPort;											// Port number of the proxy server
+		char ProxyUsername[256];								// Maximum user name length
+		char ProxyPassword[256];								// Maximum password length
+		char CustomHttpHeader[1025];							// Custom HTTP proxy header
+		UINT NumRetry;											// Automatic retries
+		UINT RetryInterval;										// Retry interval
+		char HubName[256];										// HUB name
+		UINT MaxConnection;										// Maximum number of concurrent TCP connections
+		bool UseEncrypt;										// Use encrypted communication
+		bool UseCompress;										// Use data compression
+		bool HalfConnection;									// Use half connection in TCP
+		bool NoRoutingTracking;									// Disable the routing tracking
+		char DeviceName[32];									// VLAN device name
+		UINT AdditionalConnectionInterval;						// Connection attempt interval when additional connection establish
+		UINT ConnectionDisconnectSpan;							// Disconnection interval
+		bool HideStatusWindow;									// Hide the status window
+		bool HideNicInfoWindow;									// Hide the NIC status window
+		bool RequireMonitorMode;								// Monitor port mode
+		bool RequireBridgeRoutingMode;							// Bridge or routing mode
+		bool DisableQoS;										// Disable the VoIP / QoS function
+		bool FromAdminPack;										// For Administration Pack
+		bool NoUdpAcceleration;									// Do not use UDP acceleration mode
+		UCHAR HostUniqueKey[20];								// Host unique key
+	} OLD_CLIENT_OPTION;
+
+	typedef struct OLD_SETTING
+	{
+		wchar_t Title[512];				// Setting Name
+		bool ServerAdminMode;			// Server management mode
+		char HubName[256];				// HUB name
+		UCHAR HashedPassword[20];		// Password
+		OLD_CLIENT_OPTION ClientOption;		// Client Option
+		UCHAR Reserved[10212];			// Reserved area
+	} OLD_SETTING;
+
+	if (b->Size != sizeof(OLD_SETTING))	// 14436
+	{
+		return NULL;
+	}
+
+	OLD_SETTING s0;
+	Copy(&s0, b->Buf, sizeof(OLD_SETTING));
+
+	SETTING *s = ZeroMalloc(sizeof(SETTING));
+	UniStrCpy(s->Title, sizeof(s->Title), s0.Title);
+	s->ServerAdminMode = s0.ServerAdminMode;
+	StrCpy(s->HubName, sizeof(s->HubName), s0.HubName);
+	Copy(s->HashedPassword, s0.HashedPassword, sizeof(s->HashedPassword));
+	UniStrCpy(s->ClientOption.AccountName, sizeof(s->ClientOption.AccountName), s0.ClientOption.AccountName);
+	StrCpy(s->ClientOption.Hostname, sizeof(s->ClientOption.Hostname), s0.ClientOption.Hostname);
+	s->ClientOption.Port = s0.ClientOption.Port;
+	s->ClientOption.ProxyType = s0.ClientOption.ProxyType;
+	StrCpy(s->ClientOption.ProxyName, sizeof(s->ClientOption.ProxyName), s0.ClientOption.ProxyName);
+	s->ClientOption.ProxyPort = s0.ClientOption.ProxyPort;
+	StrCpy(s->ClientOption.ProxyUsername, sizeof(s->ClientOption.ProxyUsername), s0.ClientOption.ProxyUsername);
+	StrCpy(s->ClientOption.ProxyPassword, sizeof(s->ClientOption.ProxyPassword), s0.ClientOption.ProxyPassword);
+
+	return s;
+}
+
 // Load the connection list
 void SmLoadSettingList()
 {
@@ -19981,11 +20190,27 @@ void SmLoadSettingList()
 		BUF *b = MsRegReadBin(REG_CURRENT_USER, key_name, name);
 		if (b != NULL)
 		{
-			if (b->Size == sizeof(SETTING))
+			SETTING *s = NULL;
+			if (b->Size == 13416)	// 5.01 Build 9658 - 9665
 			{
-				SETTING *s = ZeroMalloc(sizeof(SETTING));
+				s = LoadSetting9658(b);
+			}
+			else if (b->Size == 14444)	// 5.01 Build 9666 - 9674
+			{
+				s = LoadSetting9666(b);
+			}
+			else if (b->Size == 14436)	// 5.02
+			{
+				s = LoadSetting502(b);
+			}
+			else if (b->Size == sizeof(SETTING))	// Must be 13420 (the size used since version 4.x)
+			{
+				s = ZeroMalloc(sizeof(SETTING));
 				Copy(s, b->Buf, sizeof(SETTING));
+			}
 
+			if (s != NULL)
+			{
 				Add(sm->SettingList, s);
 			}
 			FreeBuf(b);

--- a/src/Cedar/SMInner.h
+++ b/src/Cedar/SMInner.h
@@ -31,14 +31,17 @@
 #define	SM_SETTING_REG_KEY_OLD	"Software\\SoftEther Corporation\\PacketiX VPN\\Server Manager\\Settings"
 
 // Connection setting
+// Do not change item size or order
+// Size must be kept at 13420 (use Reserved to adjust for new items)
 typedef struct SETTING
 {
 	wchar_t Title[MAX_SIZE];	// Setting Name
 	bool ServerAdminMode;		// Server management mode
+	char pad1[3];
 	char HubName[MAX_HUBNAME_LEN + 1];	// HUB name
 	UCHAR HashedPassword[SHA1_SIZE];	// Password
 	CLIENT_OPTION ClientOption;	// Client Option
-	UCHAR Reserved[10240 - sizeof(bool) * 8 - SHA1_SIZE];	// Reserved area
+	UCHAR Reserved[10240 - sizeof(UINT) * 8 - SHA1_SIZE - HTTP_CUSTOM_HEADER_MAX_SIZE];	// Reserved area
 } SETTING;
 
 // Structure declaration

--- a/src/Cedar/Wpc.h
+++ b/src/Cedar/Wpc.h
@@ -32,7 +32,7 @@ struct WPC_CONNECT
 	UINT ProxyPort;											// Proxy server port number
 	char ProxyUsername[MAX_USERNAME_LEN + 1];				// Proxy server user name
 	char ProxyPassword[MAX_USERNAME_LEN + 1];				// Proxy server password
-	char CustomHttpHeader[HTTP_CUSTOM_HEADER_MAX_SIZE + 1];	// Custom HTTP header
+	char CustomHttpHeader[HTTP_CUSTOM_HEADER_MAX_SIZE];		// Custom HTTP header
 	bool UseCompress;										// Use of compression
 	bool DontCheckCert;										// Do not check the certificate
 };
@@ -45,7 +45,7 @@ struct INTERNET_SETTING
 	UINT ProxyPort;											// Proxy server port number
 	char ProxyUsername[MAX_USERNAME_LEN + 1];				// Proxy server user name
 	char ProxyPassword[MAX_USERNAME_LEN + 1];				// Proxy server password
-	char CustomHttpHeader[HTTP_CUSTOM_HEADER_MAX_SIZE + 1];	// Custom HTTP header
+	char CustomHttpHeader[HTTP_CUSTOM_HEADER_MAX_SIZE];		// Custom HTTP header
 };
 
 // URL

--- a/src/Mayaqua/Proxy.h
+++ b/src/Mayaqua/Proxy.h
@@ -28,7 +28,7 @@ struct PROXY_PARAM_IN
 	char Username[PROXY_MAX_USERNAME_LEN + 1];
 	char Password[PROXY_MAX_PASSWORD_LEN + 1];
 	UINT Timeout;
-	char HttpCustomHeader[HTTP_CUSTOM_HEADER_MAX_SIZE + 1];
+	char HttpCustomHeader[HTTP_CUSTOM_HEADER_MAX_SIZE];
 	char HttpUserAgent[HTTP_HEADER_USER_AGENT_MAX_SIZE + 1];
 #ifdef OS_WIN32
 	void *Hwnd;


### PR DESCRIPTION
As mentioned in #1535 , since 5.01 build 9658 we have accidentally diverted from the original format (for 3 times) used to save server manager settings in the Windows registry. 
This PR restores the compatibility with the original format and automatically convert three diverted formats when loading from the registry. 

This should eliminate any data loss no matter what version the user is upgrading from.

Close #1535 
