### PR TITLE
IPC.c: Cast the pointer to a defined size due to the error in compiling.

### DIFF
--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -1537,7 +1537,8 @@ void IPCProcessL3EventsEx(IPC *ipc, UINT64 now)
 								// Remove link-layer address options for Windows clients (required on Windows 11)
 								if (header_size > 0)
 								{
-									UCHAR *src = p->ICMPv6HeaderPacketInfo.Headers.HeaderPointer + header_size;
+									//UCHAR *src = p->ICMPv6HeaderPacketInfo.Headers.HeaderPointer + header_size;
+									UCHAR* src = (UCHAR *)p->ICMPv6HeaderPacketInfo.Headers.HeaderPointer + header_size;// Cast the pointer to UCHAR *.
 									UINT opt_size = p->ICMPv6HeaderPacketInfo.DataSize - header_size;
 									UCHAR *dst = src;
 									UINT removed = 0;


### PR DESCRIPTION
Changes proposed in this pull request:
 - Cast the void pointer to UCHAR *. 
 - The reason is
 - MSVC compiler generates error below.
    error C2036: 'void *' : unknown size
 - I can't perform pointer arithmetic on a void * because void doesn't have a defined size.
    Cast the pointer to UCHAR * and it will work as expected.



