### PR TITLE
Windows: link MSVC runtime static

### DIFF
--- a/.ci/azure-pipelines/windows.yml
+++ b/.ci/azure-pipelines/windows.yml
@@ -10,7 +10,7 @@ jobs:
     parameters:
       architecture: "x64"
       compilerPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe"
-      vcpkgTriplet: "x64-windows-static-md"
+      vcpkgTriplet: "x64-windows-static"
       vcvarsPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
 - job: Windows_x86
   pool:
@@ -23,5 +23,5 @@ jobs:
     parameters:
       architecture: "x86"
       compilerPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/bin/clang-cl.exe"
-      vcpkgTriplet: "x86-windows-static-md"
+      vcpkgTriplet: "x86-windows-static"
       vcvarsPath: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cproject
 .project
 .settings/
+.vs/
 Makefile
 /src/bin/*
 !/src/bin/hamcore/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ if (BUILD_NUMBER LESS 5180)
 		"For detailed info: https://github.com/SoftEtherVPN/SoftEtherVPN/issues/1392#issuecomment-867348281")
 endif()
 
+#
+# Link MSVC runtime statically
+# this should be revisited after installer migration to MSI
+#
+cmake_policy(SET CMP0091 NEW)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 project("SoftEther VPN"
   VERSION "5.02.${BUILD_NUMBER}"
   LANGUAGES C

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -30,7 +30,7 @@
         },
         {
           "name": "VCPKG_TARGET_TRIPLET",
-          "value": "x64-windows-static-md",
+          "value": "x64-windows-static",
           "type": "STRING"
         }
       ]
@@ -64,7 +64,7 @@
         },
         {
           "name": "VCPKG_TARGET_TRIPLET",
-          "value": "x86-windows-static-md",
+          "value": "x86-windows-static",
           "type": "STRING"
         }
       ]
@@ -98,7 +98,7 @@
         },
         {
           "name": "VCPKG_TARGET_TRIPLET",
-          "value": "x64-windows-static-md",
+          "value": "x64-windows-static",
           "type": "STRING"
         }
       ]
@@ -132,7 +132,7 @@
         },
         {
           "name": "VCPKG_TARGET_TRIPLET",
-          "value": "x86-windows-static-md",
+          "value": "x86-windows-static",
           "type": "STRING"
         }
       ]


### PR DESCRIPTION
let us link MSVC runtime statically. this should eliminate the need of installing VC Redist.
thank @pizzaprogram for details

