### PR TITLE
Cedar/IPC: Change IPv6 router lookup to non-blocking

### DIFF
--- a/src/Cedar/IPC.h
+++ b/src/Cedar/IPC.h
@@ -233,7 +233,7 @@ bool IPCIPv6CheckExistingLinkLocal(IPC *ipc, UINT64 eui);
 // RA
 void IPCIPv6AddRouterPrefixes(IPC *ipc, ICMPV6_OPTION_LIST *recvPrefix, UCHAR *macAddress, IP *ip);
 bool IPCIPv6CheckUnicastFromRouterPrefix(IPC *ipc, IP *ip, IPC_IPV6_ROUTER_ADVERTISEMENT *matchedRA);
-bool IPCSendIPv6RouterSoliciation(IPC *ipc);
+bool IPCSendIPv6RouterSoliciation(IPC *ipc, bool blocking);
 // Data flow
 BLOCK *IPCIPv6Recv(IPC *ipc);
 void IPCIPv6Send(IPC *ipc, void *data, UINT size);


### PR DESCRIPTION
After #1755, IPv6 router lookup is blocking. This PR changes it to non-blocking.

The lookup should not take place as long as the client is well configured because under IPv6 it is the L3 client's responsibility to send RS.
In case that the client may be misconfigured, we do the lookup at best effort without blocking.

Fix #1755
