### PR TITLE
Zero out protocol strings when reconnecting

### DIFF
--- a/src/Cedar/Session.c
+++ b/src/Cedar/Session.c
@@ -1430,6 +1430,8 @@ void ClientThread(THREAD *t, void *param)
 	while (true)
 	{
 		Zero(&s->ServerIP_CacheForNextConnect, sizeof(IP));
+		Zero(s->UnderlayProtocol, sizeof(s->UnderlayProtocol));
+		Zero(s->ProtocolDetails, sizeof(s->ProtocolDetails));
 
 		if (s->Link != NULL && ((*s->Link->StopAllLinkFlag) || s->Link->Halting))
 		{


### PR DESCRIPTION
Protocol details may contain old information when reconnecting and need to be flushed.