### PR TITLE
Cedar: Trim contiguous whitespaces in version string

### DIFF
--- a/src/Cedar/Cedar.c
+++ b/src/Cedar/Cedar.c
@@ -1564,11 +1564,14 @@ CEDAR *NewCedar(X *server_x, K *server_k)
 #endif	// ALPHA_VERSION
 
 	ToStr(tmp2, c->Beta);
+	Format(tmp2, sizeof(tmp2), " %s %s ", beta_str, tmp2);
 
-	Format(tmp, sizeof(tmp), "Version %u.%02u Build %u %s %s (%s)",
+	Format(tmp, sizeof(tmp),
+		"Version %u.%02u Build %u"
+		"%s"    // Alpha, Beta, Release Candidate or nothing
+		"(%s)", // Language
 		CEDAR_VERSION_MAJOR, CEDAR_VERSION_MINOR, CEDAR_VERSION_BUILD,
-		c->Beta == 0 ? "" : beta_str,
-		c->Beta == 0 ? "" : tmp2,
+		c->Beta == 0 ? " " : tmp2,
 		_SS("LANGSTR"));
 	Trim(tmp);
 


### PR DESCRIPTION
This is also a cosmetic fix.

----


Before change, contiguous whitespaces appeared in version string. This room is for beta string (such as Alpha, Beta) and beta number but it looks a bit odd if the build is not alpha/beta/RC.

```
> Version 5.02 Build 5180 Alpha 3 (Japanese)
> Version 5.02 Build 5180 Beta 3 (Japanese)
> Version 5.02 Build 5180 Release Candidate 3 (Japanese)
> Version 5.02 Build 5180   (Japanese)
>                        ^^^
```

Now version string looks neat like this:

```
> Version 5.02 Build 5180 (Japanese)
> Version 5.02 Build 5180 Release Candidate 3 (Japanese)
```

------

The version string appears in the output of `vpncmd` and "About this VPN server" in Server Manager.

![image](https://user-images.githubusercontent.com/941609/221876008-577a8141-54be-4498-b369-c5c3cb752ea9.png)

![image](https://user-images.githubusercontent.com/941609/221876918-75305cfa-3614-48d9-87f3-533d49c9507c.png)

