### PR TITLE
Show connection names in tray tips

### DIFF
--- a/src/Cedar/CM.c
+++ b/src/Cedar/CM.c
@@ -10472,7 +10472,7 @@ void CmRefreshAccountListEx2(HWND hWnd, bool easy, bool style_changed)
 	UINT num = 0;
 	RPC_CLIENT_ENUM_ACCOUNT a;
 	UINT num_connecting = 0, num_connected = 0;
-	wchar_t tmp[MAX_SIZE];
+	wchar_t tooltip[MAX_SIZE];
 	wchar_t new_inserted_item[MAX_ACCOUNT_NAME_LEN + 1];
 	bool select_new_inserted_item = true;
 	// Validate arguments
@@ -10525,6 +10525,8 @@ void CmRefreshAccountListEx2(HWND hWnd, bool easy, bool style_changed)
 	{
 		select_new_inserted_item = false;
 	}
+
+	UniStrCpy(tooltip, sizeof(tooltip), _UU("CM_TRAY_INITING"));
 
 	// Enumerate the account list
 	if (CALL(hWnd, CcEnumAccount(cm->Client, &a)))
@@ -10649,10 +10651,16 @@ void CmRefreshAccountListEx2(HWND hWnd, bool easy, bool style_changed)
 				if (t->Connected)
 				{
 					num_connected++;
+					UniStrCat(tooltip, sizeof(tooltip), L"\r\n"L"\r\n");
+					UniStrCat(tooltip, sizeof(tooltip), t->AccountName);
+					UniStrCat(tooltip, sizeof(tooltip), _UU("CM_TRAY_CONNECTED"));
 				}
 				else
 				{
 					num_connecting++;
+					UniStrCat(tooltip, sizeof(tooltip), L"\r\n"L"\r\n");
+					UniStrCat(tooltip, sizeof(tooltip), t->AccountName);
+					UniStrCat(tooltip, sizeof(tooltip), _UU("CM_TRAY_CONNECTING"));
 				}
 			}
 		}
@@ -10705,22 +10713,8 @@ void CmRefreshAccountListEx2(HWND hWnd, bool easy, bool style_changed)
 		if (num_connecting == 0 && num_connected == 0)
 		{
 			// There is no connecting or connected account
-			UniStrCpy(tmp, sizeof(tmp), _UU("CM_TRAY_NOT_CONNECTED"));
-		}
-		else if (num_connected == 0)
-		{
-			// There is only connecting account
-			UniFormat(tmp, sizeof(tmp), _UU("CM_TRAY_CONNECTED_1"), num_connecting);
-		}
-		else if (num_connecting == 0)
-		{
-			// There is only connected account
-			UniFormat(tmp, sizeof(tmp), _UU("CM_TRAY_CONNECTED_2"), num_connected);
-		}
-		else
-		{
-			// There are both
-			UniFormat(tmp, sizeof(tmp), _UU("CM_TRAY_CONNECTED_0"), num_connected, num_connecting);
+			UniStrCat(tooltip, sizeof(tooltip), L"\r\n");
+			UniStrCat(tooltip, sizeof(tooltip), _UU("CM_TRAY_NOT_CONNECTED"));
 		}
 
 		if (num_connecting == 0 && num_connected == 0)
@@ -10742,7 +10736,7 @@ void CmRefreshAccountListEx2(HWND hWnd, bool easy, bool style_changed)
 			}
 		}
 
-		CmChangeTrayString(hWnd, tmp);
+		CmChangeTrayString(hWnd, tooltip);
 	}
 
 	Refresh(hWnd);

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -974,11 +974,10 @@ CM_VPN_FILE_IMPORT_NG		无法导入 VPN 连接设置文件。由于 VPN Client �
 CM_VLAN_INSTALLING			请稍候...
 CM_SECURE_MUST_LOCAL		因为目前您对远程计算机进行连接并管理 VPN Client，因此无法修改智能卡设置。
 CM_DETAIL_MODE_LINK_STR		使用级联，则“通过网桥，路由模式连接”始终启用。
