### PR TITLE
FreeBSD: Make sure to destroy tap device for bridge

### DIFF
--- a/src/Cedar/BridgeUnix.c
+++ b/src/Cedar/BridgeUnix.c
@@ -321,7 +321,7 @@ TOKEN_LIST *GetEthListLinux(bool enum_normal, bool enum_rawip)
 					{
 						if (IsInListStr(o, name) == false)
 						{
-							if (StartWith(name, "tap_") == false)
+							if (StartWith(name, UNIX_VLAN_BRDEST_IFACE_PREFIX"_") == false)
 							{
 								Add(o, CopyStr(name));
 							}

--- a/src/Cedar/BridgeUnix.c
+++ b/src/Cedar/BridgeUnix.c
@@ -321,7 +321,7 @@ TOKEN_LIST *GetEthListLinux(bool enum_normal, bool enum_rawip)
 					{
 						if (IsInListStr(o, name) == false)
 						{
-							if (StartWith(name, UNIX_VLAN_BRDEST_IFACE_PREFIX"_") == false)
+							if (StartWith(name, UNIX_VLAN_BRIDGE_IFACE_PREFIX"_") == false)
 							{
 								Add(o, CopyStr(name));
 							}

--- a/src/Cedar/BridgeUnix.c
+++ b/src/Cedar/BridgeUnix.c
@@ -506,7 +506,7 @@ ETH *OpenEthLinux(char *name, bool local, bool tapmode, char *tapaddr)
 	{
 #ifndef	NO_VLAN
 		// In tap mode
-		VLAN *v = NewTap(name, tapaddr, true);
+		VLAN *v = NewBridgeTap(name, tapaddr, true);
 		if (v == NULL)
 		{
 			return NULL;
@@ -1399,7 +1399,7 @@ ETH *OpenEthBSD(char *name, bool local, bool tapmode, char *tapaddr)
 	{
 #ifndef	NO_VLAN
 		// In tap mode
-		VLAN *v = NewTap(name, tapaddr, true);
+		VLAN *v = NewBridgeTap(name, tapaddr, true);
 		if (v == NULL)
 		{
 			return NULL;
@@ -1475,7 +1475,7 @@ void CloseEth(ETH *e)
 	if (e->Tap != NULL)
 	{
 #ifndef	NO_VLAN
-		FreeTap(e->Tap);
+		FreeBridgeTap(e->Tap);
 #endif	// NO_VLAN
 	}
 

--- a/src/Cedar/Cedar.h
+++ b/src/Cedar/Cedar.h
@@ -676,7 +676,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #define	UNIX_VLAN_CLIENT_IFACE_PREFIX		"vpn"			// Prefix of UNIX virtual LAN card interface (used for client)
-#define	UNIX_VLAN_BRDEST_IFACE_PREFIX		"tap"			// Prefix of UNIX virtual LAN card interface (used for bridge destination)
+#define	UNIX_VLAN_BRIDGE_IFACE_PREFIX		"tap"			// Prefix of UNIX virtual LAN card interface (used for bridge destination)
 
 #ifndef	UNIX_BSD
 #define	TAP_FILENAME_1				"/dev/net/tun"

--- a/src/Cedar/Cedar.h
+++ b/src/Cedar/Cedar.h
@@ -675,7 +675,8 @@
 // 
 //////////////////////////////////////////////////////////////////////
 
-#define	UNIX_VLAN_IFACE_PREFIX			"vpn"			// Prefix of UNIX virual LAN card interface
+#define	UNIX_VLAN_CLIENT_IFACE_PREFIX		"vpn"			// Prefix of UNIX virtual LAN card interface (used for client)
+#define	UNIX_VLAN_BRDEST_IFACE_PREFIX		"tap"			// Prefix of UNIX virtual LAN card interface (used for bridge destination)
 
 #ifndef	UNIX_BSD
 #define	TAP_FILENAME_1				"/dev/net/tun"

--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -7988,7 +7988,7 @@ void SmBridgeDlgOnOk(HWND hWnd, SM_SERVER *s)
 	t.TapMode = tapmode;
 
 	if (InStrEx(t.DeviceName, UNIX_VLAN_CLIENT_IFACE_PREFIX, false)
-		|| InStrEx(t.DeviceName, "UNIX_VLAN_BRIDGE_IFACE_PREFIX, false)
+		|| InStrEx(t.DeviceName, UNIX_VLAN_BRIDGE_IFACE_PREFIX, false)
 		|| InStrEx(t.DeviceName, "tun", false)
 		|| InStrEx(t.DeviceName, "tap", false))
 	{

--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -7988,7 +7988,7 @@ void SmBridgeDlgOnOk(HWND hWnd, SM_SERVER *s)
 	t.TapMode = tapmode;
 
 	if (InStrEx(t.DeviceName, UNIX_VLAN_CLIENT_IFACE_PREFIX, false)
-		|| InStrEx(t.DeviceName, "UNIX_VLAN_BRDEST_IFACE_PREFIX, false)
+		|| InStrEx(t.DeviceName, "UNIX_VLAN_BRIDGE_IFACE_PREFIX, false)
 		|| InStrEx(t.DeviceName, "tun", false)
 		|| InStrEx(t.DeviceName, "tap", false))
 	{

--- a/src/Cedar/SM.c
+++ b/src/Cedar/SM.c
@@ -7987,7 +7987,8 @@ void SmBridgeDlgOnOk(HWND hWnd, SM_SERVER *s)
 	StrCpy(t.HubName, sizeof(t.HubName), hub);
 	t.TapMode = tapmode;
 
-	if (InStrEx(t.DeviceName, UNIX_VLAN_IFACE_PREFIX, false)
+	if (InStrEx(t.DeviceName, UNIX_VLAN_CLIENT_IFACE_PREFIX, false)
+		|| InStrEx(t.DeviceName, "UNIX_VLAN_BRDEST_IFACE_PREFIX, false)
 		|| InStrEx(t.DeviceName, "tun", false)
 		|| InStrEx(t.DeviceName, "tap", false))
 	{

--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -273,7 +273,7 @@ VLAN *NewTap(char *name, char *mac_address, bool create_up)
 		return NULL;
 	}
 
-	fd = UnixCreateTapDeviceEx(name, "tap", mac_address, create_up);
+	fd = UnixCreateTapDeviceEx(name, UNIX_VLAN_BRDEST_IFACE_PREFIX, mac_address, create_up);
 	if (fd == -1)
 	{
 		return NULL;
@@ -565,7 +565,7 @@ int UnixCreateTapDeviceEx(char *name, char *prefix, UCHAR *mac_address, bool cre
 }
 int UnixCreateTapDevice(char *name, UCHAR *mac_address, bool create_up)
 {
-	return UnixCreateTapDeviceEx(name, UNIX_VLAN_IFACE_PREFIX, mac_address, create_up);
+	return UnixCreateTapDeviceEx(name, UNIX_VLAN_CLIENT_IFACE_PREFIX, mac_address, create_up);
 }
 
 // Close the tap device
@@ -701,7 +701,7 @@ bool UnixVLanCreateEx(char *name, char *prefix, UCHAR *mac_address, bool create_
 }
 bool UnixVLanCreate(char *name, UCHAR *mac_address, bool create_up)
 {
-	return UnixVLanCreateEx(name, UNIX_VLAN_IFACE_PREFIX, mac_address, create_up);
+	return UnixVLanCreateEx(name, UNIX_VLAN_CLIENT_IFACE_PREFIX, mac_address, create_up);
 }
 
 // Set a VLAN up/down
@@ -728,7 +728,7 @@ bool UnixVLanSetState(char* name, bool state_up)
 			return false;
 		}
 
-		GenerateTunName(name, UNIX_VLAN_IFACE_PREFIX, eth_name, sizeof(eth_name));
+		GenerateTunName(name, UNIX_VLAN_CLIENT_IFACE_PREFIX, eth_name, sizeof(eth_name));
 		Zero(&ifr, sizeof(ifr));
 		StrCpy(ifr.ifr_name, sizeof(ifr.ifr_name), eth_name);
 

--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -624,14 +624,15 @@ void UnixDestroyClientTapDevice(char *name)
 
 #else	// NO_VLAN
 
-void UnixCloseBridgeTapDevice(int fd)
+void UnixCloseDevice(int fd)
 {
 }
 
-void UnixCloseClientTapDevice(int fd)
-{
-
 void UnixDestroyTapDevice(char *name)
+{
+}
+
+void UnixDestroyTapDeviceEx(char *name, char *prefix)
 {
 }
 

--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -263,7 +263,7 @@ void FreeVLan(VLAN *v)
 }
 
 // Create a tap
-VLAN *NewTap(char *name, char *mac_address, bool create_up)
+VLAN *NewBridgeTap(char *name, char *mac_address, bool create_up)
 {
 	int fd;
 	VLAN *v;
@@ -288,7 +288,7 @@ VLAN *NewTap(char *name, char *mac_address, bool create_up)
 }
 
 // Close the tap
-void FreeTap(VLAN *v)
+void FreeBridgeTap(VLAN *v)
 {
 	// Validate arguments
 	if (v == NULL)
@@ -296,7 +296,11 @@ void FreeTap(VLAN *v)
 		return;
 	}
 
-	close(v->fd);
+	UnixCloseTapDevice(v->fd);
+#ifdef	UNIX_BSD
+	UnixDestroyBridgeTapDevice(v->InstanceName);
+#endif
+
 	FreeVLan(v);
 }
 
@@ -582,7 +586,7 @@ void UnixCloseTapDevice(int fd)
 
 // Destroy the tap device (for FreeBSD)
 // FreeBSD tap device is still plumbed after closing fd so need to destroy after close
-void UnixDestroyTapDevice(char *name)
+void UnixDestroyTapDeviceEx(char *name, char *prefix)
 {
 #ifdef UNIX_BSD
 	struct ifreq ifr;
@@ -590,7 +594,7 @@ void UnixDestroyTapDevice(char *name)
 	int s;
 
 	Zero(&ifr, sizeof(ifr));
-	GenerateTunName(name, UNIX_VLAN_IFACE_PREFIX, eth_name, sizeof(eth_name));
+	GenerateTunName(name, prefix, eth_name, sizeof(eth_name));
 	StrCpy(ifr.ifr_name, sizeof(ifr.ifr_name), eth_name);
 
 	s = socket(AF_INET, SOCK_DGRAM, 0);
@@ -604,11 +608,28 @@ void UnixDestroyTapDevice(char *name)
 #endif	// UNIX_BSD
 }
 
+void UnixDestroyBridgeTapDevice(char *name)
+{
+#ifdef UNIX_BSD
+	UnixDestroyTapDeviceEx(name, UNIX_VLAN_BRDEST_IFACE_PREFIX);
+#endif	// UNIX_BSD
+}
+
+void UnixDestroyClientTapDevice(char *name)
+{
+#ifdef UNIX_BSD
+	UnixDestroyTapDeviceEx(name, UNIX_VLAN_CLIENT_IFACE_PREFIX);
+#endif	// UNIX_BSD
+}
+
 #else	// NO_VLAN
 
-void UnixCloseTapDevice(int fd)
+void UnixCloseBridgeTapDevice(int fd)
 {
 }
+
+void UnixCloseClientTapDevice(int fd)
+{
 
 void UnixDestroyTapDevice(char *name)
 {
@@ -809,7 +830,7 @@ void UnixVLanDelete(char *name)
 		{
 			UnixCloseTapDevice(t->fd);
 #ifdef UNIX_BSD
-			UnixDestroyTapDevice(t->Name);
+			UnixDestroyClientTapDevice(t->Name);
 #endif
 			Delete(unix_vlan, t);
 			Free(t);
@@ -858,7 +879,7 @@ void UnixVLanFree()
 
 		UnixCloseTapDevice(t->fd);
 #ifdef UNIX_BSD
-		UnixDestroyTapDevice(t->Name);
+		UnixDestroyClientTapDevice(t->Name);
 #endif
 		Free(t);
 	}

--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -273,7 +273,7 @@ VLAN *NewBridgeTap(char *name, char *mac_address, bool create_up)
 		return NULL;
 	}
 
-	fd = UnixCreateTapDeviceEx(name, UNIX_VLAN_BRDEST_IFACE_PREFIX, mac_address, create_up);
+	fd = UnixCreateTapDeviceEx(name, UNIX_VLAN_BRIDGE_IFACE_PREFIX, mac_address, create_up);
 	if (fd == -1)
 	{
 		return NULL;
@@ -611,7 +611,7 @@ void UnixDestroyTapDeviceEx(char *name, char *prefix)
 void UnixDestroyBridgeTapDevice(char *name)
 {
 #ifdef UNIX_BSD
-	UnixDestroyTapDeviceEx(name, UNIX_VLAN_BRDEST_IFACE_PREFIX);
+	UnixDestroyTapDeviceEx(name, UNIX_VLAN_BRIDGE_IFACE_PREFIX);
 #endif	// UNIX_BSD
 }
 

--- a/src/Cedar/VLanUnix.h
+++ b/src/Cedar/VLanUnix.h
@@ -31,9 +31,9 @@ struct VLAN
 
 // Function prototype
 VLAN *NewVLan(char *instance_name, VLAN_PARAM *param);
-VLAN *NewTap(char *name, char *mac_address, bool create_up);
+VLAN *NewBridgeTap(char *name, char *mac_address, bool create_up);
 void FreeVLan(VLAN *v);
-void FreeTap(VLAN *v);
+void FreeBridgeTap(VLAN *v);
 CANCEL *VLanGetCancel(VLAN *v);
 bool VLanGetNextPacket(VLAN *v, void **buf, UINT *size);
 bool VLanPutPacket(VLAN *v, void *buf, UINT size);
@@ -60,7 +60,8 @@ struct UNIX_VLAN_LIST
 int UnixCreateTapDevice(char *name, UCHAR *mac_address, bool create_up);
 int UnixCreateTapDeviceEx(char *name, char *prefix, UCHAR *mac_address, bool create_up);
 void UnixCloseTapDevice(int fd);
-void UnixDestroyTapDevice(char *name);
+void UnixDestroyBridgeTapDevice(char *name);
+void UnixDestroyClientTapDevice(char *name);
 void UnixVLanInit();
 void UnixVLanFree();
 bool UnixVLanCreate(char *name, UCHAR *mac_address, bool create_up);


### PR DESCRIPTION
This PR applies the same fix as well as #1859 for the bridge destination tap interface.

## Behaviour after this PR

1. No tap interfaces before starting vpnbridge.
```
root@freebsd:~/SoftEtherVPN/build # ifconfig -a -g tap
root@freebsd:~/SoftEtherVPN/build #
```

2. Bridge tap device is created after starting vpnbridge.
```
root@freebsd:~/SoftEtherVPN/build # ./vpnbridge start
root@freebsd:~/SoftEtherVPN/build # ./vpncmd /server localhost /cmd:bridgelist
BridgeList command - Get List of Local Bridge Connection
Number|Virtual Hub Name|Network Adapter or Tap Device Name|Status
------+----------------+----------------------------------+---------
1     |BRIDGE          |bridge                            |Operating                        
The command completed successfully.         

root@freebsd:~/SoftEtherVPN/build # ifconfig -a -g tap
tap_bridge: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
        description: SoftEther Virtual Network Adapter
        options=80000<LINKSTATE>
        ether 5e:d5:70:50:52:7d
        hwaddr 58:9c:fc:10:34:2a
        groups: tap
        media: Ethernet autoselect
        status: active
        nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
        Opened by PID 757
```

3. All tap devices created by SoftEther are properly cleaned up after shutting down vpnbridge.
```
root@freebsd:~/SoftEtherVPN/build # ./vpnbridge stop
root@freebsd:~/SoftEtherVPN/build # ifconfig -a -g tap
root@freebsd:~/SoftEtherVPN/build #
```

## Behaviour before this PR (e6123d36a0f34f0243f216233e85f316a4a3ff54)

Tap device for bridge destination is not properly destroyed, remains after shutting down vpnbridge.
```
root@freebsd:~/SoftEtherVPN/build # ./vpnbridge start
root@freebsd:~/SoftEtherVPN/build # ifconfig -a -g tap
tap_bridge: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
        options=80000<LINKSTATE>
        ether 5e:d5:70:50:52:7d
        hwaddr 58:9c:fc:10:34:2a
        inet 0.0.0.0 netmask 0xff000000 broadcast 255.255.255.255
        groups: tap
        media: Ethernet autoselect
        status: active
        nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
        Opened by PID 1187

root@freebsd:~/SoftEtherVPN/build # ./vpnbridge stop
root@freebsd:~/SoftEtherVPN/build # ifconfig -a -g tap
tap_bridge: flags=8802<BROADCAST,SIMPLEX,MULTICAST> metric 0 mtu 1500
        options=80000<LINKSTATE>
        ether 5e:d5:70:50:52:7d
        hwaddr 58:9c:fc:10:34:2a
        groups: tap
        media: Ethernet autoselect
        status: no carrier
        nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
```