### PR TITLE
Fix azure pipelines: Publish separate artifacts for both x64 and x86.

### DIFF
--- a/.ci/azure-pipelines/windows-steps.yml
+++ b/.ci/azure-pipelines/windows-steps.yml
@@ -29,12 +29,12 @@ steps:
   inputs:
     sourceFolder: '$(Build.BinariesDirectory)'
     contents: '?(*.exe|*.se2|*.pdb)'
-    TargetFolder: '$(Build.StagingDirectory)/binaries'
+    TargetFolder: '$(Build.StagingDirectory)/binaries/${{parameters.architecture}}'
     flattenFolders: true
 - task: PublishBuildArtifacts@1
   inputs:
-    pathtoPublish: '$(Build.StagingDirectory)/binaries'
-    artifactName: 'Binaries'
+    pathtoPublish: '$(Build.StagingDirectory)/binaries/${{parameters.architecture}}'
+    artifactName: 'Binaries_${{parameters.architecture}}'
 - task: PublishBuildArtifacts@1
   inputs:
     pathtoPublish: '$(Build.StagingDirectory)/installers'


### PR DESCRIPTION
Changes proposed in this pull request:
 - Published binaries include only either X64 or X86. Not both. 
 - Separate the directories for both X64 and X86 to publish binary files.
        Binaries_x64
        Binaries_x86
        Installers

