### PR TITLE
src/Cedar/Proto_OpenVPN.c: fix denial of service found by Cisco Talos

### DIFF
--- a/src/Cedar/Proto_OpenVPN.c
+++ b/src/Cedar/Proto_OpenVPN.c
@@ -147,7 +147,7 @@ bool OvsProcessData(void *param, TCP_RAW_DATA *in, FIFO *out)
 		payload_size = READ_USHORT(FifoPtr(fifo));
 		packet_size = payload_size + sizeof(USHORT);
 
-		if (payload_size == 0 || packet_size > sizeof(buf))
+		if (payload_size == 0 || payload_size > (sizeof(buf) - sizeof(USHORT)))
 		{
 			ret = false;
 			Debug("OvsProcessData(): Invalid payload size: %u bytes\n", payload_size);


### PR DESCRIPTION
specially crafted network packet lead to buffer overrun and process crash. working exploit was provided by Cisco Talos team.

An integer underflow vulnerability exists in the vpnserver OvsProcessData functionality of SoftEther VPN 5.01.9674 and 5.02. A specially-crafted network packet can lead to denial of service. An attacker can send a malicious packet to trigger this vulnerability.

The versions below were either tested or verified to be vulnerable by Talos or confirmed to be vulnerable by the vendor.

SoftEther VPN 5.01.9674
SoftEther VPN 5.02
While 5.01.9674 is a development version, it is distributed at the time of writing by Ubuntu and other Debian-based distributions.
