### PR TITLE
Mayaqua/Memory: Fix memory corruption in base64

### DIFF
--- a/src/Mayaqua/Memory.c
+++ b/src/Mayaqua/Memory.c
@@ -3463,7 +3463,7 @@ void *Base64ToBin(UINT *out_size, const void *src, const UINT size)
 		return NULL;
 	}
 
-	void *bin = Malloc(bin_size);
+	void *bin = ZeroMalloc(bin_size + 1);
 	bin_size = Base64Decode(bin, src, size);
 	if (bin_size == 0)
 	{


### PR DESCRIPTION
Base64 operations were refactored in #1404. However a '\0' is not added to the binary output and may corrupt memory in HTTP basic auth.