### PR TITLE
Adjust TCP MSS if UDP acceleration is enabled (even if inactive)

### DIFF
--- a/src/Cedar/Hub.c
+++ b/src/Cedar/Hub.c
@@ -3564,7 +3564,7 @@ bool HubPaPutPacket(SESSION *s, void *data, UINT size)
 
 		target_mss = MIN(target_mss, session_mss);
 
-		if (s->IsUsingUdpAcceleration && s->UdpAccelMss != 0)
+		if (s->UseUdpAcceleration && s->UdpAccelMss != 0)
 		{
 			// If the link is established with UDP acceleration function, use optimum value of the UDP acceleration function
 			target_mss = MIN(target_mss, s->UdpAccelMss);
@@ -5362,7 +5362,7 @@ void StorePacketToHubPa(HUB_PA *dest, SESSION *src, void *data, UINT size, PKT *
 	if (src != NULL && dest->Session != NULL && src->Hub != NULL && src->Hub->Option != NULL)
 	{
 		if (dest->Session->AdjustMss != 0 ||
-			(dest->Session->IsUsingUdpAcceleration && dest->Session->UdpAccelMss != 0) ||
+			(dest->Session->UseUdpAcceleration && dest->Session->UdpAccelMss != 0) ||
 			(dest->Session->IsRUDPSession && dest->Session->RUdpMss != 0))
 		{
 			if (src->Hub->Option->DisableAdjustTcpMss == false)
@@ -5374,7 +5374,7 @@ void StorePacketToHubPa(HUB_PA *dest, SESSION *src, void *data, UINT size, PKT *
 					target_mss = MIN(target_mss, dest->Session->AdjustMss);
 				}
 
-				if (dest->Session->IsUsingUdpAcceleration && dest->Session->UdpAccelMss != 0)
+				if (dest->Session->UseUdpAcceleration && dest->Session->UdpAccelMss != 0)
 				{
 					target_mss = MIN(target_mss, dest->Session->UdpAccelMss);
 				}


### PR DESCRIPTION
Currently we don't adjust TCP MSS for UDP acceleration sessions unless the acceleration is active (in use).

This is troublesome because UDP acceleration can turn active in the middle of a session. If an encapsulated TCP connection was started when UDP acceleration is not in use (but enabled), its MSS was not adjusted but once acceleration turns active the unadjusted TCP packets will be sent over UDP, resulting in fragmentation or packet loss.

This PR adjusts MSS for sessions that have UDP acceleration enabled, no matter in use or not.

This screenshot shows the situation when UDP acceleration turns active. You can see that data starts to be sent via UDP but is fragmented due to the size.

![スクリーンショット 2022-06-13 224958](https://user-images.githubusercontent.com/54519668/173369433-5cabff12-612f-48aa-9ba8-f5f484361374.png)
