### PR TITLE
Openvpn: only send AUTH_FAILED reply on auth errors

### DIFF
--- a/src/Cedar/Proto_OpenVPN.c
+++ b/src/Cedar/Proto_OpenVPN.c
@@ -2562,9 +2562,16 @@ void OvsRecvPacket(OPENVPN_SERVER *s, LIST *recv_packet_list, UINT protocol)
 								Debug("OpenVPN Channel %u Failed.\n", j);
 								OvsLog(s, se, c, "LO_CHANNEL_FAILED");
 
-								// Return the AUTH_FAILED
-								str = "AUTH_FAILED";
-								WriteFifo(c->SslPipe->SslInOut->SendFifo, str, StrSize(str));
+								if ((se->IpcAsync->ErrorCode == ERR_AUTHTYPE_NOT_SUPPORTED) ||
+									(se->IpcAsync->ErrorCode == ERR_AUTH_FAILED) ||
+									(se->IpcAsync->ErrorCode == ERR_PROXY_AUTH_FAILED) ||
+									(se->IpcAsync->ErrorCode == ERR_USER_AUTHTYPE_NOT_PASSWORD) ||
+									(se->IpcAsync->ErrorCode == ERR_NOT_SUPPORTED_AUTH_ON_OPENSOURCE))
+								{
+									// Return the AUTH_FAILED
+									str = "AUTH_FAILED";
+									WriteFifo(c->SslPipe->SslInOut->SendFifo, str, StrSize(str));
+								}
 
 								s->SessionEstablishedCount++;
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - Only send a "AUTH_FAILED" response in case the connection was really rejected due to auth problems.

Note:
Through this errors which appear e.g. due to timeout errors won't be recognized by the client as auth error. Instead, if configured (default), the client would run into its own timeout.