### PR TITLE
Fix macOS build: add missing headers

### DIFF
--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -23,6 +23,10 @@
 #ifdef UNIX_OPENBSD
 #include <pthread.h>
 #endif
+
+#ifdef UNIX_MACOS
+#include <pthread.h>
+#endif
 #endif
 
 

--- a/src/Mayaqua/TunTap.h
+++ b/src/Mayaqua/TunTap.h
@@ -162,6 +162,13 @@ struct tundladdr {
 #ifndef _NET_IF_TUN_H_
 #define _NET_IF_TUN_H_
 
+#ifdef UNIX_MACOS
+#ifndef _DARWIN_C_SOURCE
+#define _DARWIN_C_SOURCE
+#endif
+#include <sys/types.h>
+#endif
+
 /* Refer to if_tunvar.h for the softc stuff */
 
 /* Maximum transmit packet size (default) */


### PR DESCRIPTION
1. `pthread.h` should be included also on macOS, otherwise `pthread_t` is undefined.
2. `sys/types.h` is needed with `_DARWIN_C_SOURCE` in order to `u_char` and `u_short` be recognized.