### PR TITLE
Implement additional option for PrivacyFilter Mode settings

### DIFF
--- a/src/Cedar/Hub.h
+++ b/src/Cedar/Hub.h
@@ -172,6 +172,7 @@ struct HUB_OPTION
 	bool DoNotSaveHeavySecurityLogs;	// Do not take heavy security log
 	bool DropBroadcastsInPrivacyFilterMode;	// Drop broadcasting packets if the both source and destination session is PrivacyFilter mode
 	bool DropArpInPrivacyFilterMode;	// Drop ARP packets if the both source and destination session is PrivacyFilter mode
+	bool AllowSameUserInPrivacyFilterMode;	// Allow packets if both the source and destination session user are the same
 	bool SuppressClientUpdateNotification;	// Suppress the update notification function on the VPN Client
 	UINT FloodingSendQueueBufferQuota;	// The global quota of send queues of flooding packets
 	bool AssignVLanIdByRadiusAttribute;	// Assign the VLAN ID for the VPN session, by the attribute value of RADIUS

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -3880,6 +3880,16 @@ void SiLoadHubOptionCfg(FOLDER *f, HUB_OPTION *o)
 		o->DropArpInPrivacyFilterMode = true;
 	}
 
+	if (CfgIsItem(f, "AllowSameUserInPrivacyFilterMode"))
+        {
+                o->AllowSameUserInPrivacyFilterMode = CfgGetBool(f, "AllowSameUserInPrivacyFilterMode");
+        }
+        else
+        {
+                o->AllowSameUserInPrivacyFilterMode = false;
+        }
+
+
 	o->NoLookBPDUBridgeId = CfgGetBool(f, "NoLookBPDUBridgeId");
 	o->AdjustTcpMssValue = CfgGetInt(f, "AdjustTcpMssValue");
 	o->DisableAdjustTcpMss = CfgGetBool(f, "DisableAdjustTcpMss");
@@ -4004,6 +4014,7 @@ void SiWriteHubOptionCfg(FOLDER *f, HUB_OPTION *o)
 	CfgAddBool(f, "DoNotSaveHeavySecurityLogs", o->DoNotSaveHeavySecurityLogs);
 	CfgAddBool(f, "DropBroadcastsInPrivacyFilterMode", o->DropBroadcastsInPrivacyFilterMode);
 	CfgAddBool(f, "DropArpInPrivacyFilterMode", o->DropArpInPrivacyFilterMode);
+	CfgAddBool(f, "AllowSameUserInPrivacyFilterMode", o->AllowSameUserInPrivacyFilterMode);
 	CfgAddBool(f, "SuppressClientUpdateNotification", o->SuppressClientUpdateNotification);
 	CfgAddBool(f, "AssignVLanIdByRadiusAttribute", o->AssignVLanIdByRadiusAttribute);
 	CfgAddBool(f, "DenyAllRadiusLoginWithNoVlanAssign", o->DenyAllRadiusLoginWithNoVlanAssign);
@@ -7465,6 +7476,7 @@ void SiCalledUpdateHub(SERVER *s, PACK *p)
 	o.DoNotSaveHeavySecurityLogs = PackGetBool(p, "DoNotSaveHeavySecurityLogs");
 	o.DropBroadcastsInPrivacyFilterMode = PackGetBool(p, "DropBroadcastsInPrivacyFilterMode");
 	o.DropArpInPrivacyFilterMode = PackGetBool(p, "DropArpInPrivacyFilterMode");
+	o.AllowSameUserInPrivacyFilterMode= PackGetBool(p, "AllowSameUserInPrivacyFilterMode");
 	o.SuppressClientUpdateNotification = PackGetBool(p, "SuppressClientUpdateNotification");
 	o.AssignVLanIdByRadiusAttribute = PackGetBool(p, "AssignVLanIdByRadiusAttribute");
 	o.DenyAllRadiusLoginWithNoVlanAssign = PackGetBool(p, "DenyAllRadiusLoginWithNoVlanAssign");
