### PR TITLE
Remove CM timer event to fix taskbar behavior on Win 11

### DIFF
--- a/src/Cedar/CM.c
+++ b/src/Cedar/CM.c
@@ -4251,9 +4251,6 @@ UINT CmMainWindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, void *p
 	case WM_TIMER:
 		switch (wParam)
 		{
-		case 1:
-			CmSetForegroundProcessToCnService();
-			break;
 		case 2:
 			CmPollingTray(hWnd);
 			break;
@@ -11269,7 +11266,6 @@ void CmMainWindowOnInit(HWND hWnd)
 	CmInitNotifyClientThread();
 
 	// Timer setting
-	SetTimer(hWnd, 1, 128, NULL);
 	SetTimer(hWnd, 6, 5000, NULL);
 
 	// Initialize the task tray


### PR DESCRIPTION
### Symptom
On Win 11, when CM is in focus, some taskbar functions are not working properly. 
For example, right clicks on icons do not work. Some programs will open in background (below CM).

### Cause

In CM we have a timer event that repeatedly puts notification service into foreground. This prevents other programs to get focus.
```c
		case WM_TIMER:
		switch (wParam)
		{
		case 1:
			CmSetForegroundProcessToCnService();
			break;
```

### Fix

The timer event can be safely removed. The notification service is used to show connection status and only needs to be brought up when a connection is started or restarted, which is already done in `CmConnect()`.

Tested on Windows Vista and 11. More tests are welcome.

Related: #1591 