-CM_TRAY_INITING				VPN Client 管理器 (Developer Edition)
-CM_TRAY_NOT_CONNECTED		VPN Client 管理器 (Developer Edition)\r\n未连接
-CM_TRAY_CONNECTED_0			VPN Client 管理器 (Developer Edition)\r\n主动连接到%u个服务器，并尝试连接到 %u 个服务器
-CM_TRAY_CONNECTED_1			VPN Client 管理器 (Developer Edition)\r\n尝试连接到%u个服务器
-CM_TRAY_CONNECTED_2			VPN Client 管理器 (Developer Edition)\r\n的 %u 个服务器中的连接
+CM_TRAY_INITING				SoftEther VPN
+CM_TRAY_NOT_CONNECTED		\r\n未连接
+CM_TRAY_CONNECTING			\r\n正在连接
+CM_TRAY_CONNECTED			\r\n已连接
 CM_TRAY_MENU_1_SHOW			显示 VPN Client 管理器(&S)
 CM_TRAY_MENU_1_HIDE			关闭 VPN Client 管理器(&O)
 CM_TRAY_MENU_2_QUIT			退出 VPN Client 管理器程序(&X)

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -969,11 +969,10 @@ CM_VPN_FILE_IMPORT_NG	Unable to import the VPN Connection Setting File. Because 
 CM_VLAN_INSTALLING		Please Wait a While
 CM_SECURE_MUST_LOCAL	It is currently not possible to configure smart card settings because you are connected to and managing a VPN Client on a remote computer.
 CM_DETAIL_MODE_LINK_STR	With a Cascade Connection, Connect by Bridge / Router mode is always enabled.
-CM_TRAY_INITING			SoftEther VPN Client Manager (Developer Edition) ...
-CM_TRAY_NOT_CONNECTED	SoftEther VPN Client Manager (Developer Edition)\r\nNot connected.
-CM_TRAY_CONNECTED_0		SoftEther VPN Client Manager (Developer Edition)\r\nActive connections to %u servers and is attempting to connect to %u servers
-CM_TRAY_CONNECTED_1		SoftEther VPN Client Manager (Developer Edition)\r\nAttempting to connect to %u servers
-CM_TRAY_CONNECTED_2		SoftEther VPN Client Manager (Developer Edition)\r\nActive connections to %u servers
+CM_TRAY_INITING			SoftEther VPN
+CM_TRAY_NOT_CONNECTED	\r\nNot connected
+CM_TRAY_CONNECTING		\r\nConnecting
+CM_TRAY_CONNECTED		\r\nConnected
 CM_TRAY_MENU_1_SHOW		&Show VPN Client Manager
 CM_TRAY_MENU_1_HIDE		Cl&ose VPN Client Manager
 CM_TRAY_MENU_2_QUIT		E&xit VPN Client Manager Program

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -970,11 +970,10 @@ CM_VPN_FILE_IMPORT_NG	接続設定ファイルをインポートできません�
 CM_VLAN_INSTALLING		しばらくお待ちください...
 CM_SECURE_MUST_LOCAL	現在リモートコンピュータの VPN Client サービスに接続して管理しているため、スマートカードの設定を行うことはできません。
 CM_DETAIL_MODE_LINK_STR	カスケード接続では、常に [ブリッジ / ルータモードで接続] が有効になっています。
-CM_TRAY_INITING			SoftEther VPN クライアント接続マネージャ (Developer Edition)
-CM_TRAY_NOT_CONNECTED	SoftEther VPN クライアント接続マネージャ (Developer Edition)\r\n接続していません
-CM_TRAY_CONNECTED_0		SoftEther VPN クライアント接続マネージャ (Developer Edition)\r\n%u 個のサーバーとの接続が完了し、%u 個のサーバーに接続を試行しています
-CM_TRAY_CONNECTED_1		SoftEther VPN クライアント接続マネージャ (Developer Edition)\r\n%u 個のサーバーに接続を試行しています
-CM_TRAY_CONNECTED_2		SoftEther VPN クライアント接続マネージャ (Developer Edition)\r\n%u 個のサーバーと接続が完了しています
+CM_TRAY_INITING			SoftEther VPN
+CM_TRAY_NOT_CONNECTED	\r\n接続していません
+CM_TRAY_CONNECTING		\r\n接続処理中
+CM_TRAY_CONNECTED		\r\n接続完了
 CM_TRAY_MENU_1_SHOW		接続マネージャを表示する(&S)
 CM_TRAY_MENU_1_HIDE		接続マネージャを閉じる(&O)
 CM_TRAY_MENU_2_QUIT		接続マネージャプログラムの終了(&X)

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -971,11 +971,10 @@ CM_VPN_FILE_IMPORT_NG 연결 설정 파일을 가져올 수 없습니다. VPN Cl
 CM_VLAN_INSTALLING 기다려주십시오...
 CM_SECURE_MUST_LOCAL 현재 원격 컴퓨터의 VPN Client 서비스에 연결하여 관리하고 있기 때문에 스마트 카드의 설정을 할 수 없습니다.
 CM_DETAIL_MODE_LINK_STR 캐스케이드는 항상 브리지/라우터 모드에서 연결이 활성화되어 있습니다.
