### PR TITLE
FreeBSD: Improve client's virtual network interface handling

### DIFF
--- a/src/Cedar/Cedar.h
+++ b/src/Cedar/Cedar.h
@@ -675,6 +675,8 @@
 // 
 //////////////////////////////////////////////////////////////////////
 
+#define	UNIX_VLAN_IFACE_PREFIX			"vpn"			// Prefix of UNIX virual LAN card interface
+
 #ifndef	UNIX_BSD
 #define	TAP_FILENAME_1				"/dev/net/tun"
 #define	TAP_FILENAME_2				"/dev/tun"

--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -6524,9 +6524,7 @@ bool CtConnect(CLIENT *c, RPC_CLIENT_CONNECT *connect)
 // Requires account and VLan lists of the CLIENT argument to be already locked
 bool CtVLansDown(CLIENT *c)
 {
-#ifndef UNIX_LINUX
-	return true;
-#else
+#if defined(UNIX_LINUX) || defined(UNIX_BSD)
 	int i;
 	LIST *tmpVLanList;
 	UNIX_VLAN t, *r;
@@ -6568,6 +6566,8 @@ bool CtVLansDown(CLIENT *c)
 
 	ReleaseList(tmpVLanList);
 	return result;
+#else
+	return true;
 #endif
 }
 
@@ -6575,9 +6575,7 @@ bool CtVLansDown(CLIENT *c)
 // Requires VLan list of the CLIENT argument to be already locked
 bool CtVLansUp(CLIENT *c)
 {
-#ifndef UNIX_LINUX
-	return true;
-#else
+#if defined(UNIX_LINUX) || defined(UNIX_BSD)
 	int i;
 	UNIX_VLAN *r;
 
@@ -6591,9 +6589,8 @@ bool CtVLansUp(CLIENT *c)
 		r = LIST_DATA(c->UnixVLanList, i);
 		UnixVLanSetState(r->Name, true);
 	}
-
-	return true;
 #endif
+	return true;
 }
 
 // Get the account information

--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -7987,7 +7987,8 @@ void SmBridgeDlgOnOk(HWND hWnd, SM_SERVER *s)
 	StrCpy(t.HubName, sizeof(t.HubName), hub);
 	t.TapMode = tapmode;
 
-	if (InStrEx(t.DeviceName, "vpn", false) || InStrEx(t.DeviceName, "tun", false)
+	if (InStrEx(t.DeviceName, UNIX_VLAN_IFACE_PREFIX, false)
+		|| InStrEx(t.DeviceName, "tun", false)
 		|| InStrEx(t.DeviceName, "tap", false))
 	{
 		// Trying to make a local bridge to the VPN device

--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -554,7 +554,7 @@ int UnixCreateTapDeviceEx(char *name, char *prefix, UCHAR *mac_address, bool cre
 }
 int UnixCreateTapDevice(char *name, UCHAR *mac_address, bool create_up)
 {
-	return UnixCreateTapDeviceEx(name, "vpn", mac_address, create_up);
+	return UnixCreateTapDeviceEx(name, UNIX_VLAN_IFACE_PREFIX, mac_address, create_up);
 }
 
 // Close the tap device
@@ -662,7 +662,7 @@ bool UnixVLanCreateEx(char *name, char *prefix, UCHAR *mac_address, bool create_
 }
 bool UnixVLanCreate(char *name, UCHAR *mac_address, bool create_up)
 {
-	return UnixVLanCreateEx(name, "vpn", mac_address, create_up);
+	return UnixVLanCreateEx(name, UNIX_VLAN_IFACE_PREFIX, mac_address, create_up);
 }
 
 // Set a VLAN up/down
@@ -689,7 +689,7 @@ bool UnixVLanSetState(char* name, bool state_up)
 			return false;
 		}
 
-		GenerateTunName(name, "vpn", eth_name, sizeof(eth_name));
+		GenerateTunName(name, UNIX_VLAN_IFACE_PREFIX, eth_name, sizeof(eth_name));
 		Zero(&ifr, sizeof(ifr));
 		StrCpy(ifr.ifr_name, sizeof(ifr.ifr_name), eth_name);
 

--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -846,7 +846,7 @@ void UnixVLanFree()
 		UNIX_VLAN_LIST *t = LIST_DATA(unix_vlan, i);
 
 		UnixCloseTapDevice(t->fd);
-#ifdef	UNIX_BSD
+#ifdef UNIX_BSD
 		UnixDestroyTapDevice(t->Name);
 #endif
 		Free(t);

--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -569,9 +569,37 @@ void UnixCloseTapDevice(int fd)
 	close(fd);
 }
 
