### PR TITLE
src/Cedar/Server.c: mute Coverity warning

### DIFF
--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -8130,12 +8130,10 @@ PACK *SiCalledCreateTicket(SERVER *s, PACK *p)
 	if (PackGetDataSize(p, "Ticket") == SHA1_SIZE)
 	{
 		PackGetData(p, "Ticket", ticket);
+		BinToStr(ticket_str, sizeof(ticket_str), ticket, SHA1_SIZE);
+		SLog(s->Cedar, "LS_TICKET_2", hubname, username, realusername, sessionname,
+			ticket_str, TICKET_EXPIRES / 1000);
 	}
-
-	BinToStr(ticket_str, sizeof(ticket_str), ticket, SHA1_SIZE);
-
-	SLog(s->Cedar, "LS_TICKET_2", hubname, username, realusername, sessionname,
-		ticket_str, TICKET_EXPIRES / 1000);
 
 	// Get the HUB
 	h = GetHub(s->Cedar, hubname);


### PR DESCRIPTION
CID 375156: Uninitialized scalar variable (UNINIT)5. uninit_use_in_call: Using uninitialized element of array ticket when calling BinToStr. 8135        BinToStr(ticket_str, sizeof(ticket_str), ticket, SHA1_SIZE);



