### PR TITLE
Adding artifact publishing for Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,6 +26,13 @@ jobs:
         cd build
         cpack -C Release -G DEB 
 
+    - name: Upload DEB packages as artifacts
+      if: github.ref == 'refs/heads/master'
+      uses: actions/upload-artifact@v4
+      with:
+        name: deb-packages
+        path: build/*.deb
+
     - name: Test
       run: |
        .ci/appveyor-deb-install-test.sh


### PR DESCRIPTION
Changes proposed in this pull request:
 - Simple Workflow change to download deb packages created within the Linux workflow
 

