### PR TITLE
Update minimal cmake version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 
 set(BUILD_NUMBER CACHE STRING "The number of the current build.")
 


### PR DESCRIPTION
Update required cmake version to the actual state:
* 3.12 is required for add_compile_definitions introduced with edcdc923ad2b4feaf25080412a57f560093f725e on Jan 31st, 2023.
* 3.15 is required for CMP0091 policy introduced with 96ab9691521b7352b4c13b347dfe9ec9cd2850d9 on March 11th, 2023.

Only two distros have cmake of lower version according to https://pkgs.org/download/cmake:
* RHEL 8: 3.11.4
* Debian 10: 3.13.4. Debian 10 is supported until June 30th, 2024.

Since there are no issues about cmake version, I think there is no need to keep it low.

Closes #2040 
