### PR TITLE
src/Mayaqua/Unix.c: improve memory allocation handling according to Coverity

### DIFF
--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -1869,11 +1869,16 @@ LOCK *UnixNewLock()
 	pthread_mutex_t *mutex;
 	// Memory allocation
 	LOCK *lock = UnixMemoryAlloc(sizeof(LOCK));
+	if (lock == NULL)
+	{
+		return NULL;
+	}
 
 	// Create a mutex
 	mutex = UnixMemoryAlloc(sizeof(pthread_mutex_t));
 	if (mutex == NULL)
 	{
+		UnixMemoryFree(lock);
 		return NULL;
 	}
 


### PR DESCRIPTION


1875        if (mutex == NULL)
1876        {
    CID 367204 (#1 of 1): Resource leak (RESOURCE_LEAK)4. leaked_storage: Variable lock going out of scope leaks the storage it points to. 1877                return NULL;
1878        }