-CM_TRAY_INITING SoftEther VPN 클라이언트 연결 관리자
-CM_TRAY_NOT_CONNECTED SoftEther VPN 클라이언트 연결 관리자 \r\n 연결되어 있지 않습니다
-CM_TRAY_CONNECTED_0 SoftEther VPN 클라이언트 연결 관리자 \r\n %u 개의 서버와의 연결이 완료 %u 개의 서버에 연결을 시도합니다
-CM_TRAY_CONNECTED_1 SoftEther VPN 클라이언트 연결 관리자 \r\n %u 개의 서버에 연결을 시도합니다
-CM_TRAY_CONNECTED_2 SoftEther VPN 클라이언트 연결 관리자 \r\n %u 개의 서버와 연결이 완료하고 있습니다
+CM_TRAY_INITING SoftEther VPN
+CM_TRAY_NOT_CONNECTED \r\n연결되어 있지 않습니다
+CM_TRAY_CONNECTING \r\n연결 중
+CM_TRAY_CONNECTED \r\n연결됨
 CM_TRAY_MENU_1_SHOW 연결 관리자를 표시 (&S)
 CM_TRAY_MENU_1_HIDE 연결 관리자를 닫기 (&O)
 CM_TRAY_MENU_2_QUIT 연결 관리자 프로그램의 종료 (&X)

--- a/src/bin/hamcore/strtable_pt_br.stb
+++ b/src/bin/hamcore/strtable_pt_br.stb
@@ -984,11 +984,10 @@ CM_VPN_FILE_IMPORT_NG	Unable to import the VPN Connection Setting File. Because 
 CM_VLAN_INSTALLING	Please Wait a While
 CM_SECURE_MUST_LOCAL	It is currently not possible to configure smart card settings because you are connected to and managing a VPN Client on a remote computer.
 CM_DETAIL_MODE_LINK_STR	With a Cascade Connection, Connect by Bridge / Router mode is always enabled.
-CM_TRAY_INITING	Gerenciador de clientes VPN SoftEther (Edição de desenvolvedor)
-CM_TRAY_NOT_CONNECTED	SoftEther VPN Client Manager (Developer Edition)\r\nNot connected.
-CM_TRAY_CONNECTED_0	SoftEther VPN Client Manager (Developer Edition)\r\nActive connections to %u servers and is attempting to connect to %u servers
-CM_TRAY_CONNECTED_1	SoftEther VPN Client Manager (Developer Edition)\r\nAttempting to connect to %u servers
-CM_TRAY_CONNECTED_2	Gerenciador de clientes VPN SoftEther (Edição de desenvolvedor)\r\nConexões ativas com %u servidores
+CM_TRAY_INITING			SoftEther VPN
+CM_TRAY_NOT_CONNECTED	\r\nNot connected
+CM_TRAY_CONNECTING		\r\nConnecting
+CM_TRAY_CONNECTED		\r\nConnected
 CM_TRAY_MENU_1_SHOW	&Mostra gerenciador de clientes VPN
 CM_TRAY_MENU_1_HIDE	&Fechar o gerenciador de clientes VPN
 CM_TRAY_MENU_2_QUIT	Sair doGerenciador de clientes VPN

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -968,11 +968,10 @@ CM_VPN_FILE_IMPORT_NG	Unable to import the VPN Connection Setting File. Because 
 CM_VLAN_INSTALLING		Please Wait a While
 CM_SECURE_MUST_LOCAL	It is currently not possible to configure smart card settings because you are connected to and managing a VPN Client on a remote computer.
 CM_DETAIL_MODE_LINK_STR	With a Cascade Connection, Connect by Bridge / Router mode is always enabled.
