### PR TITLE
Update BuildNumber to match (next) tagged release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 set(BUILD_NUMBER CACHE STRING "The number of the current build.")
 
 if ("${BUILD_NUMBER}" STREQUAL "")
-	set(BUILD_NUMBER "5180")
+	set(BUILD_NUMBER "5182")
 endif()
 
 if (BUILD_NUMBER LESS 5180)

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,5 +1,5 @@
 ﻿{
-  "environments": [ { "BuildNumber": "5180" } ],
+  "environments": [ { "BuildNumber": "5182" } ],
   "configurations": [
     {
       "name": "x64-native",


### PR DESCRIPTION
Thanks @chipitsine for tagging a new release (back in December) and thereby addressing #1916 , which can presumably be closed now. However, as was mentioned downstream, the hardcoded build number 5180 isn't updated to 5182.

This PR would presumably fix this for the next version (5182).