### PR TITLE
Fix wrong endianness in InRpcNodeInfo() and OutRpcNodeInfo()

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -14658,19 +14658,19 @@ void InRpcNodeInfo(NODE_INFO *t, PACK *p)
 	PackGetStr(p, "HubName", t->HubName, sizeof(t->HubName));
 	PackGetData2(p, "UniqueId", t->UniqueId, sizeof(t->UniqueId));
 
-	t->ClientProductVer = PackGetInt(p, "ClientProductVer");
-	t->ClientProductBuild = PackGetInt(p, "ClientProductBuild");
-	t->ServerProductVer = PackGetInt(p, "ServerProductVer");
-	t->ServerProductBuild = PackGetInt(p, "ServerProductBuild");
+	t->ClientProductVer = LittleEndian32(PackGetInt(p, "ClientProductVer"));
+	t->ClientProductBuild = LittleEndian32(PackGetInt(p, "ClientProductBuild"));
+	t->ServerProductVer = LittleEndian32(PackGetInt(p, "ServerProductVer"));
+	t->ServerProductBuild = LittleEndian32(PackGetInt(p, "ServerProductBuild"));
 	t->ClientIpAddress = PackGetIp32(p, "ClientIpAddress");
 	PackGetData2(p, "ClientIpAddress6", t->ClientIpAddress6, sizeof(t->ClientIpAddress6));
-	t->ClientPort = PackGetInt(p, "ClientPort");
+	t->ClientPort = LittleEndian32(PackGetInt(p, "ClientPort"));
 	t->ServerIpAddress = PackGetIp32(p, "ServerIpAddress");
 	PackGetData2(p, "ServerIpAddress6", t->ServerIpAddress6, sizeof(t->ServerIpAddress6));
-	t->ServerPort = PackGetInt(p, "ServerPort2");
+	t->ServerPort = LittleEndian32(PackGetInt(p, "ServerPort2"));
 	t->ProxyIpAddress = PackGetIp32(p, "ProxyIpAddress");
 	PackGetData2(p, "ProxyIpAddress6", t->ProxyIpAddress6, sizeof(t->ProxyIpAddress6));
-	t->ProxyPort = PackGetInt(p, "ProxyPort");
+	t->ProxyPort = LittleEndian32(PackGetInt(p, "ProxyPort"));
 }
 void OutRpcNodeInfo(PACK *p, NODE_INFO *t)
 {
@@ -14691,19 +14691,19 @@ void OutRpcNodeInfo(PACK *p, NODE_INFO *t)
 	PackAddStr(p, "HubName", t->HubName);
 	PackAddData(p, "UniqueId", t->UniqueId, sizeof(t->UniqueId));
 
-	PackAddInt(p, "ClientProductVer", t->ClientProductVer);
-	PackAddInt(p, "ClientProductBuild", t->ClientProductBuild);
-	PackAddInt(p, "ServerProductVer", t->ServerProductVer);
-	PackAddInt(p, "ServerProductBuild", t->ServerProductBuild);
+	PackAddInt(p, "ClientProductVer", LittleEndian32(t->ClientProductVer));
+	PackAddInt(p, "ClientProductBuild", LittleEndian32(t->ClientProductBuild));
+	PackAddInt(p, "ServerProductVer", LittleEndian32(t->ServerProductVer));
+	PackAddInt(p, "ServerProductBuild", LittleEndian32(t->ServerProductBuild));
 	PackAddIp32(p, "ClientIpAddress", t->ClientIpAddress);
 	PackAddData(p, "ClientIpAddress6", t->ClientIpAddress6, sizeof(t->ClientIpAddress6));
-	PackAddInt(p, "ClientPort", t->ClientPort);
+	PackAddInt(p, "ClientPort", LittleEndian32(t->ClientPort));
 	PackAddIp32(p, "ServerIpAddress", t->ServerIpAddress);
 	PackAddData(p, "ServerIpAddress6", t->ServerIpAddress6, sizeof(t->ServerIpAddress6));
-	PackAddInt(p, "ServerPort2", t->ServerPort);
+	PackAddInt(p, "ServerPort2", LittleEndian32(t->ServerPort));
 	PackAddIp32(p, "ProxyIpAddress", t->ProxyIpAddress);
 	PackAddData(p, "ProxyIpAddress6", t->ProxyIpAddress6, sizeof(t->ProxyIpAddress6));
-	PackAddInt(p, "ProxyPort", t->ProxyPort);
+	PackAddInt(p, "ProxyPort", LittleEndian32(t->ProxyPort));
 }
 
 // RPC_SESSION_STATUS

--- a/src/Mayaqua/Memory.c
+++ b/src/Mayaqua/Memory.c
@@ -3373,6 +3373,48 @@ UINT64 Endian64(UINT64 src)
 	}
 }
 
+// Endian conversion 16bit
+USHORT LittleEndian16(USHORT src)
+{
+	int x = 0x01000000;
+	if (*((char *)&x))
+	{
+		return Swap16(src);
+	}
+	else
+	{
+		return src;
+	}
+}
+
+// Endian conversion 32bit
+UINT LittleEndian32(UINT src)
+{
+	int x = 0x01000000;
+	if (*((char *)&x))
+	{
+		return Swap32(src);
+	}
+	else
+	{
+		return src;
+	}
+}
+
+// Endian conversion 64bit
+UINT64 LittleEndian64(UINT64 src)
+{
+	int x = 0x01000000;
+	if (*((char *)&x))
+	{
+		return Swap64(src);
+	}
+	else
+	{
+		return src;
+	}
+}
+
 // 16bit swap
 USHORT Swap16(USHORT value)
 {

--- a/src/Mayaqua/Memory.h
+++ b/src/Mayaqua/Memory.h
@@ -199,6 +199,9 @@ UINT64 Swap64(UINT64 value);
 USHORT Endian16(USHORT src);
 UINT Endian32(UINT src);
 UINT64 Endian64(UINT64 src);
+USHORT LittleEndian16(USHORT src);
+UINT LittleEndian32(UINT src);
+UINT64 LittleEndian64(UINT64 src);
 void EndianUnicode(wchar_t *str);
 
 BUF *NewBuf();


### PR DESCRIPTION
Fix problem of "Wrong endianness in buffers created from node info #1555" https://github.com/SoftEtherVPN/SoftEtherVPN/issues/1555