### PR TITLE
Cedar/VLanUnix: assign virtual interface to softether group

### DIFF
--- a/src/Cedar/VLanUnix.c
+++ b/src/Cedar/VLanUnix.c
@@ -485,6 +485,9 @@ int UnixCreateTapDeviceEx(char *name, char *prefix, UCHAR *mac_address, bool cre
 		}
 #endif
 
+		// Set interface group
+		UnixSetIfGroup(s, tap_name, CEDAR_PRODUCT_STR);
+
 		if (create_up)
 		{
 			Zero(&ifr, sizeof(ifr));
@@ -622,6 +625,24 @@ void UnixDestroyClientTapDevice(char *name)
 #endif	// UNIX_BSD
 }
 
+void UnixSetIfGroup(int fd, const char *name, const char *group_name)
+{
+#ifdef	SIOCAIFGROUP
+	struct ifgroupreq ifgr;
+	char *tmp;
+
+	tmp = CopyStr((char *)group_name);
+	StrLower(tmp);
+	Zero(&ifgr, sizeof(ifgr));
+
+	StrCpy(ifgr.ifgr_name, sizeof(ifgr.ifgr_name), (char *) name);
+	StrCpy(ifgr.ifgr_group, sizeof(ifgr.ifgr_group), tmp);
+	ioctl(fd, SIOCAIFGROUP, &ifgr);
+
+	Free(tmp);
+#endif
+}
+
 #else	// NO_VLAN
 
 void UnixCloseDevice(int fd)
@@ -633,6 +654,10 @@ void UnixDestroyTapDevice(char *name)
 }
 
 void UnixDestroyTapDeviceEx(char *name, char *prefix)
+{
+}
+
+void UnixSetIfGroup()
 {
 }
 

--- a/src/Cedar/VLanUnix.h
+++ b/src/Cedar/VLanUnix.h
@@ -62,6 +62,7 @@ int UnixCreateTapDeviceEx(char *name, char *prefix, UCHAR *mac_address, bool cre
 void UnixCloseTapDevice(int fd);
 void UnixDestroyBridgeTapDevice(char *name);
 void UnixDestroyClientTapDevice(char *name);
+void UnixSetIfGroup(int fd, const char *name, const char *group_name);
 void UnixVLanInit();
 void UnixVLanFree();
 bool UnixVLanCreate(char *name, UCHAR *mac_address, bool create_up);


### PR DESCRIPTION
This is the final one of the series of pull requests I have been working on improving SoftEther bridge/client functionality on FreeBSD.

#1859, #1860, #1863 and this one.

-----

Interface grouping is available on FreeBSD and OpenBSD. This will allow you to enumerate only SoftEther virtual interfaces or exclude SoftEther virtual interfaces, and be helpful when making custom scripts to start DHCP client when virtual interface become up (=VPN connection established) for example.

Usage examples as follows.

List all interfaces' names available on the system:
```
$ ifconfig -l
vtnet0 lo0 vpn_client0 vpn_client1 vpn_client2
```

Display a list of SoftEther virtual interfaces:
```
$ ifconfig -g softether
vpn_client0
vpn_client1
vpn_client2
```

Display details about SoftEther virtual interfaces that are up:
```
$ ifconfig -a -u -g softether
vpn_client0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
        description: SoftEther Virtual Network Adapter
        options=80000<LINKSTATE>
        ether 5e:71:fa:f8:91:4a
        hwaddr 58:9c:fc:10:34:2a
        groups: tap softether     <=== HERE: the interface is assigned to softether group
        media: Ethernet autoselect
        status: active
        nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
        Opened by PID 1445
```

Display details about interfaces except for SoftEther virtual interfaces:
```
$ ifconfig -a -G softether
vtnet0: flags=8863<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
        options=80028<VLAN_MTU,JUMBO_MTU,LINKSTATE>
        ether 58:9c:fc:00:f0:23
        inet6 fe80::5a9c:fcff:fe00:f023%vtnet0 prefixlen 64 scopeid 0x1
        inet 192.168.96.7 netmask 0xffffff00 broadcast 192.168.96.255
        media: Ethernet autoselect (10Gbase-T <full-duplex>)
        status: active
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> metric 0 mtu 16384
        options=680003<RXCSUM,TXCSUM,LINKSTATE,RXCSUM_IPV6,TXCSUM_IPV6>
        inet6 ::1 prefixlen 128
        inet6 fe80::1%lo0 prefixlen 64 scopeid 0x2
        inet 127.0.0.1 netmask 0xff000000
        groups: lo
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
```

