### PR TITLE
Fix Azure environment inconsistency

### DIFF
--- a/.ci/azure-pipelines/windows.yml
+++ b/.ci/azure-pipelines/windows.yml
@@ -24,4 +24,4 @@ jobs:
       architecture: "x86"
       compilerPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/bin/clang-cl.exe"
       vcpkgTriplet: "x86-windows-static-md"
-      vcvarsPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsamd64_x86.bat"
+      vcvarsPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"


### PR DESCRIPTION
For x86 builds, the environment `vcvarsamd64_x86` is cross compling x86 on x64 host.
But the clang compiler is x86.
By not specifying the path, the correct clang is now auto selected.
