### PR TITLE
Exclude inactive routes in Windows routing management

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -9414,7 +9414,15 @@ RETRY:
 	{
 		e = ZeroMallocFast(sizeof(ROUTE_ENTRY));
 		Win32IpForwardRow2ToRouteEntry(e, &p->Table[i]);
-		Add(o, e);
+
+		if (e->Active)
+		{
+			Add(o, e);
+		}
+		else
+		{
+			FreeRouteEntry(e);
+		}
 	}
 	FreeMibTable(p);
 
@@ -9573,6 +9581,7 @@ void Win32IpForwardRow2ToRouteEntry(ROUTE_ENTRY *entry, void *ip_forward_row)
 	{
 		entry->IfMetric = p->Metric;
 		entry->Metric = r->Metric + p->Metric;
+		entry->Active = p->Connected;
 	}
 	else
 	{

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -293,6 +293,7 @@ struct ROUTE_ENTRY
 	UINT IfMetric;
 	UINT InterfaceID;
 	UINT64 InnerScore;
+	bool Active;
 };
 
 // Routing table


### PR DESCRIPTION
This issue was discovered by hiura on vpnusers.com forum. 

Original post: https://www.vpnusers.com/viewtopic.php?f=15&p=96843

When we implemented routing management for IPv6 (#1443), we replaced `GetIpForwardTable` with `GetIpForwardEntry2`. However it turned out that `GetIpForwardEntry2` might include inactive routes, such as those belong to disconnected interfaces.

The solution is to filter the returned routes by querying the status of the IP interface. To maintain comparability, inactive routes are simply dropped in `Win32GetRouteTable2`. This behavior can be changed in the future.