### PR TITLE
Fix "RemoveDefGwOnDhcpForLocalhost" function: Change to exclude unplugged device from MAC address list.

### DIFF
--- a/src/Mayaqua/Microsoft.c
+++ b/src/Mayaqua/Microsoft.c
@@ -2568,6 +2568,7 @@ MS_ADAPTER_LIST *MsCreateAdapterListInnerExVista(bool no_info)
 				UniStrCpy(a->TitleW, sizeof(a->TitleW), title);
 				UniToStr(a->Title, sizeof(a->Title), title);
 				a->Index = r->InterfaceIndex;
+				a->MediaConnectState = r->MediaConnectState;
 				a->Type = r->Type;
 				a->Status = ConvertMidStatusVistaToXp(r->OperStatus);
 				a->Mtu = r->Mtu;

--- a/src/Mayaqua/Microsoft.h
+++ b/src/Mayaqua/Microsoft.h
@@ -281,6 +281,7 @@ typedef struct MS_ADAPTER
 	char Title[MAX_PATH];			// Display name
 	wchar_t TitleW[MAX_PATH];		// Display Name (Unicode)
 	UINT Index;						// Index
+	UINT MediaConnectState;			// Media Connect State
 	UINT Type;						// Type
 	UINT Status;					// Status
 	UINT Mtu;						// MTU

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -540,6 +540,13 @@ LIST *Win32GetNicList()
 
 		if (a->Type == 6 && a->AddressSize == 6)
 		{
+			// If the connection state of the interface is unknown, then exclude it.
+			// Unknown means that the device is not plugged into the local host.
+			if (a->MediaConnectState == MediaConnectStateUnknown)
+			{
+				continue;
+			}
+
 			NIC_ENTRY *e = ZeroMalloc(sizeof(NIC_ENTRY));
 
 			StrCpy(e->IfName, sizeof(e->IfName), a->Title);


### PR DESCRIPTION
Changes proposed in this pull request:
 - DHCP client can not get default GW address and DNS address.
 - Preparation before reproducing:
①Plug the "USB ETHERNET ADAPTER 2" into PC2 once. The MAC address of it will be saved in WIN11 of PC2.
②Set up local bridge in PC1. Also in PC2.
③Set up cascade connection in PC1.
④Set RemoveDefGwOnDhcpForLocalhost to false in "vpn_server.config" in PC1.
⑤Set RemoveDefGwOnDhcpForLocalhost to true  in "vpn_server.config" in PC2.

- How to reproduce:
①Run VPN SERVER in PC1.
②Run VPN SERVER in PC2.
③Plug the "USB ETHERNET ADAPTER 2" into PC1 to access LAN.  This adapter is used in PC2 before.
④Confirm that the "USB ETHERNET ADAPTER 2" can not get default GW address and DNS address.
- Change to exclude unplugged device from MAC address list.
   DHCP client will get default GW address and DNS address.

Refer to 
[netconfig.txt](https://github.com/SoftEtherVPN/SoftEtherVPN/files/14865652/netconfig.txt)
![netconfig2024-04-04](https://github.com/SoftEtherVPN/SoftEtherVPN/assets/137624316/60bec1d9-7a35-4129-940e-15aa57416d6d)
