### PR TITLE
src/Mayaqua/Str.c: fix denial of service reported by Cisco Talos

### DIFF
--- a/src/Mayaqua/Str.c
+++ b/src/Mayaqua/Str.c
@@ -2062,11 +2062,11 @@ void EnSafeHttpHeaderValueStr(char *str, char replace)
 	length = StrLen(str);
 	while (index < length)
 	{
-		if (str[index] == '\r' || str[index] == '\n')
+		if ((str[index] == '\r' || str[index] == '\n') &&  length - index > 1)
 		{
 			if (replace == ' ')
 			{
-				Move(&str[index], &str[index + 1], length - index);
+				Move(&str[index], &str[index + 1], length - index - 1);
 			}
 			else
 			{
@@ -2075,12 +2075,12 @@ void EnSafeHttpHeaderValueStr(char *str, char replace)
 		}
 		else if (str[index] == '\\')
 		{
-			if (str[index + 1] == 'r' || str[index + 1] == 'n')
+			if ((str[index + 1] == 'r' || str[index + 1] == 'n') && length - index > 2)
 			{
 				if (replace == ' ')
 				{
-					Move(&str[index], &str[index + 2], length - index);
-					index--;
+					Move(&str[index], &str[index + 2], length - index - 2);
+					index++;
 				}
 				else
 				{


### PR DESCRIPTION
TALOS-2023-1741
CVE-2023-23581

SoftEther VPN vpnserver EnSafeHttpHeaderValueStr denial of service vulnerability

A denial of service vulnerability exists in the vpnserver EnSafeHttpHeaderValueStr functionality of SoftEther VPN 5.01.9674 and 5.02. A specially-crafted network packet can lead to denial of service.


