### PR TITLE
Change var of CMAKE_INSTALL_RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if(UNIX)
   #
   # use rpath for locating installed libraries
   #
-  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
   include(CheckIncludeFile)


### PR DESCRIPTION
A library problem occurred when building and installing on a RHEL-based distribution.

The cause is that even though the library is installed in the lib64 directory, the executable file looks for the lib directory.
To solve this problem, I changed part of CMakeLists.txt.

This problem also occurs on Gentoo Linux.

My environment
```
$ cat /etc/redhat-release 
MIRACLE LINUX release 9.2 (Feige)
$ uname -a
Linux localhost.localdomain 5.14.0-284.11.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri May 26 02:39:48 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
```


p.s.
With the help of @nvsofts , I have solved this problem.