### PR TITLE
fix: Continue decapsulation to parse L3 data from VLAN-tagged packets

### DIFF
--- a/src/Mayaqua/TcpIp.h
+++ b/src/Mayaqua/TcpIp.h
@@ -87,7 +87,8 @@ struct ARPV4_HEADER
 // Tagged VLAN header
 struct TAGVLAN_HEADER
 {
-	UCHAR Data[2];					// Data
+	UCHAR TagID[2];					// TagID
+	UCHAR Protocol[2];				// Protocol
 } GCC_PACKED;
 
 // IPv4 header
@@ -762,10 +763,11 @@ void FreePacketTCPv4(PKT *p);
 void FreePacketICMPv4(PKT *p);
 void FreePacketDHCPv4(PKT *p);
 bool ParsePacketL2Ex(PKT *p, UCHAR *buf, UINT size, bool no_l3, bool no_l3_l4_except_icmpv6);
+bool ParsePacketL3(PKT *p, UCHAR *buf, UINT size, USHORT proto, bool no_l3, bool no_l3_l4_except_icmpv6);
 bool ParsePacketARPv4(PKT *p, UCHAR *buf, UINT size);
 bool ParsePacketIPv4(PKT *p, UCHAR *buf, UINT size);
 bool ParsePacketBPDU(PKT *p, UCHAR *buf, UINT size);
-bool ParsePacketTAGVLAN(PKT *p, UCHAR *buf, UINT size);
+bool ParsePacketTAGVLAN(PKT *p, UCHAR *buf, UINT size, bool no_l3, bool no_l3_l4_except_icmpv6);
 bool ParseICMPv4(PKT *p, UCHAR *buf, UINT size);
 bool ParseICMPv6(PKT *p, UCHAR *buf, UINT size);
 bool ParseTCP(PKT *p, UCHAR *buf, UINT size);


### PR DESCRIPTION
This pull request addresses a bug where the ParsePacketL2Ex won't parse Layer 3 packet data when it was encapsulated in a frame with a VLAN tag.

Previously, upon receiving a packet with a VLAN tag, the decapsulation process would not proceed to analyze the inner packet. This prevented the Layer 3 protocol (e.g., IP) from being correctly identified and processed, breaking functionalities that rely on L3 information (packet log for example).

This patch modifies the packet handling logic to ensure that after a VLAN tag is identified, the process continues to decapsulate the rest of the frame, allowing for the proper parsing of the Layer 3 packet within.

The issue I mentioned before #2138 