### PR TITLE
set static hostname in docker-compose so ddns feature works cross restarts

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,7 @@
-version: '3'
-
 services:
   softether:
     image: softethervpn/vpnserver:latest
+    hostname: softethervpnserver
     cap_add:
       - NET_ADMIN
     restart: always


### PR DESCRIPTION
Fixes SoftEtherVPN/SoftetherVPN-docker#15 by configuring static hostname


