### PR TITLE
draft CMakeSettings.json (make project Visual Studio friendly)

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,42 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-windows-static-md",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "clang_cl_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "cmakeToolchain": "C:/vcpkg/scripts/buildsystems/vcpkg.cmake",
+      "variables": [
+        {
+          "name": "VCPKG_TARGET_TRIPLET",
+          "value": "x64-windows-static-md",
+          "type": "STRING"
+        }
+      ]
+    },
+    {
+      "name": "x86-windows-static-md",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "clang_cl_x86" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "cmakeToolchain": "C:/vcpkg/scripts/buildsystems/vcpkg.cmake",
+      "variables": [
+        {
+          "name": "VCPKG_TARGET_TRIPLET",
+          "value": "x86-windows-static-md",
+          "type": "STRING"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
improve Visual Studio experience by using CMakeSettings.json


this is draft PR, I do not consider it any production ready. ideas are welcome.

currently, VS refuses to open CMake, because it falls under "pkgconfig libsodium detection" which happens because no VCPKG triplet is defined. however, VS supports several CMake config files, CMAkeSettings.json (VS and VS Code only) and CMakePresets.json (usable for cmd line as well).

by using CMakeSettings we can define several profiles visible to VS, all define VCPKG triplets and other goodies. this looks like good thing. I'm not happy about hardcoded "c:\vcpkg" path and there are issues with compilers. I tried "msvc", it fails on blake2 (  https://github.com/BLAKE2/BLAKE2/pull/81 ), "clang_cl" almost works, but it tries to run c++ detection using msvc style flags. it should support msvc style flags because we choose "clang_cl", not "clang", clang_cl is supposed to be msvc style friendly, but under the hood it runs "clang++.exe", not "clang_cl.exe. 

@davidebeatrici , I would appreciate your expertise with CMake in this area.

for the record, I tried VS2022 community edition.