+// Destroy the tap device (for FreeBSD)
+// FreeBSD tap device is still plumbed after closing fd so need to destroy after close
+void UnixDestroyTapDevice(char *name)
+{
+#ifdef UNIX_BSD
+	struct ifreq ifr;
+	char eth_name[MAX_SIZE];
+	int s;
+
+	Zero(&ifr, sizeof(ifr));
+	GenerateTunName(name, UNIX_VLAN_IFACE_PREFIX, eth_name, sizeof(eth_name));
+	StrCpy(ifr.ifr_name, sizeof(ifr.ifr_name), eth_name);
+
+	s = socket(AF_INET, SOCK_DGRAM, 0);
+	if (s == -1)
+	{
+		return;
+	}
+	ioctl(s, SIOCIFDESTROY, &ifr);
+
+	close(s);
+#endif	// UNIX_BSD
+}
+
 #else	// NO_VLAN
 
 void UnixCloseTapDevice(int fd)
+{
+}
+
+void UnixDestroyTapDevice(char *name)
 {
 }
 
@@ -769,6 +797,9 @@ void UnixVLanDelete(char *name)
 		if (t != NULL)
 		{
 			UnixCloseTapDevice(t->fd);
+#ifdef UNIX_BSD
+			UnixDestroyTapDevice(t->Name);
+#endif
 			Delete(unix_vlan, t);
 			Free(t);
 		}
@@ -815,6 +846,9 @@ void UnixVLanFree()
 		UNIX_VLAN_LIST *t = LIST_DATA(unix_vlan, i);
 
 		UnixCloseTapDevice(t->fd);
+#ifdef	UNIX_BSD
+		UnixDestroyTapDevice(t->Name);
+#endif
 		Free(t);
 	}
 

--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -696,7 +696,7 @@ bool UnixVLanCreate(char *name, UCHAR *mac_address, bool create_up)
 // Set a VLAN up/down
 bool UnixVLanSetState(char* name, bool state_up)
 {
-#ifdef UNIX_LINUX
+#if defined(UNIX_LINUX) || defined(UNIX_BSD)
 	UNIX_VLAN_LIST *t, tt;
 	struct ifreq ifr;
 	int s;
@@ -742,7 +742,7 @@ bool UnixVLanSetState(char* name, bool state_up)
 		close(s);
 	}
 	UnlockList(unix_vlan);
-#endif // UNIX_LINUX
+#endif // UNIX_LINUX || UNIX_BSD
 
 	return true;
 }

--- a/src/Cedar/VLanUnix.h
+++ b/src/Cedar/VLanUnix.h
@@ -60,6 +60,7 @@ struct UNIX_VLAN_LIST
 int UnixCreateTapDevice(char *name, UCHAR *mac_address, bool create_up);
 int UnixCreateTapDeviceEx(char *name, char *prefix, UCHAR *mac_address, bool create_up);
 void UnixCloseTapDevice(int fd);
+void UnixDestroyTapDevice(char *name);
 void UnixVLanInit();
 void UnixVLanFree();
 bool UnixVLanCreate(char *name, UCHAR *mac_address, bool create_up);


### PR DESCRIPTION
As a result of this PR, vpnclient functionality on FreeBSD has become more practical.

- Don't hardcode prefix for UNIX virtual network interface
- Make NicDelete work on FreeBSD
    -  Virtual network interfaces are properly cleaned up when shutting down vpnclient
- Make NIC state change (up/down) work on FreeBSD
   -  Virtual network interface state is set to up when attempt to VPN server
 
Fixes: #1858 
