### PR TITLE
Fix invalid systemd TasksMax

### DIFF
--- a/systemd/softether-vpnserver.service
+++ b/systemd/softether-vpnserver.service
@@ -5,7 +5,7 @@ ConditionPathExists=!@DIR@/softether/vpnserver/do_not_run
 
 [Service]
 Type=forking
-TasksMax=16777216
+TasksMax=infinity
 EnvironmentFile=-@DIR@/softether/vpnserver
 ExecStart=@DIR@/softether/vpnserver/vpnserver start
 ExecStop=@DIR@/softether/vpnserver/vpnserver stop


### PR DESCRIPTION
Max pid is usually 32768 on 32-bit systems and 4194304 on 64-bit. 16777216 is way too large.

Changes proposed in this pull request:
 - Use `infinity` instead of a fixed number for `TasksMax`

Close #903 
