### PR TITLE
CI: Update to FreeBSD 14.0-RELEASE

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ FreeBSD_task:
       SSL:
   matrix:
     freebsd_instance:
-      image_family: freebsd-13-2
+      image_family: freebsd-14-0
   prepare_script:
     - pkg install -y pkgconf cmake git libsodium $SSL
     - git submodule update --init --recursive


### PR DESCRIPTION
since FreeBSD 13.2 image is no longer available on the CI platform.

