### PR TITLE
add requirements package on Debian/Ubuntu

### DIFF
--- a/src/BUILD_UNIX.md
+++ b/src/BUILD_UNIX.md
@@ -38,7 +38,7 @@ sudo yum -y install cmake ncurses-devel openssl-devel libsodium-devel readline-d
 
 ## Install requirements on Debian/Ubuntu
 ```bash
-sudo apt -y install cmake gcc g++ make libncurses5-dev libssl-dev libsodium-dev libreadline-dev zlib1g-dev
+sudo apt -y install cmake gcc g++ make pkgconf libncurses5-dev libssl-dev libsodium-dev libreadline-dev zlib1g-dev
 ```
 
 ## Install requirements on macOS


### PR DESCRIPTION
On Ubuntu Server 22.04 LTS (and newer?), the ./configure command fails because the 'pkgconf' package is not installed by default. Suggest that the 'pkgconf' package be installed in this command line.