### PR TITLE
Cedar/Proto_IKE: fix too many arguments to function 'NewBuf'

### DIFF
--- a/src/Cedar/Proto_IKE.c
+++ b/src/Cedar/Proto_IKE.c
@@ -2253,8 +2253,8 @@ void ProcIkeQuickModePacketRecv(IKE_SERVER *ike, UDPPACKET *p, IKE_PACKET *heade
 														// Update the information of IPsec SA
 														if (shared_key != NULL)
 														{
-															ipsec_sa_sc->SharedKey = NewBuf(shared_key, shared_key_size);
-															ipsec_sa_cs->SharedKey = NewBuf(shared_key, shared_key_size);
+															ipsec_sa_sc->SharedKey = NewBufFromMemory(shared_key, shared_key_size);
+															ipsec_sa_cs->SharedKey = NewBufFromMemory(shared_key, shared_key_size);
 														}
 
 														ipsec_sa_sc->Spi = setting.SpiServerToClient;


### PR DESCRIPTION
This commit fixes the following error:

```
Proto_IKE.c: In function ‘ProcIkeQuickModePacketRecv’:
Proto_IKE.c:2362:146: error: too many arguments to function ‘NewBuf’; expected 0, have 2
 2362 |                                                                                                                         ipsec_sa_sc->SharedKey = NewBuf(shared_key, shared_key_size);
      |                                                                                                                                                  ^~~~~~ ~~~~~~~~~~
In file included from ../../src/Mayaqua/Mayaqua.h:338,
                 from CedarPch.h:115,
                 from IPsec_IKE.c:105:
../../src/Mayaqua/Memory.h:303:6: note: declared here
  303 | BUF *NewBuf();
      |      ^~~~~~
Proto_IKE.c:2363:146: error: too many arguments to function ‘NewBuf’; expected 0, have 2
 2363 |                                                                                                                         ipsec_sa_cs->SharedKey = NewBuf(shared_key, shared_key_size);
      |                                                                                                                                                  ^~~~~~ ~~~~~~~~~~
```

The function `NewBuf` is defined without arguments. Replace it in favour of `NewBufFromMemory` that copy the content of the pointer into a new buffer.

Changes proposed in this pull request:
 - Fix NewBuf to call NewBufFromMemory instead