### PR TITLE
Upgrade CI template for Visual Studio 2022

### DIFF
--- a/.ci/azure-pipelines/windows.yml
+++ b/.ci/azure-pipelines/windows.yml
@@ -9,9 +9,9 @@ jobs:
   - template: "windows-steps.yml"
     parameters:
       architecture: "x64"
-      compilerPath: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe"
+      compilerPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe"
       vcpkgTriplet: "x64-windows-static-md"
-      vcvarsPath: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+      vcvarsPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
 - job: Windows_x86
   pool:
     vmImage: windows-latest
@@ -22,6 +22,6 @@ jobs:
   - template: "windows-steps.yml"
     parameters:
       architecture: "x86"
-      compilerPath: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/bin/clang-cl.exe"
+      compilerPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/bin/clang-cl.exe"
       vcpkgTriplet: "x86-windows-static-md"
-      vcvarsPath: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvarsamd64_x86.bat"
+      vcvarsPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsamd64_x86.bat"


### PR DESCRIPTION
Azure CI has upgraded to Visual Studio 2022. Our template needs upgrade as well.
