### PR TITLE
Support more EAP methods for RADIUS auth

### DIFF
--- a/src/Cedar/Cedar.h
+++ b/src/Cedar/Cedar.h
@@ -366,6 +366,7 @@
 #define	AUTHTYPE_ROOTCERT				3			// Root certificate which is issued by trusted Certificate Authority
 #define	AUTHTYPE_RADIUS					4			// Radius authentication
 #define	AUTHTYPE_NT						5			// Windows NT authentication
+#define AUTHTYPE_EXTERNAL				96			// External authentication (completed)
 #define	AUTHTYPE_WIREGUARD_KEY			97			// WireGuard public key authentication
 #define	AUTHTYPE_OPENVPN_CERT    		98			// TLS client certificate authentication
 #define	AUTHTYPE_TICKET					99			// Ticket authentication

--- a/src/Cedar/Hub.h
+++ b/src/Cedar/Hub.h
@@ -537,7 +537,8 @@ bool IsUserMatchInUserList(LIST *o, char *filename, UINT64 user_hash);
 bool IsUserMatchInUserListWithCacheExpires(LIST *o, char *filename, UINT64 user_hash, UINT64 lifetime);
 bool IsUserMatchInUserListWithCacheExpiresAcl(LIST *o, char *name_in_acl, UINT64 user_hash, UINT64 lifetime);
 bool CheckMaxLoggedPacketsPerMinute(SESSION *s, UINT max_packets, UINT64 now);
-EAP_CLIENT *HubNewEapClient(CEDAR *cedar, char *hubname, char *client_ip_str, char *username, char *vpn_protocol_state_str);
+EAP_CLIENT *HubNewEapClient(CEDAR *cedar, char *hubname, char *client_ip_str, char *username, char *vpn_protocol_state_str, bool proxy_only, 
+							PPP_LCP **response, UCHAR last_recv_eapid);
 
 #endif	// HUB_H
 

--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -244,7 +244,8 @@ IPC *NewIPCByParam(CEDAR *cedar, IPC_PARAM *param, UINT *error_code)
 	             param->UserName, param->Password, param->WgKey, error_code,
 	             &param->ClientIp, param->ClientPort, &param->ServerIp, param->ServerPort,
 	             param->ClientHostname, param->CryptName,
-	             param->BridgeMode, param->Mss, NULL, param->ClientCertificate, param->Layer);
+	             param->BridgeMode, param->Mss, NULL, param->ClientCertificate, param->RadiusOK,
+				 param->Layer);
 
 	return ipc;
 }
