### PR TITLE
CI: drop macos-11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [macos-14, macos-13, macos-12, macos-11]
+        os: [macos-14, macos-13, macos-12]
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
more details: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

