### PR TITLE
Fix "Session Timeouted.":  Change the time for checking wether all the TCP connectins are alive or not.

### DIFF
--- a/src/Cedar/Session.c
+++ b/src/Cedar/Session.c
@@ -615,7 +615,7 @@ void SessionMain(SESSION *s)
 					UINT max_conn = s->ClientOption->MaxConnection;
 
 					if ((s->CurrentConnectionEstablishTime +
-						(UINT64)(s->ClientOption->AdditionalConnectionInterval * 1000 * 2 + CONNECTING_TIMEOUT * 2))
+						(UINT64)(num_tcp_conn * s->ClientOption->AdditionalConnectionInterval * 1000 * 2 + CONNECTING_TIMEOUT * 2))
 						<= Tick64())
 					{
 						if (s->ClientOption->BindLocalPort != 0 || num_tcp_conn == 0)


### PR DESCRIPTION
Changes proposed in this pull request:
 - "Session Timeouted." occurs.
 
 - How to reproduce.
①run VPN Client.
②Set the number of tcp connections to 32 on "advanced settings" screen.
③Set the source port number to 55551 for example. Not zero value is to be required.
④click to connect.
⑤confirm that session of around or more than  29 TCP connections is killed by itself due to the unsuitable time.


 - Change the time for checking whether or not all the TCP cnnections are alive.
        from "after a certain time from the first TCP connection" to "after a certain time from the last TCP connection".