@@ -9291,6 +9303,7 @@ void SiPackAddCreateHub(PACK *p, HUB *h)
 	PackAddBool(p, "DoNotSaveHeavySecurityLogs", h->Option->DoNotSaveHeavySecurityLogs);
 	PackAddBool(p, "DropBroadcastsInPrivacyFilterMode", h->Option->DropBroadcastsInPrivacyFilterMode);
 	PackAddBool(p, "DropArpInPrivacyFilterMode", h->Option->DropArpInPrivacyFilterMode);
+	PackAddBool(p, "AllowSameUserInPrivacyFilterMode", h->Option->AllowSameUserInPrivacyFilterMode);
 	PackAddBool(p, "SuppressClientUpdateNotification", h->Option->SuppressClientUpdateNotification);
 	PackAddBool(p, "AssignVLanIdByRadiusAttribute", h->Option->AssignVLanIdByRadiusAttribute);
 	PackAddBool(p, "DenyAllRadiusLoginWithNoVlanAssign", h->Option->DenyAllRadiusLoginWithNoVlanAssign);

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -556,6 +556,7 @@ HUB_AO_MaxLoggedPacketsPerMinute			Maximum number of logging target packets per 
 HUB_AO_DoNotSaveHeavySecurityLogs			Do not take heavy security log.
 HUB_AO_DropBroadcastsInPrivacyFilterMode	Drop broadcasting packets if the both source and destination session is PrivacyFilter mode.
 HUB_AO_DropArpInPrivacyFilterMode			Drop ARP packets if the both source and destination session is PrivacyFilter mode.
+HUB_AO_AllowSameUserInPrivacyFilterMode			Allow packets if both the source and destination session users are the same, even in PrivacyFilter mode.
 HUB_AO_SuppressClientUpdateNotification		Suppress the update notification screen on the VPN Client.
 HUB_AO_FloodingSendQueueBufferQuota			Specify the quota limitation value (in bytes) of the sending queue buffer size which the flooding operation on the Virtual Hub can consume. The quota value is applied on the total length of sending queues of all active VPN sessions. Specify '0' to disable the quota. This option is effective to solve the out-of-memory problem on the network where there are many flooding packets.
 HUB_AO_AssignVLanIdByRadiusAttribute		Enable the VLAN ID dynamic assignment function. Each VPN session will be assigned its own VLAN ID by the RADIUS attribute value when the user is authenticated by the external RADIUS server unless the user object has a VLAN ID security policy. The RADIUS attribute with the name "Tunnel-Pvt-Group-ID" (ID = 81) will be used as the VLAN ID. The data type must be STRING.

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -552,6 +552,8 @@ HUB_AO_MaxLoggedPacketsPerMinute			Maximum number of logging target packets per 
 HUB_AO_DoNotSaveHeavySecurityLogs			Do not take heavy security log.
 HUB_AO_DropBroadcastsInPrivacyFilterMode	Drop broadcasting packets if the both source and destination session is PrivacyFilter mode.
 HUB_AO_DropArpInPrivacyFilterMode			Drop ARP packets if the both source and destination session is PrivacyFilter mode.
+HUB_AO_AllowSameUserInPrivacyFilterMode			Allow packets if both the source and destination session users are the same, even in PrivacyFilter mode.
+
 HUB_AO_SuppressClientUpdateNotification		Suppress the update notification screen on the VPN Client.
 HUB_AO_FloodingSendQueueBufferQuota			Specify the quota limitation value (in bytes) of the sending queue buffer size which the flooding operation on the Virtual Hub can consume. The quota value is applied on the total length of sending queues of all active VPN sessions. Specify '0' to disable the quota. This option is effective to solve the out-of-memory problem on the network where there are many flooding packets.
 HUB_AO_AssignVLanIdByRadiusAttribute		Enable the VLAN ID dynamic assignment function. Each VPN session will be assigned its own VLAN ID by the RADIUS attribute value when the user is authenticated by the external RADIUS server unless the user object has a VLAN ID security policy. The RADIUS attribute with the name "Tunnel-Pvt-Group-ID" (ID = 81) will be used as the VLAN ID. The data type must be STRING.

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -575,6 +575,7 @@ HUB_AO_MaxLoggedPacketsPerMinute			1 分間あたりにパケットログに保�
 HUB_AO_DoNotSaveHeavySecurityLogs			保存に負荷がかかるセキュリティログを保存しない設定をします。
 HUB_AO_DropBroadcastsInPrivacyFilterMode	送信元および宛先の両方のセッションがプライバシーフィルタモードの場合、ブロードキャストパケットを破棄します。
 HUB_AO_DropArpInPrivacyFilterMode			送信元および宛先の両方のセッションがプライバシーフィルタモードの場合、ARP パケットを破棄します。
