### PR TITLE
BridgeUnix.c: Disable MTU changes on FreeBSD

### DIFF
--- a/src/Cedar/BridgeUnix.c
+++ b/src/Cedar/BridgeUnix.c
@@ -805,7 +805,12 @@ bool EthIsChangeMtuSupported(ETH *e)
 		return false;
 	}
 
+// FreeBSD seriously dislikes MTU changes; disable if compiled on that platform
+#ifndef	__FreeBSD__
 	return true;
+#else
+	return false;
+#endif
 #else	// defined(UNIX_LINUX) || defined(UNIX_BSD) || defined(UNIX_SOLARIS)
 	return false;
 #endif	// defined(UNIX_LINUX) || defined(UNIX_BSD) || defined(UNIX_SOLARIS)


### PR DESCRIPTION
On FreeBSD the stock code will attempt to expand the interface MTU any time a packet is to be sent that exceeds the current MTU.  This results in a down/up on the interface that is wildly disruptive to existing services on that adapter and, eventually, is likely to run into MTU limits and start logging failures, even with jumbo-frame capable adapters.  Thus if compiling on a FreeBSD machine disable this capability.  Tested against 12.3-STABLE and 13.1-STABLE on v4.38-9760 from the FreeBSD ports tree but likely applies here as well; see bug report https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267178

Changes proposed in this pull request:
 - 
 - 
 - 

