### PR TITLE
Fix Virtual DHCP Server: Correct IP reassignment

### DIFF
--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -12314,7 +12314,7 @@ UINT SecureRecv(SOCK *sock, void *data, UINT size)
 					sock->ssl->s3->send_alert[0] != sock->Ssl_Init_Async_SendAlert[0] &&
 					sock->ssl->s3->send_alert[1] != sock->Ssl_Init_Async_SendAlert[1]
 #endif
-				)
+					)
 				{
 					UINT ssl_err_no = ERR_get_error();
 
@@ -12418,7 +12418,7 @@ UINT SecureRecv(SOCK *sock, void *data, UINT size)
 				sock->ssl->s3->send_alert[0] != sock->Ssl_Init_Async_SendAlert[0] &&
 				sock->ssl->s3->send_alert[1] != sock->Ssl_Init_Async_SendAlert[1]
 #endif
-			)
+				)
 			{
 				UINT ssl_err_no = ERR_get_error();
 

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -12288,6 +12288,11 @@ UINT SecureRecv(SOCK *sock, void *data, UINT size)
 			ret = SSL_peek(ssl, &c, sizeof(c));
 		}
 		Unlock(sock->ssl_lock);
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+		// 2021/09/10: After OpenSSL 3.x.x, both 0 and negative values might mean retryable.
+		// See: https://github.com/openssl/openssl/blob/435981cbadad2c58c35bacd30ca5d8b4c9bea72f/doc/man3/SSL_read.pod
+		// > Old documentation indicated a difference between 0 and -1, and that -1 was retryable.
+		// > You should instead call SSL_get_error() to find out if it's retryable.
 		if (ret == 0)
 		{
 			// The communication have been disconnected
@@ -12295,7 +12300,8 @@ UINT SecureRecv(SOCK *sock, void *data, UINT size)
 			Debug("%s %u SecureRecv() Disconnect\n", __FILE__, __LINE__);
 			return 0;
 		}
-		if (ret < 0)
+#endif
+		if (ret <= 0)
 		{
 			// An error has occurred
 			e = SSL_get_error(ssl, ret);
@@ -12303,14 +12309,16 @@ UINT SecureRecv(SOCK *sock, void *data, UINT size)
 			{
 				if (e == SSL_ERROR_SSL
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-				        &&
-				        sock->ssl->s3->send_alert[0] == SSL3_AL_FATAL &&
-				        sock->ssl->s3->send_alert[0] != sock->Ssl_Init_Async_SendAlert[0] &&
-				        sock->ssl->s3->send_alert[1] != sock->Ssl_Init_Async_SendAlert[1]
+					&&
+					sock->ssl->s3->send_alert[0] == SSL3_AL_FATAL &&
+					sock->ssl->s3->send_alert[0] != sock->Ssl_Init_Async_SendAlert[0] &&
+					sock->ssl->s3->send_alert[1] != sock->Ssl_Init_Async_SendAlert[1]
 #endif
-				   )
+				)
 				{
-					Debug("%s %u SSL Fatal Error on ASYNC socket !!!\n", __FILE__, __LINE__);
+					UINT ssl_err_no = ERR_get_error();
+
+					Debug("%s %u SSL_ERROR_SSL on ASYNC socket !!! ssl_err_no = %u: '%s'\n", __FILE__, __LINE__, ssl_err_no, ERR_error_string(ssl_err_no, NULL));
 					Disconnect(sock);
 					return 0;
 				}
@@ -12337,14 +12345,14 @@ UINT SecureRecv(SOCK *sock, void *data, UINT size)
 		}
 #endif	// OS_UNIX
 
-// Run the time-out thread for SOLARIS
+		// Run the time-out thread for SOLARIS
 #ifdef UNIX_SOLARIS
 		ttparam = NewSocketTimeout(sock);
 #endif // UNIX_SOLARIS
 
 		ret = SSL_read(ssl, data, size);
 
-// Stop the timeout thread
+		// Stop the timeout thread
 #ifdef UNIX_SOLARIS
 		FreeSocketTimeout(ttparam);
 #endif // UNIX_SOLARIS
@@ -12357,7 +12365,11 @@ UINT SecureRecv(SOCK *sock, void *data, UINT size)
 		}
 #endif	// OS_UNIX
 
-		if (ret < 0)
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+		if (ret < 0) // OpenSSL version < 3.0.0
+#else
+		if (ret <= 0) // OpenSSL version >= 3.0.0
+#endif
 		{
 			e = SSL_get_error(ssl, ret);
 		}
