### PR TITLE
Fix "Not on NT" error message and add uihelp to vpncmd

### DIFF
--- a/src/Mayaqua/Microsoft.c
+++ b/src/Mayaqua/Microsoft.c
@@ -4259,7 +4259,7 @@ UINT MsService(char *name, SERVICE_FUNCTION *start, SERVICE_FUNCTION *stop, UINT
 
 		if ((mode == SVC_MODE_INSTALL || mode == SVC_MODE_UNINSTALL || mode == SVC_MODE_START ||
 			mode == SVC_MODE_STOP || mode == SVC_MODE_SERVICE) &&
-			(ms->IsNt == false))
+			(IsNt() == false))
 		{
 			// Tried to use the command for the NT in non-WindowsNT system
 			MsgBox(NULL, MB_ICONSTOP, _UU("SVC_NT_ONLY"));

--- a/src/Mayaqua/Microsoft.h
+++ b/src/Mayaqua/Microsoft.h
@@ -170,7 +170,6 @@ typedef struct MS
 {
 	HINSTANCE hInst;
 	HINSTANCE hKernel32;
-	bool IsNt;
 	bool IsAdmin;
 	HANDLE hCurrentProcess;
 	UINT CurrentProcessId;

--- a/src/vpncmd/vpncmd.c
+++ b/src/vpncmd/vpncmd.c
@@ -6,7 +6,9 @@
 // VPN Command Line Management Utility
 
 #include "Cedar/Cedar.h"
-
+#ifdef OS_WIN32
+#include "Cedar/CMInner.h"
+#endif
 #include "Cedar/Command.h"
 
 #include "Mayaqua/Internat.h"
@@ -38,6 +40,10 @@ int main(int argc, char *argv[])
 	InitMayaqua(false, false, argc, argv);
 #endif
 	InitCedar();
+
+#ifdef OS_WIN32
+	CmExecUiHelperMain();
+#endif
 
 	s = GetCommandLineUniStr();
 


### PR DESCRIPTION
Fixes https://github.com/SoftEtherVPN/SoftEtherVPN/issues/2031

Running vpnclient.exe fails because ```ms->IsNt``` is never set to true. This seems to be old code from the stable branch that was never changed to ```IsNt()```.

This pull request changes changes ```ms->IsNt``` to ```IsNt()```, and removes ```IsNt``` from the ```MS``` struct, because it is no longer necessary.