@@ -253,7 +254,7 @@ IPC *NewIPCByParam(CEDAR *cedar, IPC_PARAM *param, UINT *error_code)
 IPC *NewIPC(CEDAR *cedar, char *client_name, char *postfix, char *hubname, char *username, char *password, char *wg_key,
             UINT *error_code, IP *client_ip, UINT client_port, IP *server_ip, UINT server_port,
             char *client_hostname, char *crypt_name,
-            bool bridge_mode, UINT mss, EAP_CLIENT *eap_client, X *client_certificate,
+            bool bridge_mode, UINT mss, EAP_CLIENT *eap_client, X *client_certificate, bool external_auth,
             UINT layer)
 {
 	IPC *ipc;
@@ -359,6 +360,10 @@ IPC *NewIPC(CEDAR *cedar, char *client_name, char *postfix, char *hubname, char 
 	else if (client_certificate != NULL)
 	{
 		p = PackLoginWithOpenVPNCertificate(hubname, username, client_certificate);
+	}
+	else if (external_auth)
+	{
+		p = PackLoginWithExternal(hubname, username);
 	}
 	else
 	{

--- a/src/Cedar/IPC.h
+++ b/src/Cedar/IPC.h
@@ -91,6 +91,7 @@ struct IPC_PARAM
 	UINT Mss;
 	bool IsL3Mode;
 	X *ClientCertificate;
+	bool RadiusOK;
 	UINT Layer;
 };
 
@@ -180,7 +181,7 @@ struct IPC_IPV6_ROUTER_ADVERTISEMENT
 IPC *NewIPC(CEDAR *cedar, char *client_name, char *postfix, char *hubname, char *username, char *password, char *wg_key,
             UINT *error_code, IP *client_ip, UINT client_port, IP *server_ip, UINT server_port,
             char *client_hostname, char *crypt_name,
-            bool bridge_mode, UINT mss, EAP_CLIENT *eap_client, X *client_certificate,
+            bool bridge_mode, UINT mss, EAP_CLIENT *eap_client, X *client_certificate, bool external_auth,
             UINT layer);
 IPC *NewIPCByParam(CEDAR *cedar, IPC_PARAM *param, UINT *error_code);
 IPC *NewIPCBySock(CEDAR *cedar, SOCK *s, void *mac_address);

--- a/src/Cedar/Proto_EtherIP.c
+++ b/src/Cedar/Proto_EtherIP.c
@@ -75,7 +75,7 @@ void EtherIPIpcConnectThread(THREAD *t, void *p)
 			&s->ClientIP, s->ClientPort,
 			&s->ServerIP, s->ServerPort,
 			tmp,
-			s->CryptName, true, mss, NULL, NULL, IPC_LAYER_2);
+			s->CryptName, true, mss, NULL, NULL, false, IPC_LAYER_2);
 
 		if (ipc != NULL)
 		{

--- a/src/Cedar/Proto_PPP.h
+++ b/src/Cedar/Proto_PPP.h
@@ -294,7 +294,7 @@ struct PPP_SESSION
 	UINT MsChapV2_ErrorCode;			// Authentication failure error code of MS-CHAPv2
 	UINT MsChapV2_PacketId;				// MS-CHAPv2 Packet ID
 
-	bool MsChapV2_UseDoubleMsChapV2;	// Use the double-MSCHAPv2 technique
+	bool UseEapRadius;					// Use EAP for RADIUS authentication
 	EAP_CLIENT *EapClient;				// EAP client
 
 	UCHAR ServerInterfaceId[8];			// Server IPv6CP Interface Identifier
@@ -343,6 +343,7 @@ bool PPPProcessCHAPResponsePacketEx(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *
 bool PPPProcessIPCPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
 bool PPPProcessEAPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
 bool PPPProcessIPv6CPResponsePacket(PPP_SESSION *p, PPP_PACKET *pp, PPP_PACKET *req);
+bool PPPProcessEapResponseForRadius(PPP_SESSION *p, PPP_EAP *eap_packet, UINT eap_datasize);
 // Request packets
 bool PPPProcessRequestPacket(PPP_SESSION *p, PPP_PACKET *pp);
 bool PPPProcessLCPRequestPacket(PPP_SESSION *p, PPP_PACKET *pp);

--- a/src/Cedar/Proto_PPP.h
+++ b/src/Cedar/Proto_PPP.h
@@ -413,6 +413,7 @@ bool PPPParseUsername(CEDAR *cedar, char *src, ETHERIP_ID *dst);
 void GenerateNtPasswordHash(UCHAR *dst, char *password);
 void GenerateNtPasswordHashHash(UCHAR *dst_hash, UCHAR *src_hash);
 void MsChapV2Server_GenerateChallenge(UCHAR *dst);
+void MsChapV2Client_GenerateChallenge(UCHAR *dst);
 void MsChapV2_GenerateChallenge8(UCHAR *dst, UCHAR *client_challenge, UCHAR *server_challenge, char *username);
 void MsChapV2Client_GenerateResponse(UCHAR *dst, UCHAR *challenge8, UCHAR *nt_password_hash);
 void MsChapV2Server_GenerateResponse(UCHAR *dst, UCHAR *nt_password_hash_hash, UCHAR *client_response, UCHAR *challenge8);

--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -1702,6 +1702,9 @@ bool ServerAccept(CONNECTION *c)
 				case CLIENT_AUTHTYPE_CERT:
 					authtype_str = _UU("LH_AUTH_CERT");
 					break;
+				case AUTHTYPE_EXTERNAL:
+					authtype_str = _UU("LH_AUTH_EXTERNAL");
+					break;
 				case AUTHTYPE_WIREGUARD_KEY:
 					authtype_str = _UU("LH_AUTH_WIREGUARD_KEY");
 					break;
@@ -1827,6 +1830,11 @@ bool ServerAccept(CONNECTION *c)
 				{
 				case CLIENT_AUTHTYPE_ANONYMOUS:
 					// Anonymous authentication (this have been already attempted)
+					break;
+
+				case AUTHTYPE_EXTERNAL:
+					// External authentication already completed
+					auth_ret = true;
 					break;
 
 				case AUTHTYPE_TICKET:
@@ -6707,6 +6715,25 @@ PACK *PackLoginWithAnonymous(char *hubname, char *username)
 	PackAddStr(p, "hubname", hubname);
 	PackAddStr(p, "username", username);
 	PackAddInt(p, "authtype", CLIENT_AUTHTYPE_ANONYMOUS);
+
+	return p;
+}
+
+// Create a packet for external login
+PACK *PackLoginWithExternal(char *hubname, char *username)
+{
+	PACK *p;
+	// Validate arguments
+	if (hubname == NULL || username == NULL)
+	{
+		return NULL;
+	}
+
+	p = NewPack();
+	PackAddStr(p, "method", "login");
+	PackAddStr(p, "hubname", hubname);
+	PackAddStr(p, "username", username);
+	PackAddInt(p, "authtype", AUTHTYPE_EXTERNAL);
 
 	return p;
 }

--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -1914,7 +1914,7 @@ bool ServerAccept(CONNECTION *c)
 
 						if (auth_ret == false)
 						{
-							// Attempt external authentication registered users
+							// Attempt external authentication
 							bool fail_ext_user_auth = false;
 							if (GetGlobalServerFlag(GSF_DISABLE_RADIUS_AUTH) != 0)
 							{
@@ -1923,43 +1923,12 @@ bool ServerAccept(CONNECTION *c)
 
 							if (fail_ext_user_auth == false)
 							{
-								auth_ret = SamAuthUserByPlainPassword(c, hub, username, plain_password, false, mschap_v2_server_response_20, &radius_login_opt);
+								auth_ret = SamAuthUserByPlainPassword(c, hub, username, plain_password, true, mschap_v2_server_response_20, &radius_login_opt);
 							}
 
 							if (auth_ret && pol == NULL)
 							{
 								pol = SamGetUserPolicy(hub, username);
-							}
-						}
-
-						if (auth_ret == false)
-						{
-							// Attempt external authentication asterisk user
-							bool b = false;
-							bool fail_ext_user_auth = false;
-
-							if (GetGlobalServerFlag(GSF_DISABLE_RADIUS_AUTH) != 0)
-							{
-								fail_ext_user_auth = true;
-							}
-
-							if (fail_ext_user_auth == false)
-							{
-								AcLock(hub);
-								{
-									b = AcIsUser(hub, "*");
-								}
-								AcUnlock(hub);
-
-								// If there is asterisk user, log on as the user
-								if (b)
-								{
-									auth_ret = SamAuthUserByPlainPassword(c, hub, username, plain_password, true, mschap_v2_server_response_20, &radius_login_opt);
-									if (auth_ret && pol == NULL)
-									{
-										pol = SamGetUserPolicy(hub, "*");
-									}
-								}
 							}
 						}
 

--- a/src/Cedar/Protocol.h
+++ b/src/Cedar/Protocol.h
@@ -134,6 +134,7 @@ void PackAddPolicy(PACK *p, POLICY *y);
 PACK *PackWelcome(SESSION *s);
 PACK *PackHello(void *random, UINT ver, UINT build, char *server_str);
 bool GetHello(PACK *p, void *random, UINT *ver, UINT *build, char *server_str, UINT server_str_size);
+PACK *PackLoginWithExternal(char *hubname, char *username);
 PACK *PackLoginWithAnonymous(char *hubname, char *username);
 PACK *PackLoginWithPassword(char *hubname, char *username, void *secure_password);
 PACK *PackLoginWithPlainPassword(char *hubname, char *username, void *plain_password);

--- a/src/Cedar/Radius.c
+++ b/src/Cedar/Radius.c
@@ -10,6 +10,7 @@
 #include "Connection.h"
 #include "IPC.h"
 #include "Server.h"
+#include "Proto_PPP.h"
 
 #include "Mayaqua/DNS.h"
 #include "Mayaqua/Internat.h"
@@ -300,7 +301,7 @@ bool SendPeapRawPacket(EAP_CLIENT *e, UCHAR *peap_data, UINT peap_size)
 
 		Add(send_packet->AvpList, eap_avp);
 
-		response_packet = EapSendPacketAndRecvResponse(e, send_packet);
+		response_packet = EapSendPacketAndRecvResponse(e, send_packet, true);
 
 		if (response_packet != NULL)
 		{
@@ -502,7 +503,7 @@ bool StartPeapClient(EAP_CLIENT *e)
 	Copy(eap1->Data, e->Username, StrLen(e->Username));
 	Add(request1->AvpList, NewRadiusAvp(RADIUS_ATTRIBUTE_EAP_MESSAGE, 0, 0, eap1, StrLen(e->Username) + 5));
 
-	response1 = EapSendPacketAndRecvResponse(e, request1);
+	response1 = EapSendPacketAndRecvResponse(e, request1, true);
 
 	if (response1 != NULL)
 	{
@@ -532,7 +533,7 @@ bool StartPeapClient(EAP_CLIENT *e)
 
 					Add(request2->AvpList, NewRadiusAvp(RADIUS_ATTRIBUTE_EAP_MESSAGE, 0, 0, eap2, 6));
 
-					response2 = EapSendPacketAndRecvResponse(e, request2);
+					response2 = EapSendPacketAndRecvResponse(e, request2, true);
 
 					if (response2 != NULL && response2->Parse_EapMessage_DataSize != 0 && response2->Parse_EapMessage != NULL)
 					{
@@ -657,7 +658,7 @@ bool EapClientSendMsChapv2AuthClientResponse(EAP_CLIENT *e, UCHAR *client_respon
 
 	eap1 = ZeroMalloc(sizeof(EAP_MSCHAPV2_RESPONSE));
 	eap1->Code = EAP_CODE_RESPONSE;
-	eap1->Id = e->NextEapId++;
+	eap1->Id = e->LastRecvEapId;
 	eap1->Len = Endian16(59 + StrLen(e->Username));
 	eap1->Type = EAP_TYPE_MS_AUTH;
 	eap1->Chap_Opcode = EAP_MSCHAPV2_OP_RESPONSE;
@@ -670,7 +671,7 @@ bool EapClientSendMsChapv2AuthClientResponse(EAP_CLIENT *e, UCHAR *client_respon
 
 	Add(request1->AvpList, NewRadiusAvp(RADIUS_ATTRIBUTE_EAP_MESSAGE, 0, 0, eap1, StrLen(e->Username) + 59));
 
-	response1 = EapSendPacketAndRecvResponse(e, request1);
+	response1 = EapSendPacketAndRecvResponse(e, request1, false);
 
 	if (response1 != NULL)
 	{
@@ -713,14 +714,14 @@ bool EapClientSendMsChapv2AuthClientResponse(EAP_CLIENT *e, UCHAR *client_respon
 
 									eap2 = ZeroMalloc(sizeof(EAP_MSCHAPV2_SUCCESS_CLIENT));
 									eap2->Code = EAP_CODE_RESPONSE;
-									eap2->Id = e->NextEapId++;
+									eap2->Id = e->LastRecvEapId;
 									eap2->Len = Endian16(6);
 									eap2->Type = EAP_TYPE_MS_AUTH;
 									eap2->Chap_Opcode = EAP_MSCHAPV2_OP_SUCCESS;
 
 									Add(request2->AvpList, NewRadiusAvp(RADIUS_ATTRIBUTE_EAP_MESSAGE, 0, 0, eap2, 6));
 
-									response2 = EapSendPacketAndRecvResponse(e, request2);
+									response2 = EapSendPacketAndRecvResponse(e, request2, false);
 
 									if (response2 != NULL)
 									{
@@ -770,13 +771,13 @@ bool EapClientSendMsChapv2AuthRequest(EAP_CLIENT *e)
 
 	eap1 = ZeroMalloc(sizeof(EAP_MESSAGE));
 	eap1->Code = EAP_CODE_RESPONSE;
-	eap1->Id = e->NextEapId++;
+	eap1->Id = e->LastRecvEapId;
 	eap1->Len = Endian16(StrLen(e->Username) + 5);
 	eap1->Type = EAP_TYPE_IDENTITY;
 	Copy(eap1->Data, e->Username, StrLen(e->Username));
 	Add(request1->AvpList, NewRadiusAvp(RADIUS_ATTRIBUTE_EAP_MESSAGE, 0, 0, eap1, StrLen(e->Username) + 5));
 
-	response1 = EapSendPacketAndRecvResponse(e, request1);
+	response1 = EapSendPacketAndRecvResponse(e, request1, false);
 
 	if (response1 != NULL)
 	{
@@ -799,14 +800,14 @@ bool EapClientSendMsChapv2AuthRequest(EAP_CLIENT *e)
 
 					eap2 = ZeroMalloc(sizeof(EAP_MESSAGE));
 					eap2->Code = EAP_CODE_RESPONSE;
-					eap2->Id = e->NextEapId++;
+					eap2->Id = e->LastRecvEapId;
 					eap2->Len = Endian16(6);
 					eap2->Type = EAP_TYPE_LEGACY_NAK;
 					eap2->Data[0] = EAP_TYPE_MS_AUTH;
 
 					Add(request2->AvpList, NewRadiusAvp(RADIUS_ATTRIBUTE_EAP_MESSAGE, 0, 0, eap2, 6));
 
-					response2 = EapSendPacketAndRecvResponse(e, request2);
+					response2 = EapSendPacketAndRecvResponse(e, request2, false);
 
 					if (response2 != NULL && response2->Parse_EapMessage_DataSize != 0 && response2->Parse_EapMessage != NULL)
 					{
@@ -849,8 +850,141 @@ LABEL_PARSE_EAP:
 	return ret;
 }
 
+// Send a EAP identity request to Radius
+PPP_LCP *EapClientSendEapIdentity(EAP_CLIENT *e)
+{
+	PPP_LCP *lcp = NULL;
+	RADIUS_PACKET *request = NULL;
+	RADIUS_PACKET *response = NULL;
+	EAP_MESSAGE *eap1 = NULL;
+	if (e == NULL)
+	{
+		return NULL;
+	}
+
+	request = NewRadiusPacket(RADIUS_CODE_ACCESS_REQUEST, e->NextRadiusPacketId++);
+	EapSetRadiusGeneralAttributes(request, e);
+
+	eap1 = ZeroMalloc(sizeof(EAP_MESSAGE));
+	eap1->Code = EAP_CODE_RESPONSE;
+	eap1->Id = e->LastRecvEapId;
+	eap1->Len = Endian16(StrLen(e->Username) + 5);
+	eap1->Type = EAP_TYPE_IDENTITY;
+	Copy(eap1->Data, e->Username, StrLen(e->Username));
+	Add(request->AvpList, NewRadiusAvp(RADIUS_ATTRIBUTE_EAP_MESSAGE, 0, 0, eap1, StrLen(e->Username) + 5));
+	Debug("Radius proxy: send access-request %d with EAP code %d id %d type %d datasize %d\n", 
+			request->PacketId, eap1->Code, eap1->Id, eap1->Type, StrLen(e->Username));
+
+	response = EapSendPacketAndRecvResponse(e, request, false);
+
+	if (response != NULL)
+	{
+		if (response->Parse_EapMessage_DataSize >= 5 && response->Parse_EapMessage != NULL)
+		{
+			EAP_MESSAGE *eap2 = response->Parse_EapMessage;
+			UINT datasize = response->Parse_EapMessage_DataSize - 5;
+			lcp = BuildEAPPacketEx(eap2->Code, eap2->Id, eap2->Type, datasize);
+			PPP_EAP *eap_packet = lcp->Data;
+			Copy(eap_packet->Data, eap2->Data, datasize);
+			Debug("Radius proxy: received access-challenge %d with EAP code %d id %d type %d datasize %d\n", 
+					response->PacketId, eap2->Code, eap2->Id, eap2->Type, datasize);
+		}
+	}
+
+	FreeRadiusPacket(request);
+	FreeRadiusPacket(response);
+	Free(eap1);
+
+	return lcp;
+}
+
+// Send generic EAP Radius request (client EAP response) and get reply
+PPP_LCP *EapClientSendEapRequest(EAP_CLIENT *e, PPP_EAP *eap_request, UINT request_datasize)
+{
+	PPP_LCP *lcp = NULL;
+	RADIUS_PACKET *request = NULL;
+	RADIUS_PACKET *response = NULL;
+	EAP_MESSAGE *eap1 = NULL;
+	UCHAR *pos;
+	UINT remaining;
+	if (e == NULL || eap_request == NULL)
+	{
+		return NULL;
+	}
+
+	request = NewRadiusPacket(RADIUS_CODE_ACCESS_REQUEST, e->NextRadiusPacketId++);
+	EapSetRadiusGeneralAttributes(request, e);
+
+	if (e->LastStateSize != 0)
+	{
+		Add(request->AvpList, NewRadiusAvp(RADIUS_ATTRIBUTE_STATE, 0, 0,
+			e->LastState, e->LastStateSize));
+	}
+
+	eap1 = ZeroMalloc(sizeof(EAP_MESSAGE));
+	eap1->Code = EAP_CODE_RESPONSE;
+	eap1->Id = e->LastRecvEapId;
+	eap1->Len = Endian16(request_datasize + 5);
+	eap1->Type = eap_request->Type;
+	Copy(eap1->Data, eap_request->Data, request_datasize);
+
+	// Fragmentation
+	pos = (UCHAR *)eap1;
+	remaining = request_datasize + 5;
+	while (remaining > 0)
+	{
+		UINT size = MIN(253, remaining);
+		Add(request->AvpList, NewRadiusAvp(RADIUS_ATTRIBUTE_EAP_MESSAGE, 0, 0, pos, size));
+		pos += size;
+		remaining -= size;
+	}
+	Debug("Radius proxy: send access-request %d with EAP code %d id %d type %d datasize %d\n", 
+			request->PacketId, eap1->Code, eap1->Id, eap1->Type, request_datasize);
+
+	response = EapSendPacketAndRecvResponse(e, request, false);
+
+	if (response != NULL)
+	{
+		switch (response->Code)
+		{
+		case RADIUS_CODE_ACCESS_CHALLENGE:
+			if (response->Parse_EapMessage_DataSize >= 5 && response->Parse_EapMessage != NULL)
+			{
+				EAP_MESSAGE *eap2 = response->Parse_EapMessage;
+				UINT datasize = response->Parse_EapMessage_DataSize - 5;
+				lcp = BuildEAPPacketEx(eap2->Code, eap2->Id, eap2->Type, datasize);
+				PPP_EAP *eap_packet = lcp->Data;
+				Copy(eap_packet->Data, eap2->Data, datasize);
+				Debug("Radius proxy: received access-challenge %d with EAP code %d id %d type %d datasize %d\n", 
+						response->PacketId, eap2->Code, eap2->Id, eap2->Type, datasize);
+			}
+			else
+			{
+				Debug("Radius proxy error: received access-challenge %d without EAP\n", response->PacketId);
+				lcp = NewPPPLCP(PPP_EAP_CODE_FAILURE, e->LastRecvEapId);				
+			}
+			break;
+		case RADIUS_CODE_ACCESS_ACCEPT:
+			Debug("Radius proxy: received access-accept %d\n", response->PacketId);
+			lcp = NewPPPLCP(PPP_EAP_CODE_SUCCESS, e->LastRecvEapId);
+			break;
+		case RADIUS_CODE_ACCESS_REJECT:
+		default:
+			Debug("Radius proxy: received access-reject %d\n", response->PacketId);
+			lcp = NewPPPLCP(PPP_EAP_CODE_FAILURE, e->LastRecvEapId);
+			break;
+		}
+	}
+
+	FreeRadiusPacket(request);
+	FreeRadiusPacket(response);
+	Free(eap1);
+
+	return lcp;
+}
+
 // Send a packet and recv a response
-RADIUS_PACKET *EapSendPacketAndRecvResponse(EAP_CLIENT *e, RADIUS_PACKET *r)
+RADIUS_PACKET *EapSendPacketAndRecvResponse(EAP_CLIENT *e, RADIUS_PACKET *r, bool parse_inner)
 {
 	SOCKSET set;
 	UINT64 giveup_tick = 0;
@@ -990,7 +1124,7 @@ RADIUS_PACKET *EapSendPacketAndRecvResponse(EAP_CLIENT *e, RADIUS_PACKET *r)
 									{
 										EAP_MESSAGE *eap_msg = (EAP_MESSAGE *)rp->Parse_EapMessage;
 
-										if (eap_msg->Type == EAP_TYPE_PEAP)
+										if (parse_inner && eap_msg->Type == EAP_TYPE_PEAP)
 										{
 											EAP_PEAP *peap_message = (EAP_PEAP *)eap_msg;
 
@@ -1166,7 +1300,8 @@ bool EapSendPacket(EAP_CLIENT *e, RADIUS_PACKET *r)
 }
 
 // New EAP client
-EAP_CLIENT *NewEapClient(IP *server_ip, UINT server_port, char *shared_secret, UINT resend_timeout, UINT giveup_timeout, char *client_ip_str, char *username, char *hubname)
+EAP_CLIENT *NewEapClient(IP *server_ip, UINT server_port, char *shared_secret, UINT resend_timeout, UINT giveup_timeout, char *client_ip_str, 
+						char *username, char *hubname, UCHAR last_recv_eapid)
 {
 	EAP_CLIENT *e;
 	if (server_ip == NULL)
@@ -1198,7 +1333,7 @@ EAP_CLIENT *NewEapClient(IP *server_ip, UINT server_port, char *shared_secret, U
 	StrCpy(e->CalledStationStr, sizeof(e->CalledStationStr), hubname);
 	StrCpy(e->ClientIpStr, sizeof(e->ClientIpStr), client_ip_str);
 	StrCpy(e->Username, sizeof(e->Username), username);
-	e->LastRecvEapId = 0;
+	e->LastRecvEapId = last_recv_eapid;
 
 	e->PEAP_CurrentReceivingMsg = NewBuf();
 

--- a/src/Cedar/Radius.h
+++ b/src/Cedar/Radius.h
@@ -215,7 +215,6 @@ struct EAP_CLIENT
 	UINT ResendTimeout;
 	UINT GiveupTimeout;
 	UCHAR TmpBuffer[4096];
-	UCHAR NextEapId;
 	UCHAR LastRecvEapId;
 
 	bool PeapMode;
@@ -249,14 +248,17 @@ RADIUS_AVP *GetRadiusAvp(RADIUS_PACKET *p, UCHAR type);
 void RadiusTest();
 
 
-EAP_CLIENT *NewEapClient(IP *server_ip, UINT server_port, char *shared_secret, UINT resend_timeout, UINT giveup_timeout, char *client_ip_str, char *username, char *hubname);
+EAP_CLIENT *NewEapClient(IP *server_ip, UINT server_port, char *shared_secret, UINT resend_timeout, UINT giveup_timeout, char *client_ip_str, 
+						char *username, char *hubname, UCHAR last_recv_eapid);
 void ReleaseEapClient(EAP_CLIENT *e);
 void CleanupEapClient(EAP_CLIENT *e);
 bool EapClientSendMsChapv2AuthRequest(EAP_CLIENT *e);
 bool EapClientSendMsChapv2AuthClientResponse(EAP_CLIENT *e, UCHAR *client_response, UCHAR *client_challenge);
+PPP_LCP *EapClientSendEapIdentity(EAP_CLIENT *e);
+PPP_LCP *EapClientSendEapRequest(EAP_CLIENT *e, PPP_EAP *eap_request, UINT request_datasize);
 void EapSetRadiusGeneralAttributes(RADIUS_PACKET *r, EAP_CLIENT *e);
 bool EapSendPacket(EAP_CLIENT *e, RADIUS_PACKET *r);
-RADIUS_PACKET *EapSendPacketAndRecvResponse(EAP_CLIENT *e, RADIUS_PACKET *r);
+RADIUS_PACKET *EapSendPacketAndRecvResponse(EAP_CLIENT *e, RADIUS_PACKET *r, bool parse_inner);
 
 bool PeapClientSendMsChapv2AuthRequest(EAP_CLIENT *eap);
 bool PeapClientSendMsChapv2AuthClientResponse(EAP_CLIENT *e, UCHAR *client_response, UCHAR *client_challenge);

--- a/src/Cedar/Radius.h
+++ b/src/Cedar/Radius.h
@@ -253,7 +253,7 @@ EAP_CLIENT *NewEapClient(IP *server_ip, UINT server_port, char *shared_secret, U
 void ReleaseEapClient(EAP_CLIENT *e);
 void CleanupEapClient(EAP_CLIENT *e);
 bool EapClientSendMsChapv2AuthRequest(EAP_CLIENT *e);
-bool EapClientSendMsChapv2AuthClientResponse(EAP_CLIENT *e, UCHAR *client_response, UCHAR *client_challenge);
+bool EapClientSendMsChapv2AuthClientResponse(EAP_CLIENT *e, UCHAR *client_response, UCHAR *client_challenge, char *username);
 PPP_LCP *EapClientSendEapIdentity(EAP_CLIENT *e);
 PPP_LCP *EapClientSendEapRequest(EAP_CLIENT *e, PPP_EAP *eap_request, UINT request_datasize);
 void EapSetRadiusGeneralAttributes(RADIUS_PACKET *r, EAP_CLIENT *e);
@@ -261,7 +261,7 @@ bool EapSendPacket(EAP_CLIENT *e, RADIUS_PACKET *r);
 RADIUS_PACKET *EapSendPacketAndRecvResponse(EAP_CLIENT *e, RADIUS_PACKET *r, bool parse_inner);
 
 bool PeapClientSendMsChapv2AuthRequest(EAP_CLIENT *eap);
-bool PeapClientSendMsChapv2AuthClientResponse(EAP_CLIENT *e, UCHAR *client_response, UCHAR *client_challenge);
+bool PeapClientSendMsChapv2AuthClientResponse(EAP_CLIENT *e, UCHAR *client_response, UCHAR *client_challenge, char *username);
 
 bool StartPeapClient(EAP_CLIENT *e);
 bool StartPeapSslClient(EAP_CLIENT *e);

--- a/src/Cedar/Sam.c
+++ b/src/Cedar/Sam.c
@@ -546,7 +546,7 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 				if (hub->RadiusConvertAllMsChapv2AuthRequestToEap)
 				{
 					// Do EAP or PEAP
-					eap = HubNewEapClient(hub->Cedar, hub->Name, client_ip_str, utf8, opt->In_VpnProtocolState);
+					eap = HubNewEapClient(hub->Cedar, hub->Name, client_ip_str, utf8, opt->In_VpnProtocolState, false, NULL, 0);
 
 					// Prepare MSCHAP response and replace plain password
 					if (eap != NULL)

--- a/src/Cedar/Sam.c
+++ b/src/Cedar/Sam.c
@@ -9,6 +9,7 @@
 
 #include "Account.h"
 #include "Cedar.h"
+#include "Connection.h"
 #include "Hub.h"
 #include "IPC.h"
 #include "Proto_PPP.h"
@@ -420,7 +421,7 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 	bool auth_by_nt = false;
 	HUB *h;
 	// Validate arguments
-	if (hub == NULL || c == NULL || username == NULL)
+	if (hub == NULL || c == NULL || username == NULL || password == NULL || opt == NULL)
 	{
 		return false;
 	}
@@ -438,7 +439,14 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 	AcLock(hub);
 	{
 		USER *u;
-		u = AcGetUser(hub, ast == false ? username : "*");
+
+		// Find exact user first
+		u = AcGetUser(hub, username);
+		if (u == NULL && ast)
+		{
+			u = AcGetUser(hub, "*");
+		}
+
 		if (u)
 		{
 			Lock(u->lock);
@@ -447,7 +455,7 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 				{
 					// Radius authentication
 					AUTHRADIUS *auth = (AUTHRADIUS *)u->AuthData;
-					if (ast || auth->RadiusUsername == NULL || UniStrLen(auth->RadiusUsername) == 0)
+					if (auth->RadiusUsername == NULL || UniStrLen(auth->RadiusUsername) == 0)
 					{
 						if( IsEmptyStr(h->RadiusRealm) == false )
 						{	
@@ -472,7 +480,7 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 				{
 					// NT authentication
 					AUTHNT *auth = (AUTHNT *)u->AuthData;
-					if (ast || auth->NtUsername == NULL || UniStrLen(auth->NtUsername) == 0)
+					if (auth->NtUsername == NULL || UniStrLen(auth->NtUsername) == 0)
 					{
 						name = CopyStrToUni(username);
 					}
@@ -508,9 +516,74 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 			char suffix_filter[MAX_SIZE];
 			wchar_t suffix_filter_w[MAX_SIZE];
 			UINT interval;
+			EAP_CLIENT *eap = NULL;
+			char password1[MAX_SIZE];
+			UCHAR client_challenge[16];
+			UCHAR server_challenge[16];
+			UCHAR challenge8[8];
+			UCHAR client_response[24];
+			UCHAR ntlm_hash[MD5_SIZE];
 
 			Zero(suffix_filter, sizeof(suffix_filter));
 			Zero(suffix_filter_w, sizeof(suffix_filter_w));
+
+			// MSCHAPv2 / EAP wrapper for SEVPN
+			if (c->IsInProc == false && StartWith(password, IPC_PASSWORD_MSCHAPV2_TAG) == false)
+			{
+				char client_ip_str[MAX_SIZE];
+				char utf8[MAX_SIZE];
+
+				// Convert the user name to a Unicode string
+				UniToStr(utf8, sizeof(utf8), name);
+				utf8[MAX_SIZE-1] = 0;
+
+				Zero(client_ip_str, sizeof(client_ip_str));
+				if (c != NULL && c->FirstSock != NULL)
+				{
+					IPToStr(client_ip_str, sizeof(client_ip_str), &c->FirstSock->RemoteIP);
+				}
+
+				if (hub->RadiusConvertAllMsChapv2AuthRequestToEap)
+				{
+					// Do EAP or PEAP
+					eap = HubNewEapClient(hub->Cedar, hub->Name, client_ip_str, utf8, opt->In_VpnProtocolState);
+
+					// Prepare MSCHAP response and replace plain password
+					if (eap != NULL)
+					{
+						char server_challenge_hex[MAX_SIZE];
+						char client_challenge_hex[MAX_SIZE];
+						char client_response_hex[MAX_SIZE];
+						char eap_client_hex[64];
+
+						MsChapV2Client_GenerateChallenge(client_challenge);
+						GenerateNtPasswordHash(ntlm_hash, password);
+						Copy(server_challenge, eap->MsChapV2Challenge.Chap_ChallengeValue, 16);
+						MsChapV2_GenerateChallenge8(challenge8, client_challenge, server_challenge, utf8);
+						MsChapV2Client_GenerateResponse(client_response, challenge8, ntlm_hash);
+
+						BinToStr(server_challenge_hex, sizeof(server_challenge_hex),
+								server_challenge, sizeof(server_challenge));
+						BinToStr(client_challenge_hex, sizeof(client_challenge_hex),
+								client_challenge, sizeof(client_challenge));
+						BinToStr(client_response_hex, sizeof(client_response_hex),
+								client_response, sizeof(client_response));
+						BinToStr(eap_client_hex, sizeof(eap_client_hex), &eap, 8);
+						Format(password1, sizeof(password1), "%s%s:%s:%s:%s:%s",
+										IPC_PASSWORD_MSCHAPV2_TAG,
+										utf8,
+										server_challenge_hex,
+										client_challenge_hex,
+										client_response_hex,
+										eap_client_hex);
+						password = password1;
+					}
+				}
+				else
+				{
+					// Todo: Do MSCHAPv2
+				}
+			}
 
 			// Get the Radius server information
 			if (GetRadiusServerEx2(hub, radius_server_addr, sizeof(radius_server_addr), &radius_server_port, radius_secret, sizeof(radius_secret), &interval, suffix_filter, sizeof(suffix_filter)))
@@ -528,10 +601,7 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 
 					if (b)
 					{
-						if (opt != NULL)
-						{
-							opt->Out_IsRadiusLogin = true;
-						}
+						opt->Out_IsRadiusLogin = true;
 					}
 				}
 
@@ -540,6 +610,11 @@ bool SamAuthUserByPlainPassword(CONNECTION *c, HUB *hub, char *username, char *p
 			else
 			{
 				HLog(hub, "LH_NO_RADIUS_SETTING", name);
+			}
+
+			if (eap != NULL)
+			{
+				ReleaseEapClient(eap);
 			}
 		}
 		else

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -1939,6 +1939,7 @@ LH_AUTH_PASSWORD			密码验证
 LH_AUTH_PLAIN_PASSWORD		外部服务器身份验证
 LH_AUTH_CERT				证书验证
 LH_AUTH_TICKET				票证验证
+LH_AUTH_EXTERNAL			外部服务器身份验证
 LH_AUTH_WIREGUARD_KEY		WireGuard public key authentication
 LH_AUTH_OPENVPN_CERT		OpenVPN certificate authentication
 LH_AUTH_RADIUS_NOT_SUPPORT	连接 "%S": 用户 "%S" 身份验证方法 RADIUS 或 Active Directory (NT 域)，但 VPN Server 是 "%S"，因为 RADIUS 或 Active Directory (NT 域)不能使用。连接被拒绝。

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -1925,6 +1925,7 @@ LH_AUTH_PASSWORD		Password authentication
 LH_AUTH_PLAIN_PASSWORD	External server authentication
 LH_AUTH_CERT			Certificate authentication
 LH_AUTH_TICKET			Ticket authentication
+LH_AUTH_EXTERNAL		External server authentication
 LH_AUTH_WIREGUARD_KEY	WireGuard public key authentication
 LH_AUTH_OPENVPN_CERT	OpenVPN certificate authentication
 LH_AUTH_RADIUS_NOT_SUPPORT	Connection "%S": The authentication method of the user "%S" has been specified as RADIUS Authentication or Active Directory Authentication (NT Domain Authentication). However, the edition of the VPN Server is "%S". This edition does not support RADIUS Authentication nor Active Directory Authentication (NT Domain Authentication). The connection will be denied.

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -1927,6 +1927,7 @@ LH_AUTH_PASSWORD		パスワード認証
 LH_AUTH_PLAIN_PASSWORD	外部サーバー認証
 LH_AUTH_CERT			証明書認証
 LH_AUTH_TICKET			チケット認証
+LH_AUTH_EXTERNAL		外部サーバー認証
 LH_AUTH_WIREGUARD_KEY	WireGuard 公開鍵認証
 LH_AUTH_OPENVPN_CERT    OpenVPN 証明書認証
 LH_AUTH_RADIUS_NOT_SUPPORT	コネクション "%S": ユーザー "%S" の認証方法として RADIUS 認証または Active Directory 認証 (NT ドメイン認証) が指定されましたが、現在の VPN Server のエディションは "%S" であるため、RADIUS 認証または Active Directory 認証 (NT ドメイン認証) を使用することができません。接続は拒否されます。

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -1905,6 +1905,7 @@ LH_AUTH_PASSWORD 암호 인증
 LH_AUTH_PLAIN_PASSWORD 외부 서버 인증
 LH_AUTH_CERT 인증서 인증
 LH_AUTH_TICKET 티켓 인증
+LH_AUTH_EXTERNAL 외부 서버 인증
 LH_AUTH_WIREGUARD_KEY WireGuard public key authentication
 LH_AUTH_OPENVPN_CERT OpenVPN certificate authentication
 LH_AUTH_RADIUS_NOT_SUPPORT 연결 "%S"사용자 "%S"의 인증 방법으로 RADIUS 인증 또는 Active Directory 인증 (NT 도메인 인증)이 지정 되었으나, 현재 VPN Server 버전은 "%S"이기 때문에 RADIUS 인증 또는 Active Directory 인증 (NT 도메인 인증)을 사용할 수 없습니다. 연결이 거부됩니다.

--- a/src/bin/hamcore/strtable_pt_br.stb
+++ b/src/bin/hamcore/strtable_pt_br.stb
@@ -1924,6 +1924,7 @@ LH_AUTH_PASSWORD	Senha
 LH_AUTH_PLAIN_PASSWORD	External server authentication
 LH_AUTH_CERT	Certificate authentication
 LH_AUTH_TICKET	Ticket authentication
+LH_AUTH_EXTERNAL		External server authentication
 LH_AUTH_WIREGUARD_KEY	WireGuard public key authentication
 LH_AUTH_OPENVPN_CERT	OpenVPN certificate authentication
 LH_AUTH_RADIUS_NOT_SUPPORT	Connection "%S": The authentication method of the user "%S" has been specified as RADIUS Authentication or Active Directory Authentication (NT Domain Authentication). However, the edition of the VPN Server is "%S". This edition does not support RADIUS Authentication nor Active Directory Authentication (NT Domain Authentication). The connection will be denied.

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -1924,6 +1924,7 @@ LH_AUTH_PASSWORD		Password authentication
 LH_AUTH_PLAIN_PASSWORD	External server authentication
 LH_AUTH_CERT			Certificate authentication
 LH_AUTH_TICKET			Ticket authentication
+LH_AUTH_EXTERNAL		External server authentication
 LH_AUTH_WIREGUARD_KEY	WireGuard public key authentication
 LH_AUTH_OPENVPN_CERT	OpenVPN certificate authentication
 LH_AUTH_RADIUS_NOT_SUPPORT	Connection "%S": The authentication method of the user "%S" has been specified as RADIUS Authentication or Active Directory Authentication (NT Domain Authentication). However, the edition of the VPN Server is "%S". This edition does not support RADIUS Authentication nor Active Directory Authentication (NT Domain Authentication). The connection will be denied.

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -1941,6 +1941,7 @@ LH_AUTH_PASSWORD		密碼驗證
 LH_AUTH_PLAIN_PASSWORD	外部伺服器身份驗證
 LH_AUTH_CERT			證書驗證
 LH_AUTH_TICKET			票證驗證
+LH_AUTH_EXTERNAL		外部伺服器身份驗證
 LH_AUTH_WIREGUARD_KEY	WireGuard public key authentication
 LH_AUTH_OPENVPN_CERT	OpenVPN certificate authentication
 LH_AUTH_RADIUS_NOT_SUPPORT	連接 "%S": 用戶 "%S" 身份驗證方法 RADIUS 或 Active Directory (NT 域)，但 VPN Server 是 "%S"，因為 RADIUS 或 Active Directory (NT 域)不能使用。連接被拒絕。


### PR DESCRIPTION
Changes proposed in this pull request:
- Support EAP and PEAP for SEVPN clients (requires no change on the client side)
   A wrapper is created for SEVPN authentication that reuses the existing EAP / PEAP client for PPP sessions.
- Support all EAP methods (as long as supported by Radius server) for EAP-capable PPP clients
  In other words, we act like a EAP proxy in this case, forwarding EAP packets back and forth.
- Fix the issue that EAP ID may not match incoming Radius challenges
- Fix the issue that clients may get authenticated twice if both the exact user and the asterisk user exist on a hub
  Now we match user twice (exact -> *) but only authenticate once. Authenticate twice can lead to a deadlock for EAP clients.
- Fix the issue that MS-CHAP responses sent to Radius server may not contain the original username
  Since MS-CHAP response is generated from the username, we should not use the parsed username in the response which can make the response invalid. Only EAP / PEAP with Radius is fixed. For users having trouble doing Radius on non-default hubs with some PPP clients, it's recommended to do EAP or PEAP, either client side or server side. See #1103 .
- The existing option `RadiusConvertAllMsChapv2AuthRequestToEap` and `RadiusUsePeapInsteadOfEap` controls whether MSCHAPv2 and SEVPN authentication is converted to EAP or PEAP. EAP authentication is always used to talk to Radius if the PPP client had chosen EAP, not affected by these options.

No changes in UI and vpncmd yet.
