### PR TITLE
src/Cedar/Server.c: fix race condition

### DIFF
--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -1092,10 +1092,15 @@ UINT GetServerCapsInt(SERVER *s, char *name)
 		return 0;
 	}
 
-	Zero(&t, sizeof(t));
-	GetServerCaps(s, &t);
 
-	ret = GetCapsInt(&t, name);
+	Lock(s->CapsCacheLock);
+	{
+		Zero(&t, sizeof(t));
+		GetServerCaps(s, &t);
+
+		ret = GetCapsInt(&t, name);
+	}
+	Unlock(s->CapsCacheLock);
 
 	return ret;
 }
@@ -1164,10 +1169,14 @@ void FlushServerCaps(SERVER *s)
 		return;
 	}
 
-	DestroyServerCapsCache(s);
+	Lock(s->CapsCacheLock);
+	{
+		DestroyServerCapsCache(s);
 
-	Zero(&t, sizeof(t));
-	GetServerCaps(s, &t);
+		Zero(&t, sizeof(t));
+		GetServerCaps(s, &t);
+	}
+	Unlock(s->CapsCacheLock);
 }
 
 // Get the Caps list for this server


### PR DESCRIPTION
```
================================================================= ==1505093==ERROR: AddressSanitizer: heap-use-after-free on address 0x607000366b88 at pc 0x7f72afadc34a bp 0x7f72990fa390 sp 0x7f72990fa388 READ of size 4 at 0x607000366b88 thread T22
    #0 0x7f72afadc349 in GetCaps /home/ilia/SoftEtherVPN/src/Cedar/Server.c:1861
    #1 0x7f72afadc382 in GetCapsInt /home/ilia/SoftEtherVPN/src/Cedar/Server.c:1802
    #2 0x7f72afaf72a5 in GetServerCapsInt /home/ilia/SoftEtherVPN/src/Cedar/Server.c:1098
    #3 0x7f72afaf7318 in GetServerCapsBool /home/ilia/SoftEtherVPN/src/Cedar/Server.c:1104
    #4 0x7f72afaf771e in SiWriteHubCfg /home/ilia/SoftEtherVPN/src/Cedar/Server.c:4887
    #5 0x7f72afaf771e in SiWriteHubCfg /home/ilia/SoftEtherVPN/src/Cedar/Server.c:4824
    #6 0x7f72afaf7c0b in SiWriteHubs /home/ilia/SoftEtherVPN/src/Cedar/Server.c:5548
    #7 0x7f72afaf7c0b in SiWriteHubs /home/ilia/SoftEtherVPN/src/Cedar/Server.c:5515
    #8 0x7f72afaf81d6 in SiWriteConfigurationToCfg /home/ilia/SoftEtherVPN/src/Cedar/Server.c:3166
    #9 0x7f72afaf86bc in SiWriteConfigurationFile /home/ilia/SoftEtherVPN/src/Cedar/Server.c:6593
    #10 0x7f72afaf86bc in SiWriteConfigurationFile /home/ilia/SoftEtherVPN/src/Cedar/Server.c:6569
    #11 0x7f72afaf8914 in SiSaverThread /home/ilia/SoftEtherVPN/src/Cedar/Server.c:6561
    #12 0x7f72afaf8914 in SiSaverThread /home/ilia/SoftEtherVPN/src/Cedar/Server.c:6547
    #13 0x7f72af6e0cfa in ThreadPoolProc /home/ilia/SoftEtherVPN/src/Mayaqua/Kernel.c:872
    #14 0x7f72af6e0cfa in ThreadPoolProc /home/ilia/SoftEtherVPN/src/Mayaqua/Kernel.c:827
    #15 0x7f72af76eeb4 in UnixDefaultThreadProc /home/ilia/SoftEtherVPN/src/Mayaqua/Unix.c:1604
    #16 0x7f72af4ffc56 in start_thread (/lib64/libc.so.6+0x8cc56) (BuildId: 6107835fa7d4725691b2b7f6aaee7abe09f493b2)
    #17 0x7f72af585a6f in __clone3 (/lib64/libc.so.6+0x112a6f) (BuildId: 6107835fa7d4725691b2b7f6aaee7abe09f493b2)

0x607000366b88 is located 24 bytes inside of 72-byte region [0x607000366b70,0x607000366bb8) freed by thread T0 here:
    #0 0x7f72afed7fc8 in __interceptor_free.part.0 (/lib64/libasan.so.8+0xd7fc8) (BuildId: 9501248886f79bf1482f3e153f794be742818172)
    #1 0x7f72af76ed6f in UnixMemoryFree /home/ilia/SoftEtherVPN/src/Mayaqua/Unix.c:2072

previously allocated by thread T22 here:
    #0 0x7f72afed92ff in malloc (/lib64/libasan.so.8+0xd92ff) (BuildId: 9501248886f79bf1482f3e153f794be742818172)
    #1 0x7f72af76f35d in UnixMemoryAlloc /home/ilia/SoftEtherVPN/src/Mayaqua/Unix.c:2053

Thread T22 created by T0 here:
    #0 0x7f72afe48966 in pthread_create (/lib64/libasan.so.8+0x48966) (BuildId: 9501248886f79bf1482f3e153f794be742818172)
    #1 0x7f72af76f713 in UnixInitThread /home/ilia/SoftEtherVPN/src/Mayaqua/Unix.c:1683

SUMMARY: AddressSanitizer: heap-use-after-free /home/ilia/SoftEtherVPN/src/Cedar/Server.c:1861 in GetCaps Shadow bytes around the buggy address:
  0x607000366900: 00 00 00 fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x607000366980: 00 fa fa fa fa fa 00 00 00 00 00 00 00 00 00 fa
  0x607000366a00: fa fa fa fa 00 00 00 00 00 00 00 00 00 fa fa fa
  0x607000366a80: fa fa 00 00 00 00 00 00 00 00 00 fa fa fa fa fa
  0x607000366b00: 00 00 00 00 00 00 00 00 00 fa fa fa fa fa fd fd
=>0x607000366b80: fd[fd]fd fd fd fd fd fa fa fa fa fa fd fd fd fd
  0x607000366c00: fd fd fd fd fd fa fa fa fa fa fd fd fd fd fd fd
  0x607000366c80: fd fd fd fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x607000366d00: fd fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x607000366d80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x607000366e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
```