### PR TITLE
Fix memory access error when IPv6 prefix reading, should resolve #1972

### DIFF
--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -2354,7 +2354,14 @@ void IPCIPv6AddRouterPrefixes(IPC *ipc, ICMPV6_OPTION_LIST *recvPrefix, UCHAR *m
 				IntToSubnetMask6(&newRA->RoutedMask, recvPrefix->Prefix[i]->SubnetLength);
 				CopyIP(&newRA->RouterAddress, ip);
 				Copy(newRA->RouterMacAddress, macAddress, 6);
-				Copy(newRA->RouterLinkLayerAddress, recvPrefix->SourceLinkLayer->Address, 6);
+				if (recvPrefix->SourceLinkLayer != NULL)
+				{
+					Copy(newRA->RouterLinkLayerAddress, recvPrefix->SourceLinkLayer->Address, 6);
+				}
+				else
+				{
+					Zero(newRA->RouterLinkLayerAddress, 6);
+				}
 				Add(ipc->IPv6RouterAdvs, newRA);
 			}
 		}
@@ -2657,7 +2664,7 @@ void IPCIPv6SendUnicast(IPC *ipc, void *data, UINT size, IP *next_ip)
 		}
 
 		destMac = ra.RouterMacAddress;
-		if (!IsMacUnicast(destMac) && !IsMacInvalid(ra.RouterMacAddress))
+		if (!IsMacUnicast(destMac) && !IsMacInvalid(ra.RouterLinkLayerAddress))
 		{
 			destMac = ra.RouterLinkLayerAddress;
 		}

--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -1517,7 +1517,9 @@ void IPCProcessL3EventsEx(IPC *ipc, UINT64 now)
 									// We save the router advertisement data for later use
 									IPCIPv6AddRouterPrefixes(ipc, &p->ICMPv6HeaderPacketInfo.OptionList, src_mac, &ip_src);
 									IPCIPv6AssociateOnNDTEx(ipc, &ip_src, src_mac, true);
-									IPCIPv6AssociateOnNDTEx(ipc, &ip_src, p->ICMPv6HeaderPacketInfo.OptionList.SourceLinkLayer->Address, true);
+									if (p->ICMPv6HeaderPacketInfo.OptionList.SourceLinkLayer != NULL) {
+										IPCIPv6AssociateOnNDTEx(ipc, &ip_src, p->ICMPv6HeaderPacketInfo.OptionList.SourceLinkLayer->Address, true);
+									}
 									ndtProcessed = true;
 									header_size = sizeof(ICMPV6_ROUTER_ADVERTISEMENT_HEADER);
 									break;


### PR DESCRIPTION
Apparently we don't always get the RouterLinkLayerAddress, so it is null, and we crash. Fixing that. Made sure that this case is handled appropriately when we actually resolve the prefixes later

Should fix #1972 