### PR TITLE
Fix build when NO_VLAN

### DIFF
--- a/src/Cedar/BridgeUnix.c
+++ b/src/Cedar/BridgeUnix.c
@@ -1416,7 +1416,7 @@ ETH *OpenEthBSD(char *name, bool local, bool tapmode, char *tapaddr)
 
 		return e;
 #else	// NO_VLAN
-return NULL:
+	return NULL;
 #endif	// NO_VLAN
 	}
 

--- a/src/Cedar/Client.c
+++ b/src/Cedar/Client.c
@@ -22,6 +22,9 @@
 #include "VLanWin32.h"
 #include "Win32Com.h"
 #include "WinUi.h"
+#ifdef	NO_VLAN
+#include "NullLan.h"
+#endif
 
 #include "Mayaqua/Cfg.h"
 #include "Mayaqua/Encrypt.h"


### PR DESCRIPTION
Occurred at:	 #670
Closes:		#1864

Tested build on FreeBSD with NO_VLAN by modifying CMakeLists.txt like this:

```diff
diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
index c49a3c78..1dad3691 100644
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,6 +93,7 @@ if(UNIX)
if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
     add_definitions(-DUNIX_BSD -DBRIDGE_BPF)
+    add_definitions(-DNO_VLAN)
     include_directories(SYSTEM /usr/local/include)
     link_directories(SYSTEM /usr/local/lib)
   endif()
```