-CM_TRAY_INITING			SoftEther VPN Client Manager (Developer Edition) ...
-CM_TRAY_NOT_CONNECTED	SoftEther VPN Client Manager (Developer Edition)\r\nNot connected.
-CM_TRAY_CONNECTED_0		SoftEther VPN Client Manager (Developer Edition)\r\nActive connections to %u servers and is attempting to connect to %u servers
-CM_TRAY_CONNECTED_1		SoftEther VPN Client Manager (Developer Edition)\r\nAttempting to connect to %u servers
-CM_TRAY_CONNECTED_2		SoftEther VPN Client Manager (Developer Edition)\r\nActive connections to %u servers
+CM_TRAY_INITING			SoftEther VPN
+CM_TRAY_NOT_CONNECTED	\r\nNot connected
+CM_TRAY_CONNECTING		\r\nConnecting
+CM_TRAY_CONNECTED		\r\nConnected
 CM_TRAY_MENU_1_SHOW		Открыть VPN Client Manager (&S)
 CM_TRAY_MENU_1_HIDE		Cl&ose VPN Client Manager
 CM_TRAY_MENU_2_QUIT		E&xit VPN Client Manager Program

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -976,11 +976,10 @@ CM_VPN_FILE_IMPORT_NG	無法導入 VPN 連接設置檔案。由於 VPN Client �
 CM_VLAN_INSTALLING		請稍候...
 CM_SECURE_MUST_LOCAL	因為目前您對遠端電腦進行連接並管理 VPN Client，因此無法修改智慧卡設置。
 CM_DETAIL_MODE_LINK_STR	使用級聯，則“通過橋接器，路由模式連接”始終啟用。
-CM_TRAY_INITING			VPN Client 管理器 (Developer Edition)
-CM_TRAY_NOT_CONNECTED	VPN Client 管理器 (Developer Edition)\r\n未連接
-CM_TRAY_CONNECTED_0		VPN Client 管理器 (Developer Edition)\r\n主動連接到%u個伺服器，並嘗試連接到 %u 個伺服器
-CM_TRAY_CONNECTED_1		VPN Client 管理器 (Developer Edition)\r\n嘗試連接到%u個伺服器
-CM_TRAY_CONNECTED_2		VPN Client 管理器 (Developer Edition)\r\n的 %u 個伺服器中的連接
+CM_TRAY_INITING			SoftEther VPN
+CM_TRAY_NOT_CONNECTED	\r\n未連接
+CM_TRAY_CONNECTING		\r\n正在連接
+CM_TRAY_CONNECTED		\r\n已連接
 CM_TRAY_MENU_1_SHOW		顯示 VPN Client 管理器(&S)
 CM_TRAY_MENU_1_HIDE		關閉 VPN Client 管理器(&O)
 CM_TRAY_MENU_2_QUIT		退出 VPN Client 管理器程式(&X)


### PR DESCRIPTION
Changes proposed in this pull request:
 - Show names of connecting and connected accounts over tray icon
 - Tips have been shortened to be easier to read

Feel free to suggest better wording.

Effects
![image](https://user-images.githubusercontent.com/54519668/168422563-eb19b7a9-c0b9-41bf-bda1-4f4ff82f7a12.png) ![image](https://user-images.githubusercontent.com/54519668/168422611-b14878aa-e733-4609-87a2-1cb91b79849b.png) ![image](https://user-images.githubusercontent.com/54519668/168422584-068e29ae-782e-4522-94dc-c3700f48fbdc.png)

![image](https://user-images.githubusercontent.com/54519668/168422648-2a700b5e-446a-45dc-b773-2d2dd02f9c04.png) ![image](https://user-images.githubusercontent.com/54519668/168422632-afa89883-6639-4890-8a6f-e1b0e6f2c9d8.png) ![image](https://user-images.githubusercontent.com/54519668/168422656-46725966-bd13-4ec0-a413-f976ed524738.png)

Fix #1037 
