### PR TITLE
Add vcpkg manifest, VS presets and update build instruction for Windows

### DIFF
--- a/.ci/azure-pipelines/windows-steps.yml
+++ b/.ci/azure-pipelines/windows-steps.yml
@@ -11,13 +11,9 @@ parameters:
 steps:
 - task: Cache@2
   inputs:
-    key: '"vcpkg-installed-windows-${{parameters.architecture}}"'
-    path: 'C:/vcpkg/installed'
+    key: '"vcpkg-manifest" | "$(Agent.OS)" | "${{parameters.vcpkgTriplet}}" | C:/vcpkg/.git/refs/heads/master'
+    path: '$(Build.BinariesDirectory)/vcpkg_installed'
   displayName: 'Environment storage'
-- script: |
-    vcpkg install libsodium openssl zlib --triplet ${{parameters.vcpkgTriplet}}
-  workingDirectory: C:/vcpkg
-  displayName: 'Prepare environment'
 - script: '$(Build.SourcesDirectory)/.ci/azure-pipelines/windows_build.bat'
   env:
     ARCHITECTURE: ${{parameters.architecture}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ if(EXISTS "${TOP_DIRECTORY}/.git" AND NOT EXISTS "${TOP_DIRECTORY}/src/libhamcor
     message (FATAL_ERROR "Submodules are not initialized. Run\n\tgit submodule update --init --recursive")
 endif()
 
+if(WIN32 AND VCPKG_TARGET_TRIPLET AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  message (FATAL_ERROR "vcpkg not installed or integrated with Visual Studio. Install it and run\n\tvcpkg integrate install")
+endif()
+
 if(UNIX)
   include(GNUInstallDirs)
 

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,141 @@
+﻿{
+  "environments": [ { "BuildNumber": "5180" } ],
+  "configurations": [
+    {
+      "name": "x64-native",
+      "description": "Target x64 with 64-bit compiler",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "clang_cl_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "BUILD_NUMBER",
+          "value": "${env.BuildNumber}",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "${env.VCINSTALLDIR}Tools/Llvm/x64/bin/clang-cl.exe",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "${env.VCINSTALLDIR}Tools/Llvm/x64/bin/clang-cl.exe",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "VCPKG_TARGET_TRIPLET",
+          "value": "x64-windows-static-md",
+          "type": "STRING"
+        }
+      ]
+    },
+    {
+      "name": "x86-on-x64",
+      "description": "Target x86 with 64-bit compiler",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "clang_cl_x86_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "BUILD_NUMBER",
+          "value": "${env.BuildNumber}",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "${env.VCINSTALLDIR}Tools/Llvm/x64/bin/clang-cl.exe",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "${env.VCINSTALLDIR}Tools/Llvm/x64/bin/clang-cl.exe",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "VCPKG_TARGET_TRIPLET",
+          "value": "x86-windows-static-md",
+          "type": "STRING"
+        }
+      ]
+    },
+    {
+      "name": "x64-on-x86",
+      "description": "Target x64 with 32-bit compiler",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "clang_cl_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "BUILD_NUMBER",
+          "value": "${env.BuildNumber}",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "${env.VCINSTALLDIR}Tools/Llvm/bin/clang-cl.exe",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "${env.VCINSTALLDIR}Tools/Llvm/bin/clang-cl.exe",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "VCPKG_TARGET_TRIPLET",
+          "value": "x64-windows-static-md",
+          "type": "STRING"
+        }
+      ]
+    },
+    {
+      "name": "x86-native",
+      "description": "Target x86 with 32-bit compiler",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "clang_cl_x86" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "BUILD_NUMBER",
+          "value": "${env.BuildNumber}",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "${env.VCINSTALLDIR}Tools/Llvm/bin/clang-cl.exe",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "${env.VCINSTALLDIR}Tools/Llvm/bin/clang-cl.exe",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "VCPKG_TARGET_TRIPLET",
+          "value": "x86-windows-static-md",
+          "type": "STRING"
+        }
+      ]
+    }
+  ]
+}

--- a/src/BUILD_WINDOWS.md
+++ b/src/BUILD_WINDOWS.md
@@ -1,31 +1,90 @@
 How to build SoftEther VPN for Windows
 ======================================
 
-Full Build Instructions
------------------------
-
-There are several methods for using CMake but the easiest by far is through Visual Studio 2019 by importing the CMake project directly
+There are several methods for using CMake but the easiest by far is through Visual Studio by importing the CMake project directly
 into it. So that is what will be described below.
 
-Requirements:
+## Requirements
 
