### PR TITLE
FreeBSD CI: Add test with OpenSSL 3.0.x

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,11 +3,14 @@ FreeBSD_task:
     env:
       SSL: openssl
     env:
+      # OpenSSL 3.0.x
+      SSL: openssl-devel
+    env:
       # base openssl
       SSL:
   matrix:
     freebsd_instance:
-      image_family: freebsd-12-1
+      image_family: freebsd-13-1
   prepare_script:
     - pkg install -y pkgconf cmake git libsodium $SSL
     - git submodule update --init --recursive


### PR DESCRIPTION
As the stable version uses OpenSSL 3.0.x, it is nice to perform test with OpenSSL 3.0.x as well.

Also, update FreeBSD to 13.1.

