### PR TITLE
Fix openssl engine support on Fedora Rawhide

### DIFF
--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -25,7 +25,7 @@ jobs:
         submodules: true
     - name: Install dependencies
       run: |
-        dnf -y install git cmake ncurses-devel openssl-devel libsodium-devel readline-devel zlib-devel gcc-c++ clang
+        dnf -y install git cmake ncurses-devel openssl-devel-engine libsodium-devel readline-devel zlib-devel gcc-c++ clang
     - name: Compile with ${{ matrix.cc }}
       run: |
         export CC=${{ matrix.cc }}

--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -20,7 +20,9 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
+#endif
 #include <openssl/bio.h>
 #include <openssl/x509.h>
 #include <openssl/pkcs7.h>


### PR DESCRIPTION
Fedora Rawhide's ```openssl-devel``` package does not support engines (it is built with the no-engine flag). However, it does not define OPENSSL_NO_ENGINE. This seems to be a bug.

This pull requests adds the ability to build with any OpenSSL that does not have engine support that *correctly* defines OPENSSL_NO_ENGINE. It also replaces ```openssl-devel``` with ```openssl-devel-engine``` for the Fedora test, to workaround the issue.