### PR TITLE
Restrict access to JSON-RPC API based on client IP address

### DIFF
--- a/developer_tools/vpnserver-jsonrpc-clients/README.html
+++ b/developer_tools/vpnserver-jsonrpc-clients/README.html
@@ -30,6 +30,7 @@
 <ul>
 <li>Older versions of SoftEther VPN before June 2019 don't support JSON-RPC APIs.</li>
 <li>If you want to completely disable the JSON-RPC on your VPN Server, set the <code>DisableJsonRpcWebApi</code> variable to <code>true</code> on the <code>vpn_server.config</code>.</li>
+<li>You may also restrict access to JSON-RPC API to a specific subnet, e.g. your internal network, by setting the <code>JsonRpcWebApiAllowedSubnet</code> variable to, for example, <code>192.168.0.0/16</code>.</li>
 </ul>
 <h3 id="json-rpc-specification">JSON-RPC specification</h3>
 <p>You must use HTTPS 1.1 <code>POST</code> method to call each of JSON-RPC APIs.<br />

--- a/developer_tools/vpnserver-jsonrpc-clients/README.md
+++ b/developer_tools/vpnserver-jsonrpc-clients/README.md
@@ -25,6 +25,7 @@ https://<vpn_server_hostname>:<port>/api/
 
   - Older versions of SoftEther VPN before June 2019 don't support JSON-RPC APIs.
   - If you want to completely disable the JSON-RPC on your VPN Server, set the `DisableJsonRpcWebApi` variable to `true` on the `vpn_server.config`.
+  - You may also restrict access to JSON-RPC API to a specific subnet, e.g. your internal network, by setting the `JsonRpcWebApiAllowedSubnet` variable to, for example, `192.168.0.0/16`.
 
 
 ### JSON-RPC specification

--- a/developer_tools/vpnserver-jsonrpc-codegen/Templates/doc.txt
+++ b/developer_tools/vpnserver-jsonrpc-codegen/Templates/doc.txt
@@ -25,6 +25,7 @@ https://<vpn_server_hostname>:<port>/api/
 
   - Older versions of SoftEther VPN before June 2019 don't support JSON-RPC APIs.
   - If you want to completely disable the JSON-RPC on your VPN Server, set the `DisableJsonRpcWebApi` variable to `true` on the `vpn_server.config`.
+  - You may also restrict access to JSON-RPC API to a specific subnet, e.g. your internal network, by setting the `JsonRpcWebApiAllowedSubnet` variable to, for example, `192.168.0.0/16`.
 
 
 ### JSON-RPC specification

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -30,6 +30,7 @@
 #include "Mayaqua/Internat.h"
 #include "Mayaqua/Memory.h"
 #include "Mayaqua/Microsoft.h"
+#include "Mayaqua/Network.h"
 #include "Mayaqua/Object.h"
 #include "Mayaqua/OS.h"
 #include "Mayaqua/Pack.h"
@@ -6032,6 +6033,15 @@ void SiLoadServerCfg(SERVER *s, FOLDER *f)
 		// Disable JSON-RPC Web API
 		s->DisableJsonRpcWebApi = CfgGetBool(f, "DisableJsonRpcWebApi");
 
+		char tmpaddr[MAX_PATH];
+		if (CfgGetStr(f, "JsonRpcWebApiAllowedSubnet", tmpaddr, sizeof(tmpaddr))) {
+			IP _subnet, _mask;
+			if (ParseIpAndMask46(tmpaddr, &_subnet, &_mask)) {
+				s->JsonRpcWebApiAllowedSubnetAddr = _subnet;
+				s->JsonRpcWebApiAllowedSubnetMask = _mask;
+			}
+		}
+
 		// Bits of Diffie-Hellman parameters
 		c->DhParamBits = CfgGetInt(f, "DhParamBits");
 		if (c->DhParamBits == 0)
@@ -6365,6 +6375,11 @@ void SiWriteServerCfg(FOLDER *f, SERVER *s)
 
 		// Disable JSON-RPC Web API
 		CfgAddBool(f, "DisableJsonRpcWebApi", s->DisableJsonRpcWebApi);
+
+		char tmpaddr[MAX_PATH];
+		IPAndMaskToStr(tmpaddr, sizeof(tmpaddr),
+			&s->JsonRpcWebApiAllowedSubnetAddr, &s->JsonRpcWebApiAllowedSubnetMask);
+		CfgAddStr(f, "JsonRpcWebApiAllowedSubnet", tmpaddr);
 	}
 	Unlock(c->lock);
 }

--- a/src/Cedar/Server.h
+++ b/src/Cedar/Server.h
@@ -276,6 +276,9 @@ struct SERVER
 	IP ListenIP;						// Listen IP
 	bool StrictSyslogDatetimeFormat;	// Make syslog datetime format strict RFC3164
 	bool DisableJsonRpcWebApi;					// Disable JSON-RPC Web API
+
+	IP JsonRpcWebApiAllowedSubnetAddr;  // If set, allow access to JSON-RPC Web API from
+	IP JsonRpcWebApiAllowedSubnetMask;  //   this subnet only
 };
 
 

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -6976,6 +6976,18 @@ void IPToStr6Inner(char *str, IP *ip)
 	}
 }
 
+// Format IP and subnet mask as "<ip>/<masksize>"
+void IPAndMaskToStr(char *str, UINT size, IP *ip, IP *subnet)
+{
+	int iplen;
+	UINT masksize;
+
+	IPToStr(str, size, ip);
+	iplen = StrLen(str);
+	masksize = SubnetMaskToInt(subnet);
+	Format(str + iplen, size - iplen, "/%d", masksize);
+}
+
 // Convert the string to an IP address
 bool StrToIP6(IP *ip, char *str)
 {

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -1270,6 +1270,7 @@ void IPToStr6(char *str, UINT size, IP *ip);
 void IP6AddrToStr(char *str, UINT size, IPV6_ADDR *addr);
 void IPToStr6Array(char *str, UINT size, UCHAR *bytes);
 void IPToStr6Inner(char *str, IP *ip);
+void IPAndMaskToStr(char *str, UINT size, IP *ip, IP *subnet);
 void IntToSubnetMask6(IP *ip, UINT i);
 void IPAnd6(IP *dst, IP *a, IP *b);
 void GetAllRouterMulticastAddress6(IP *ip);


### PR DESCRIPTION
Currently one can either disable the JSON-RPC API entirely (`DisableJsonRpcWebApi` config variable) or allow it to be accessed via the VPN server's public endpoint by anyone, protected only by a password.

Due to security considerations it might be undesirable to expose the JSON-RPC API on a public endpoint, even with password protection.

This PR adds a server config variable named `JsonRpcWebApiAllowedSubnet`. It can contain a subnet address in CIDR notation, such as `192.168.0.0/16`. When set, only clients from this subnet can access the JSON-RPC API; for others, the server behaves as if `DisableJsonRpcWebApi` were set to true.

```
declare root
{
        declare ServerConfiguration
        {
                ...
                bool DisableJsonRpcWebApi false
                string JsonRpcWebApiAllowedSubnet 192.168.0.0/16
                ...
        }
}
```

By default, `JsonRpcWebApiAllowedSubnet` is not set, i.e. it contains a zero subnet address, which is represented in config file as `::/0`.

This PR partially resolves #1140.