### PR TITLE
README: SEvsDE: document AES-NI hardware acceleration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ https://github.com/domosekai
 | ECDSA Certificates Import | ❌ | ✅ | |
 | Runs on Windows XP and Earlier | ✅ | ❌ | |
 | Compatible with SoftEther VPN 1.0 | ✅ | ❌ | |
+| AES-NI Hardware Acceleration | ⚠️ |  ✅ | SE requires [intel_aes_lib](https://software.intel.com/sites/default/files/article/181731/intel-aesni-sample-library-v1.2.zip) to enable AES-NI, so x86 only. In DE, enabled by default as long as processor supports it (at least x86 and ARM). |
 
 # Installation
 


### PR DESCRIPTION
Hi, I just remembered there's one more difference between Stable Edition and Developer Edition.

-----

Stable Edition requires intel_aes_lib to enable AES-NI [1]. Developer Edition depends on OpeSSL to use AES-NI. It is enabled by default as long as processor supports it.

[1] https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/blob/bf23fe0/src/Mayaqua/Encrypt.c#L145-L147
