### PR TITLE
Add missing headers required for solaris/illumos

### DIFF
--- a/src/Cedar/BridgeUnix.c
+++ b/src/Cedar/BridgeUnix.c
@@ -29,11 +29,13 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
-#ifndef UNIX_OPENBSD
+#if !defined(UNIX_OPENBSD) && !defined(UNIX_SOLARIS)
 #include <net/ethernet.h>
 #endif
 
 #ifdef UNIX_SOLARIS
+#include <stropts.h>
+#include <sys/dlpi.h>
 #include <sys/sockio.h>
 #endif
 

--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -29,7 +29,7 @@
 #include <net/if.h>
 #include <sys/ioctl.h>
 
-#ifdef UNIX_OPENBSD
+#if defined(UNIX_OPENBSD) || defined(UNIX_SOLARIS)
 #include <netinet/if_ether.h>
 #else
 #include <net/ethernet.h>

--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -46,6 +46,11 @@
 #include <sys/statfs.h>
 #endif
 
+#ifdef UNIX_SOLARIS
+#define USE_STATVFS
+#include <sys/statvfs.h>'
+#endif
+
 #ifdef	UNIX_MACOS
 #ifdef	NO_VLAN
 // Struct statfs for MacOS X


### PR DESCRIPTION
A recent refactor removed a number of headers required on solaris/illumos systems. This patch adds those headers back. 

See https://gitlab.com/SoftEther/SoftEtherVPN/-/jobs/1818748494 for details of (one of) the missing definitions.

