### PR TITLE
OpenVPN certificate authorization with cn_username in 'email' format

### DIFF
--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -6784,7 +6784,8 @@ PACK *PackLoginWithOpenVPNCertificate(char *hubname, char *username, X *x)
 
 		UniToStr(cn_username, sizeof(cn_username), x->subject_name->CommonName);
 
-		if(strchr(cn_username, '@') != NULL)
+		if (strchr(cn_username, '@') != NULL)
+
 		{
 			PackAddStr(p, "username", strtok(cn_username, "@"));
 			PackAddStr(p, "hubname", strtok(NULL, ""));

--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -6773,7 +6773,6 @@ PACK *PackLoginWithOpenVPNCertificate(char *hubname, char *username, X *x)
 
 	p = NewPack();
 	PackAddStr(p, "method", "login");
-	PackAddStr(p, "hubname", hubname);
 
 	if (IsEmptyStr(username))
 	{
@@ -6782,12 +6781,25 @@ PACK *PackLoginWithOpenVPNCertificate(char *hubname, char *username, X *x)
 			FreePack(p);
 			return NULL;
 		}
+
 		UniToStr(cn_username, sizeof(cn_username), x->subject_name->CommonName);
-		PackAddStr(p, "username", cn_username);
+
+		if(strchr(cn_username, '@') != NULL)
+		{
+			PackAddStr(p, "username", strtok(cn_username, "@"));
+			PackAddStr(p, "hubname", strtok(NULL, ""));
+		}
+		else
+		{
+			PackAddStr(p, "username", cn_username);
+			PackAddStr(p, "hubname", hubname);
+		}
+
 	}
 	else
 	{
 		PackAddStr(p, "username", username);
+		PackAddStr(p, "hubname", hubname);
 	}
 
 	PackAddInt(p, "authtype", AUTHTYPE_OPENVPN_CERT);


### PR DESCRIPTION
This patch addresses such a scenario when OpenVPN clients utilize the certificate-only authorization scheme. It works out-of-the box in case `cn_username` contains a 'plain' username that is identical to corresponding user name of default Hub user database. However, if `cn_username` is in `user@domain.tld` format, the whole `cn_username` string is compared to Hub user database entries and does not match as Hub usernames cannot contain `@` sign.

Changes proposed in this pull request:
 - If `cn_username`  contains @ sign, it is being split into user name and domain name which are being passed along as `username` and `hubname`, respectively.
 - If `cn_username` does not contain @ sign, `username` and `hubname` are set as usual.

This patch has been tested on an experimental installation and shows the desired behavior:
- If `cn_username` is a bare name, user is being authenticated agains the default hub.
- If `cn_username` has the 'domain' part and a Hub with corresponding name exists, user is being authenticated and connected to the corresponding Hub.
- If `cn_username` has the 'domain' part and a Hub with corresponding name does not exist, error messages `Virtual Hub "company.tld" that the client is trying to connect to does not exist on the server.` and `The specified Virtual Hub does not exist on the server.` are being logged and user is disconnected.

