### PR TITLE
Mayaqua/Unix: Make VM detection work on FreeBSD

### DIFF
--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -295,16 +295,25 @@ void UnixDisableInterfaceOffload(char *name)
 #endif	// UNIX_LINUX
 }
 
-// Validate whether the UNIX is running in a VM
+// Validate whether the Linux/FreeBSD is running in a VM
+// Not implemented yet on other OS
 bool UnixIsInVmMain()
 {
 	TOKEN_LIST *t = NULL;
 	bool ret = false;
+#if defined(UNIX_LINUX)
 	char *vm_str_list = "Hypervisor detected,VMware Virtual Platform,VMware Virtual USB,qemu,xen,paravirtualized,virtual hd,virtualhd,virtual pc,virtualpc,kvm,oracle vm,oraclevm,parallels,xvm,bochs";
+#elif defined(__FreeBSD__)
+	char *vm_str_list = "generic,xen,hv,vmware,kvm,bhyve";
+#endif
 
-#ifdef	UNIX_LINUX
+#if defined(UNIX_LINUX)
 	t = UnixExec("/bin/dmesg");
+#elif defined(__FreeBSD__)
+	t = UnixExec("/sbin/sysctl -n kern.vm_guest");
+#endif
 
+#if defined(UNIX_LINUX) || defined(__FreeBSD__)
 	if (t != NULL)
 	{
 		BUF *b = NewBuf();
@@ -327,10 +336,11 @@ bool UnixIsInVmMain()
 		FreeBuf(b);
 		FreeToken(t);
 	}
-#endif	// UNIX_LINUX
+#endif // defined(UNIX_LINUX) || defined(__FreeBSD)
 
 	return ret;
 }
+
 bool UnixIsInVm()
 {
 	static bool is_in_vm_flag = false;


### PR DESCRIPTION
This is just a cosmetic problem in the result of "Caps" command which gets the list of server functions/capability.  There's no behavioural changes in SoftEtherVPN whether running on VM so far.

![image](https://user-images.githubusercontent.com/941609/221811318-c724e313-181a-48c9-9094-03e7f093300a.png)

