### PR TITLE
URL for Nightly builds  for windows is updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ Also SoftEther VPN [Stable Edition](https://www.freshports.org/security/softethe
 
 ## For Windows
 
-[Nightly builds](https://github.com/SoftEtherVPN/SoftEtherVPN/releases)
+[Releases](https://github.com/SoftEtherVPN/SoftEtherVPN/releases)
+
+[Nightly builds](https://github.com/SoftEtherVPN/SoftEtherVPN/actions/workflows/windows.yml)
 (choose appropriate platform, then find binaries or installers as artifacts)
 
 ## From binary installers (stable channel)

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Also SoftEther VPN [Stable Edition](https://www.freshports.org/security/softethe
 
 ## For Windows
 
-[Nightly builds](https://dev.azure.com/SoftEther-VPN/SoftEther%20VPN/_build?definitionId=6)
+[Nightly builds](https://github.com/SoftEtherVPN/SoftEtherVPN/releases)
 (choose appropriate platform, then find binaries or installers as artifacts)
 
 ## From binary installers (stable channel)


### PR DESCRIPTION
Based on issue #1993, the build has been moved from Azure to Github.

Changes proposed in this pull request:
 - URL for Nightly builds  for Windows