-1. Download Visual Studio 2019 (Community Edition is fine).
-2. During install, make sure to check "Desktop development with C++" under "Workloads".
-3. Click on individual components and scroll until you see "Visual C++ tools for CMake" under the compilers section. Make sure this is checked.
-4. Proceed with and finish Visual Studio 2019 installation.
-5. Install the needed submodules to build the project, avoiding CMake telling you to do so with: `git submodule update --init --recursive`
+- Visual Studio 2019 or 2022 (Community Edition is fine)
 
-Building:
+  https://visualstudio.microsoft.com/downloads
 
-Once both installs have finished, launch Visual Studio. Once its started go to the File menu click `Open --> CMake`. Then navigate to where you
-cloned the project and open the `CMakeLists.txt` file in the projects root directory.
+- Git for Windows (or other git tool)
 
-Visual Studio will proceed to start the CMake configuration process and once its finished, you can simply go to toolbar and click `CMake -> Build All`.
+  https://gitforwindows.org/
 
-Once it has finished, hopefully with no errors, look in the newly created `/build` directory in the project's folder. Inside are the development versions
-of all the SoftEtherVPN components.
+- vcpkg
 
-Congrats, you now have a complete CMake development environment for SoftEtherVPN on Windows, enjoy and happy contributing!
+  https://github.com/microsoft/vcpkg
 
-Download Links:
-- Visual Studio 2019 from Microsoft: https://visualstudio.microsoft.com/downloads
+## Installation
+
+- Visual Studio
+
+  Download from the official site and run the installer.
+
+  Make sure to check **Desktop development with C++** under *Workloads* and **Clang C++ Tools for Windows** in *Optional* components.
+
+- Git
+
+  Nothing special. Just follow the installer.
+
+- vcpkg
+
+  Let's say you will install it to `C:\vcpkg`.
+
+  Open your preferred terminal and go to `C:\`. Then run these commands.
+
+  ```
+  C:\> git clone https://github.com/microsoft/vcpkg
+  C:\> cd vcpkg
+  C:\vcpkg> bootstrap-vcpkg.bat
+  C:\vcpkg> vcpkg integrate install
+  ```
+
+## Building
+
+1. Launch Visual Studio
+
+   Choose either **Clone a repository** to clone from GitHub or **Open a local folder** if you already have a copy.
+
+1. Open Terminal (*View -> Terminal*). Install the needed submodules to build the project, avoiding CMake telling you to do so with:
+
+   `git submodule update --init --recursive`
+
+   **Note**: This step is not necessary if you have chosen **Clone a repository** as Visual Studio automatically takes care of it.
+
+1. Select a configuration from the dropdown menu below the search box. The default configurations are:
+
+   - x64-native
+
+     Build x64 executables with 64-bit compiler (most common)
+
+   - x64-on-x86
+
+     Cross compile x64 executables with 32-bit compiler
+
+   - x86-native
+
+     Build x86 executables with 32-bit compiler
+
+   - x86-on-x64
+
+     Cross compile x86 executables with 64-bit compiler
+
+   On 64-bit Windows, all four configurations can be used. 32-bit platforms can only use 32-bit compiler.
+
+1. Visual Studio will try generating CMake cache. If not, click **Project -> Configure Cache** or **Generate Cache**.
+
+   If CMake is busy, you will find **Generate Cache** greyed out. Wait until it finishes or click **Cancel CMake Cache Generation** to stop it.
+
+   The initial configuration will take a longer time since it needs to download and install dependencies.
+
+1. When *CMake generation finished* is displayed, simply go to toolbar and click **Build -> Build All**.
+
+1. Once building has finished, hopefully with no errors, look in the newly created `/build` directory in the project's folder.
+
+   Run `vpnsetup.exe` to install desired components.
+
+1. Congrats, you now have a complete CMake development environment for SoftEtherVPN on Windows, enjoy and happy contributing!

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "softether-vpn",
+  "version-string": "5.02",
+  "dependencies": [
+    "libsodium",
+    "openssl",
+    "zlib"
+  ],
+  "overrides": [
+    {
+      "name": "openssl",
+      "version-string": "1.1.1n"
+    }
+  ],
+  "builtin-baseline": "f6af75acc923c833a5620943e3fc7d5e4930f0df"
+}


### PR DESCRIPTION
Changes proposed in this pull request:
 - Create vcpkg manifest to facilitate library installation and version management
 - Temporarily pin to openssl 1.1.1n (see comments below)
 - Remove global library installation from Azure CI
 - Add `CMakeSettings.json` to facilitate configuration in Visual Studio
 - Update Windows build instructions
 - Improved Azure pipeline cache key to avoid reusing outdated cache (comments below)