+HUB_AO_AllowSameUserInPrivacyFilterMode			プライバシーフィルターモードであっても、送信元セッションと宛先セッションの両方が同じユーザーである場合は、パケットを許可します。
 HUB_AO_SuppressClientUpdateNotification		VPN Client のアップデート通知画面の表示を抑制します。
 HUB_AO_FloodingSendQueueBufferQuota			パケットの仮想 HUB 内におけるフラッディング動作時において消費することを許容する送信キューのバッファサイズの制限値 (バイト数) を指定します。クオータは、すべての接続中の VPN セッションの送信キューの合計長さに対してグローバルに適用されます。0 を指定すると無制限になります。このオプションは、フラッディングパケットが多発するネットワークにおいてメモリ消費量が増大する問題を解決するために利用できます。
 HUB_AO_AssignVLanIdByRadiusAttribute		VLAN ID の動的割り当て機能を有効にします。VPN 接続するユーザーオブジェクトのセキュリティポリシーに VLAN ID が指定されていない場合は、各 VPN セッションはユーザー認証を行った RADIUS サーバーから返却される RADIUS 属性の値に基づき VLAN が割当てられます。RADIUS 属性のうち、 "Tunnel-Pvt-Group-ID" (ID = 81) の値が使用されます。データ型は文字列である必要があります。

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -579,6 +579,7 @@ HUB_AO_MaxLoggedPacketsPerMinute 분당 패킷 로그에 저장할 수있는 최
 HUB_AO_DoNotSaveHeavySecurityLogs 저장 집약적 보안 로그를 저장하지 않는 설정을합니다.
 HUB_AO_DropBroadcastsInPrivacyFilterMode 원본 및 대상의 두 세션이 개인 정보 보호 필터 모드의 경우 브로드 캐스트 패킷을 파기합니다.
 HUB_AO_DropArpInPrivacyFilterMode 원본 및 대상의 두 세션이 개인 정보 보호 필터 모드의 경우 ARP 패킷을 삭제합니다.
+HUB_AO_AllowSameUserInPrivacyFilterMode			원본 및 대상의 두 세션 사용자가 동일할 경우 개인 정보 보호 필터 모드일지라도 패킷을 허용합니다.
 HUB_AO_SuppressClientUpdateNotification VPN Client의 업데이트 알림 화면의 표시를 억제합니다.
 HUB_AO_FloodingSendQueueBufferQuota 패킷의 가상 HUB 내에서 홍수 동작시에 소비하는 것을 허용하는 대기열의 버퍼 크기 제한 (바이트)를 지정합니다. 쿼터는 모든 연결된 VPN 세션의 전송 큐의 총 길이에 전체적으로 적용됩니다. 0을 지정하면 제한됩니다. 이 옵션은 홍수 패킷이 다발하는 네트워크에서 메모리 소비량이 증가하는 문제를 해결하기 위해 사용할 수 있습니다.
 HUB_AO_AssignVLanIdByRadiusAttribute VLAN ID의 동적 할당 기능을 활성화합니다. VPN 연결 사용자 개체의 보안 정책에 VLAN ID가 지정되지 않은 경우 각 VPN 세션은 사용자 인증 한 RADIUS 서버에서 반환되는 RADIUS 속성 값을 기준으로 VLAN이 할당됩니다. RADIUS 속성 중 "Tunnel-Pvt-Group-ID"(ID=81)의 값이 사용됩니다. 데이터 형식은 문자열이어야합니다.

