### PR TITLE
Fix potential NULL pointer dereference

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -351,6 +351,11 @@ MD *NewMdEx(char *name, bool hmac)
 #else
 		m->Ctx = EVP_MD_CTX_create();
 #endif
+		if (m->Ctx == NULL)
+		{
+			return NULL;
+		}
+
 		if (EVP_DigestInit_ex(m->Ctx, m->Md, NULL) == false)
 		{
 			Debug("NewMdEx(): EVP_DigestInit_ex() failed with error: %s\n", OpenSSL_Error());
@@ -4604,6 +4609,11 @@ DH_CTX *DhNew(char *prime, UINT g)
 	dh = ZeroMalloc(sizeof(DH_CTX));
 
 	dh->dh = DH_new();
+	if (dh->dh == NULL)
+	{
+		return NULL;
+	}
+	
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	dhp = BinToBigNum(buf->Buf, buf->Size);
 	dhg = BN_new();

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -11860,6 +11860,12 @@ bool StartSSLEx3(SOCK *sock, X *x, K *priv, LIST *chain, UINT ssl_timeout, char 
 #endif
 
 		sock->ssl = SSL_new(ssl_ctx);
+
+		if (sock->ssl == NULL)
+		{
+			return false;
+		}
+
 		SSL_set_fd(sock->ssl, (int)sock->socket);
 
 #ifdef	SSL_CTRL_SET_TLSEXT_HOSTNAME
@@ -16249,6 +16255,12 @@ UINT GetOSSecurityLevel()
 {
 	UINT security_level_new = 0, security_level_set_ssl_version = 0;
 	struct ssl_ctx_st *ctx = SSL_CTX_new(SSLv23_method());
+
+	if (ctx == NULL)
+	{
+		return security_level_new;
+	}
+
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	security_level_new = SSL_CTX_get_security_level(ctx);


### PR DESCRIPTION
Changes proposed in this pull request:
 - Passing NULL to the APIs `EVP_DigestInit_ex`, `DH_set0_pqg`, `SSL_set_fd`, and `SSL_CTX_set_ssl_version` can cause a null pointer dereference, leading to a crash. Therefore, I added null checks in src/Mayaqua/Encrypt.c and src/Mayaqua/Network.c.

