### PR TITLE
Proto_OpenVPN: Set max allowed ACKs to 8 for P_ACK_V1

### DIFF
--- a/src/Cedar/Proto_OpenVPN.c
+++ b/src/Cedar/Proto_OpenVPN.c
@@ -1902,6 +1902,10 @@ BUF *OvsBuildPacket(OPENVPN_PACKET *p)
 
 	// NumAck
 	num_ack = MIN(p->NumAck, OPENVPN_MAX_NUMACK);
+	if (p->OpCode != OPENVPN_P_ACK_V1)
+	{
+		num_ack = MIN(num_ack, OPENVPN_MAX_NUMACK_NONACK);
+	}
 	WriteBufChar(b, (UCHAR)num_ack);
 
 	if (p->NumAck >= 1)
@@ -1982,7 +1986,7 @@ OPENVPN_PACKET *OvsParsePacket(UCHAR *data, UINT size)
 
 	ret->NumAck = uc;
 
-	if (ret->NumAck > 4)
+	if (ret->NumAck > OPENVPN_MAX_NUMACK)
 	{
 		goto LABEL_ERROR;
 	}

--- a/src/Cedar/Proto_OpenVPN.h
+++ b/src/Cedar/Proto_OpenVPN.h
@@ -14,7 +14,8 @@
 #define	OPENVPN_UDP_PORT						1194	// OpenVPN default UDP port number
 #define	OPENVPN_UDP_PORT_INCLUDE				1195	// OpenVPN default UDP port number (Operating within the client)
 
-#define	OPENVPN_MAX_NUMACK						4		// The maximum number of ACKs
+#define	OPENVPN_MAX_NUMACK						8		// The maximum number of ACKs
+#define	OPENVPN_MAX_NUMACK_NONACK					4		// The maximum number of ACKs in != P_ACK_V1
 #define	OPENVPN_NUM_CHANNELS					8		// Maximum number of channels during a session
 #define	OPENVPN_CONTROL_PACKET_RESEND_INTERVAL	500		// Control packet retransmission interval
 #define	OPENVPN_CONTROL_PACKET_MAX_DATASIZE		1200	// Maximum data size that can be stored in one control packet


### PR DESCRIPTION
OpenVPN always allowed 8 ACKs in P_ACK_V1 packets but only used
up to 4 in other control packets. Since Softether drops all packets with
more than 4 ACKs it also drops legimate P_ACK_V1.

See also this issue: https://github.com/schwabe/ics-openvpn/issues/1486