--- a/src/bin/hamcore/strtable_pt_br.stb
+++ b/src/bin/hamcore/strtable_pt_br.stb
@@ -567,6 +567,7 @@ HUB_AO_MaxLoggedPacketsPerMinute	Maximum number of logging target packets per mi
 HUB_AO_DoNotSaveHeavySecurityLogs	Do not take heavy security log.
 HUB_AO_DropBroadcastsInPrivacyFilterMode	Drop broadcasting packets if the both source and destination session is PrivacyFilter mode.
 HUB_AO_DropArpInPrivacyFilterMode	Drop ARP packets if the both source and destination session is PrivacyFilter mode.
+HUB_AO_AllowSameUserInPrivacyFilterMode			Allow packets if both the source and destination session users are the same, even in PrivacyFilter mode.
 HUB_AO_SuppressClientUpdateNotification	Suppress the update notification screen on the VPN Client.
 HUB_AO_FloodingSendQueueBufferQuota	Specify the quota limitation value (in bytes) of the sending queue buffer size which the flooding operation on the Virtual Hub can consume. The quota value is applied on the total length of sending queues of all active VPN sessions. Specify '0' to disable the quota. This option is effective to solve the out-of-memory problem on the network where there are many flooding packets.
 HUB_AO_AssignVLanIdByRadiusAttribute	Enable the VLAN ID dynamic assignment function. Each VPN session will be assigned its own VLAN ID by the RADIUS attribute value when the user is authenticated by the external RADIUS server unless the user object has a VLAN ID security policy. The RADIUS attribute with the name "Tunnel-Pvt-Group-ID" (ID = 81) will be used as the VLAN ID. The data type must be STRING.

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -552,6 +552,7 @@ HUB_AO_MaxLoggedPacketsPerMinute			Maximum number of logging target packets per 
 HUB_AO_DoNotSaveHeavySecurityLogs			Do not take heavy security log.
 HUB_AO_DropBroadcastsInPrivacyFilterMode	Drop broadcasting packets if the both source and destination session is PrivacyFilter mode.
 HUB_AO_DropArpInPrivacyFilterMode			Drop ARP packets if the both source and destination session is PrivacyFilter mode.
+HUB_AO_AllowSameUserInPrivacyFilterMode			Allow packets if both the source and destination session users are the same, even in PrivacyFilter mode.
 HUB_AO_SuppressClientUpdateNotification		Suppress the update notification screen on the VPN Client.
 HUB_AO_FloodingSendQueueBufferQuota			Specify the quota limitation value (in bytes) of the sending queue buffer size which the flooding operation on the Virtual Hub can consume. The quota value is applied on the total length of sending queues of all active VPN sessions. Specify '0' to disable the quota. This option is effective to solve the out-of-memory problem on the network where there are many flooding packets.
 HUB_AO_AssignVLanIdByRadiusAttribute		Enable the VLAN ID dynamic assignment function. Each VPN session will be assigned its own VLAN ID by the RADIUS attribute value when the user is authenticated by the external RADIUS server unless the user object has a VLAN ID security policy. The RADIUS attribute with the name "Tunnel-Pvt-Group-ID" (ID = 81) will be used as the VLAN ID. The data type must be STRING.


### PR DESCRIPTION
Background
- PrivacyFilter mode is a function for administrators to restrict communication between users for security reasons.
- This option is useful for implementing the VPN user isolation.
- However, there are cases where it is necessary to allow exceptionally for communication between the same users.
(For security reasons, it is necessary to block traffic between different users, but it is often necessary to allow traffic between sessions of the same user.)

Changes proposed in this pull request:
- Added [AllowSameUserInPrivacyFilterMode] option to [Virtual Hub Extended Option]
- When PrivacyFilter Mode is set and AllowSameUserInPrivacyFilterMode is Enabled, traffic between the same users is not exceptionally blocked.
