### PR TITLE
src/Cedar/Virtual.c: mute Coverity warning

### DIFF
--- a/src/Cedar/Virtual.c
+++ b/src/Cedar/Virtual.c
@@ -4214,7 +4214,7 @@ bool NatTransactUdp(VH *v, NAT_ENTRY *n)
 	// Try to send data to the UDP socket
 	while (block = GetNext(n->UdpSendQueue))
 	{
-		UINT send_size;
+		UINT send_size = 0;
 		bool is_nbtdgm = false;
 		LIST *local_ip_list = NULL;
 


### PR DESCRIPTION
4272                FreeBlock(block);
    CID 375153 (#1 of 1): Uninitialized scalar variable (UNINIT)44. uninit_use: Using uninitialized value send_size. 4273                if (send_size == 0)



