### PR TITLE
Cedar/VLanUnix: add description to FreeBSD tap device

### DIFF
--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -470,6 +470,17 @@ int UnixCreateTapDeviceEx(char *name, char *prefix, UCHAR *mac_address, bool cre
 			ioctl(s, SIOCSIFLLADDR, &ifr);
 		}
 
+		// Set interface description
+#ifdef	SIOCSIFDESCR
+		{
+			char desc[] = CEDAR_PRODUCT_STR " Virtual Network Adapter";
+
+			ifr.ifr_buffer.buffer = desc;
+			ifr.ifr_buffer.length = StrLen(desc) + 1;
+			ioctl(s, SIOCSIFDESCR, &ifr);
+		}
+#endif
+
 		if (create_up)
 		{
 			Zero(&ifr, sizeof(ifr));


### PR DESCRIPTION
In addition to #1859, added interface description to the tap interface.

```
$ ifconfig vpn_client
vpn_client: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
        description: SoftEther Virtual Network Adapter <-- THIS IS IT!
        options=80000<LINKSTATE>
        ether 5e:51:5e:48:ea:ef
        hwaddr 58:9c:fc:10:34:2a
        groups: tap
        media: Ethernet autoselect
        status: active
        nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
        Opened by PID 35981
```