### PR TITLE
Correct and simplify systemd service files

### DIFF
--- a/systemd/softether-vpnbridge.service
+++ b/systemd/softether-vpnbridge.service
@@ -4,11 +4,8 @@ After=network.target auditd.service
 ConditionPathExists=!@DIR@/softether/vpnbridge/do_not_run
 
 [Service]
-Type=forking
-EnvironmentFile=-@DIR@/softether/vpnbridge
-ExecStart=@DIR@/softether/vpnbridge/vpnbridge start
-ExecStop=@DIR@/softether/vpnbridge/vpnbridge stop
-KillMode=process
+Type=exec
+ExecStart=@DIR@/softether/vpnbridge/vpnbridge execsvc
 Restart=on-failure
 
 # Hardening

--- a/systemd/softether-vpnclient.service
+++ b/systemd/softether-vpnclient.service
@@ -4,11 +4,8 @@ After=network.target auditd.service
 ConditionPathExists=!@DIR@/softether/vpnclient/do_not_run
 
 [Service]
-Type=forking
-EnvironmentFile=-@DIR@/softether/vpnclient
-ExecStart=@DIR@/softether/vpnclient/vpnclient start
-ExecStop=@DIR@/softether/vpnclient/vpnclient stop
-KillMode=process
+Type=exec
+ExecStart=@DIR@/softether/vpnclient/vpnclient execsvc
 Restart=on-failure
 
 # Hardening

--- a/systemd/softether-vpnserver.service
+++ b/systemd/softether-vpnserver.service
@@ -4,12 +4,9 @@ After=network.target auditd.service
 ConditionPathExists=!@DIR@/softether/vpnserver/do_not_run
 
 [Service]
-Type=forking
+Type=exec
 TasksMax=infinity
-EnvironmentFile=-@DIR@/softether/vpnserver
-ExecStart=@DIR@/softether/vpnserver/vpnserver start
-ExecStop=@DIR@/softether/vpnserver/vpnserver stop
-KillMode=process
+ExecStart=@DIR@/softether/vpnserver/vpnserver execsvc
 Restart=on-failure
 
 # Hardening


### PR DESCRIPTION
Changes proposed in this pull request:
 - Change to start the services directly. Systemd services do not require those command line wrappers.
 - Remove misused `EnvironmentFile=`. It should be pointed to a text file, not a directory.
 - Remove `KillMode=process` which is not recommended by _systemd.kill(5)_. The default `control-group` would be fine.