### PR TITLE
Mayaqua/CMakeLists: Fix win32 build without vcpkg

### DIFF
--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -54,6 +54,7 @@ if(WIN32)
 
   target_link_libraries(mayaqua
     PRIVATE
+      "crypt32.lib"
       "DbgHelp.Lib"
       "dwmapi.lib"
       "iphlpapi.lib"
@@ -62,9 +63,8 @@ if(WIN32)
       "Secur32.Lib"
       "setupapi.lib"
       "winmm.lib"
-      "WtsApi32.Lib"
       "ws2_32.lib"
-      "crypt32.lib"
+      "WtsApi32.Lib"
     )
 endif()
 

--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -63,6 +63,8 @@ if(WIN32)
       "setupapi.lib"
       "winmm.lib"
       "WtsApi32.Lib"
+      "ws2_32.lib"
+      "crypt32.lib"
     )
 endif()
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - Add `ws2_32.lib` and `crypt32.lib` to `CMakeLists.txt` to fix linking issues
 - 
 - 