@@ -12380,6 +12392,12 @@ UINT SecureRecv(SOCK *sock, void *data, UINT size)
 
 		return (UINT)ret;
 	}
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+	// 2021/09/10: After OpenSSL 3.x.x, both 0 and negative values might mean retryable.
+	// See: https://github.com/openssl/openssl/blob/435981cbadad2c58c35bacd30ca5d8b4c9bea72f/doc/man3/SSL_read.pod
+	// > Old documentation indicated a difference between 0 and -1, and that -1 was retryable.
+	// > You should instead call SSL_get_error() to find out if it's retryable.
 	if (ret == 0)
 	{
 		// Disconnect the communication
@@ -12387,20 +12405,24 @@ UINT SecureRecv(SOCK *sock, void *data, UINT size)
 		//Debug("%s %u SecureRecv() Disconnect\n", __FILE__, __LINE__);
 		return 0;
 	}
+#endif
+
 	if (sock->AsyncMode)
 	{
 		if (e == SSL_ERROR_WANT_READ || e == SSL_ERROR_WANT_WRITE || e == SSL_ERROR_SSL)
 		{
 			if (e == SSL_ERROR_SSL
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-			        &&
-			        sock->ssl->s3->send_alert[0] == SSL3_AL_FATAL &&
-			        sock->ssl->s3->send_alert[0] != sock->Ssl_Init_Async_SendAlert[0] &&
-			        sock->ssl->s3->send_alert[1] != sock->Ssl_Init_Async_SendAlert[1]
+				&&
+				sock->ssl->s3->send_alert[0] == SSL3_AL_FATAL &&
+				sock->ssl->s3->send_alert[0] != sock->Ssl_Init_Async_SendAlert[0] &&
+				sock->ssl->s3->send_alert[1] != sock->Ssl_Init_Async_SendAlert[1]
 #endif
-			   )
+			)
 			{
-				Debug("%s %u SSL Fatal Error on ASYNC socket !!!\n", __FILE__, __LINE__);
+				UINT ssl_err_no = ERR_get_error();
+
+				Debug("%s %u SSL_ERROR_SSL on ASYNC socket !!! ssl_err_no = %u: '%s'\n", __FILE__, __LINE__, ssl_err_no, ERR_error_string(ssl_err_no, NULL));
 				Disconnect(sock);
 				return 0;
 			}
@@ -12438,7 +12460,11 @@ UINT SecureSend(SOCK *sock, void *data, UINT size)
 		}
 
 		ret = SSL_write(ssl, data, size);
-		if (ret < 0)
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+		if (ret < 0) // OpenSSL version < 3.0.0
+#else
+		if (ret <= 0) // OpenSSL version >= 3.0.0
+#endif
 		{
 			e = SSL_get_error(ssl, ret);
 		}
@@ -12460,6 +12486,8 @@ UINT SecureSend(SOCK *sock, void *data, UINT size)
 		sock->WriteBlocked = false;
 		return (UINT)ret;
 	}
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 	if (ret == 0)
 	{
 		// Disconnect
@@ -12467,6 +12495,7 @@ UINT SecureSend(SOCK *sock, void *data, UINT size)
 		Disconnect(sock);
 		return 0;
 	}
+#endif
 
 	if (sock->AsyncMode)
 	{


### PR DESCRIPTION
Changes proposed in this pull request:
 - DHCP_NAK does not work correctlly

 - Changes make it work correctlly
 
 - Description of changes: 
 ①If IP address in user's note is changed, then reply to DHCP REQUEST with DHCP NAK.
      This makes DHCP sequence begin with DHCP DISCOVER.
 ②If there is any entry with the same MAC address, then remove it.
      Unused lease time record is deleted from IP lease table.
 ③Reassigning static IP address is partially modified.
 ④Thease changes enable to switch between static and dynamic IP address assignment.
      Users do not need to restart the VPN server.

 - Example below:
	  Already set to IPv4:192.168.30.222 in user's note.
	  First, set to IPv4:192.168.30.234 in user's note. Indicated with yellow line.
	  Second, delete IPv4:192.168.30.234 from user's note. Indicated with yellow line.
 	  Third, set to IPv4:192.168.30.222 in user's note. Indicated with yellow line.
	  User can switch the way of IP address assignment at any time.

 - Attach A:

Lease Limit:40 seconds
DisableSessionReconnect: true
Time-out Period: 20 seconds
![dhcpfix_switch_static_dynamic2024-05-10](https://github.com/SoftEtherVPN/SoftEtherVPN/assets/137624316/2038a8cf-03a7-4352-8543-aac158c5edc2)

 