### PR TITLE
Cedar/IPC: Improve IPv6CP configuration

### DIFF
--- a/src/Cedar/IPC.h
+++ b/src/Cedar/IPC.h
@@ -155,7 +155,7 @@ struct IPC
 	LIST *IPv6NeighborTable;			// Neighbor Discovery Table
 	LIST *IPv6RouterAdvs;				// Router offered prefixes
 	UINT64 IPv6ClientEUI;				// The EUI of the client (for the SLAAC autoconf)
-	UINT64 IPv6ServerEUI;				// The EUI of the server (from the RA discovery)
+	UINT64 IPv6ServerEUI;				// The EUI of the server (from the IPC Mac address)
 };
 
 // MS-CHAPv2 authentication information
@@ -233,7 +233,7 @@ bool IPCIPv6CheckExistingLinkLocal(IPC *ipc, UINT64 eui);
 // RA
 void IPCIPv6AddRouterPrefixes(IPC *ipc, ICMPV6_OPTION_LIST *recvPrefix, UCHAR *macAddress, IP *ip);
 bool IPCIPv6CheckUnicastFromRouterPrefix(IPC *ipc, IP *ip, IPC_IPV6_ROUTER_ADVERTISEMENT *matchedRA);
-UINT64 IPCIPv6GetServerEui(IPC *ipc);
+bool IPCSendIPv6RouterSoliciation(IPC *ipc);
 // Data flow
 BLOCK *IPCIPv6Recv(IPC *ipc);
 void IPCIPv6Send(IPC *ipc, void *data, UINT size);


### PR DESCRIPTION
IPv6CP configuration in the PPP stack has issues on both sides, as detailed below.

- Client side
  Currently we check the EUI proposed by the client against hub IP table and accept it if no conflict. 
  If there is a conflict or the client does not propose any address, we assign one based on the IPC's MAC address.
  The problem is, the IPC's MAC address is not random and can be reused from time to time.
  This would lead to distinct VPN sessions using the same EUI (although not at the same time).
  I propose to use a random address in case of a conflict.

- Server side
  Currently we try to match the server EUI to the address of the IPv6 router by sending router solicitations.
  The process can be slow if no IPv6 router is available, since we have to wait until timeout.
  It's also unnecessary because the server EUI, just like the server address under IPCP, is not used anywhere.
  I propose to use the IPC's MAC address instead, saving the time to look for a router.

