### PR TITLE
Specify the  'vpn_gateway' or 'net_gateway' keywords within the split-tunnel routing settings

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -8413,7 +8413,12 @@ UINT StSetSecureNATOption(ADMIN *a, VH_OPTION *t)
 	}
 
 	StrCpy(push_routes_str_old, sizeof(push_routes_str_old), h->SecureNATOption->DhcpPushRoutes);
+	UINT ovpn_gw_old = h->SecureNATOption->Ovpn_gateway;
 	Copy(h->SecureNATOption, t, sizeof(VH_OPTION));
+	if (t->Ovpn_gateway == (UINT)(-1))
+	{
+		h->SecureNATOption->Ovpn_gateway = ovpn_gw_old;
+	}
 	if (t->ApplyDhcpPushRoutes == false)
 	{
 		StrCpy(h->SecureNATOption->DhcpPushRoutes, sizeof(h->SecureNATOption->DhcpPushRoutes), push_routes_str_old);

--- a/src/Cedar/Command.h
+++ b/src/Cedar/Command.h
@@ -611,6 +611,18 @@ UINT PsDynamicDnsSetHostname(CONSOLE *c, char *cmd_name, wchar_t *str, void *par
 UINT PsVpnAzureSetEnable(CONSOLE *c, char *cmd_name, wchar_t *str, void *param);
 UINT PsVpnAzureGetStatus(CONSOLE *c, char *cmd_name, wchar_t *str, void *param);
 
+bool CmdEvalIpEx(CONSOLE* c, wchar_t* str, void* param);
+bool CmdEvalMinMaxEx(CONSOLE* c, wchar_t* str, void* param);
+bool CmdEvalYesEx(CONSOLE* c, wchar_t* str, void* param);
+bool CmdEvalRouteTableEx(CONSOLE* c, wchar_t* str, void* param);
+bool CmdEvalOvpnGwEx(CONSOLE* c, wchar_t* str, void* param);
+bool CmdStrToIP(IP* ip, char* str);
+bool CmdStrToUINT(UINT* v, char* str);
+bool CmdStrToStr(char* out, UINT size, char* str);
+bool CmdStrToBool(bool* b, char* str);
+bool CmdStrToIP32(UINT* ip32, char* str);
+
+UINT PsDhcpSetEx(CONSOLE* c, char* cmd_name, wchar_t* str, void* param);
 
 #endif	// COMMAND_H
 

--- a/src/Cedar/Console.h
+++ b/src/Cedar/Console.h
@@ -141,6 +141,7 @@ void ConsoleWriteOutFile(CONSOLE *c, wchar_t *str, bool add_last_crlf);
 wchar_t *ConsoleReadNextFromInFile(CONSOLE *c);
 UINT ConsoleLocalGetWidth(CONSOLE *c);
 
+LIST* ParseCommandListEx(CONSOLE* c, char* cmd_name, wchar_t* command, PARAM param[], UINT num_param);
 
 #endif	// CONSOLE_H
 

--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -1748,7 +1748,20 @@ void IPCSendIPv4(IPC *ipc, void *data, UINT size)
 		}
 		else
 		{
-			Copy(&ip_dst_local, &r->Gateway, sizeof(IP));
+			BYTE* pb = IPV4(r->Gateway.address);
+
+			if (pb[0] != 0)
+			{
+				Copy(&ip_dst_local, &r->Gateway, sizeof(IP));
+			}
+			else if (pb[1] == 'v' && pb[2] == 'p' && pb[3] == 'n')
+			{
+				UINTToIP(&ip_dst_local, ipc->ClasslessRoute.Ovpn_gateway);
+			}
+			else
+			{
+				Copy(&ip_dst_local, &ipc->DefaultGateway, sizeof(IP));
+			}
 		}
 	}
 

--- a/src/Cedar/Nat.c
+++ b/src/Cedar/Nat.c
@@ -737,6 +737,15 @@ void InVhOption(VH_OPTION *t, PACK *p)
 	PackGetStr(p, "RpcHubName", t->HubName, sizeof(t->HubName));
 	t->ApplyDhcpPushRoutes = PackGetBool(p, "ApplyDhcpPushRoutes");
 	PackGetStr(p, "DhcpPushRoutes", t->DhcpPushRoutes, sizeof(t->DhcpPushRoutes));
+
+	if (GetElement(p, "DhcpPushOvpnGateway", VALUE_INT) == NULL)   // vpnsmgr or vpnserver  is not aware of 'vpn_gateway' keyword
+	{
+		t->Ovpn_gateway = (UINT)(-1);
+	}
+	else
+	{
+		t->Ovpn_gateway = PackGetInt(p, "DhcpPushOvpnGateway");
+	}
 }
 void OutVhOption(PACK *p, VH_OPTION *t)
 {
@@ -766,6 +775,7 @@ void OutVhOption(PACK *p, VH_OPTION *t)
 	PackAddStr(p, "RpcHubName", t->HubName);
 	PackAddBool(p, "ApplyDhcpPushRoutes", true);
 	PackAddStr(p, "DhcpPushRoutes", t->DhcpPushRoutes);
+	PackAddInt(p, "DhcpPushOvpnGateway", t->Ovpn_gateway);
 }
 
 // RPC_ENUM_DHCP
@@ -1404,6 +1414,9 @@ void NiLoadVhOptionEx(VH_OPTION *o, FOLDER *root)
 	CfgGetStr(dhcp, "DhcpDomainName", o->DhcpDomainName, sizeof(o->DhcpDomainName));
 
 	CfgGetStr(dhcp, "DhcpPushRoutes", o->DhcpPushRoutes, sizeof(o->DhcpPushRoutes));
+	IP ovpn_gw;
+	CfgGetIp(dhcp, "DhcpPushOvpnGateway", &ovpn_gw);
+	o->Ovpn_gateway = IPToUINT(&ovpn_gw);
 
 // Test code
 //	StrCpy(o->DhcpPushRoutes, sizeof(o->DhcpPushRoutes),
@@ -1543,6 +1556,10 @@ void NiWriteVhOptionEx(VH_OPTION *o, FOLDER *root)
 	CfgAddIp(dhcp, "DhcpDnsServerAddress2", &o->DhcpDnsServerAddress2);
 	CfgAddStr(dhcp, "DhcpDomainName", o->DhcpDomainName);
 	CfgAddStr(dhcp, "DhcpPushRoutes", o->DhcpPushRoutes);
+
+	IP ovpn_gw;
+	UINTToIP(&ovpn_gw, o->Ovpn_gateway);
+	CfgAddIp(dhcp, "DhcpPushOvpnGateway", &ovpn_gw);
 
 	CfgAddBool(root, "SaveLog", o->SaveLog);
 }

--- a/src/Cedar/SMInner.h
+++ b/src/Cedar/SMInner.h
@@ -144,6 +144,7 @@ typedef struct SM_HUB
 	RPC *Rpc;					// RPC
 	char *HubName;				// HUB name
 	char CurrentPushRouteStr[MAX_DHCP_CLASSLESS_ROUTE_TABLE_STR_SIZE];	// Current editing push routing table string
+	UINT CurrentOvpn_gateway;		// Current value of 'vpn_gateway'
 } SM_HUB;
 
 // Show the User list

--- a/src/Cedar/Virtual.c
+++ b/src/Cedar/Virtual.c
@@ -10173,6 +10173,8 @@ void SetVirtualHostOption(VH *v, VH_OPTION *vo)
 
 			if (ParseClasslessRouteTableStr(&rt, vo->DhcpPushRoutes))
 			{
+				if (vo->Ovpn_gateway == (UINT)(-1)) rt.Ovpn_gateway = v->PushRoute.Ovpn_gateway;
+				else rt.Ovpn_gateway = vo->Ovpn_gateway;
 				Copy(&v->PushRoute, &rt, sizeof(DHCP_CLASSLESS_ROUTE_TABLE));
 			}
 		}

--- a/src/Cedar/Virtual.h
+++ b/src/Cedar/Virtual.h
@@ -339,6 +339,7 @@ struct VH_OPTION
 	bool SaveLog;					// Save a log
 	bool ApplyDhcpPushRoutes;		// Apply flag for DhcpPushRoutes
 	char DhcpPushRoutes[MAX_DHCP_CLASSLESS_ROUTE_TABLE_STR_SIZE];	// DHCP pushing routes
+	UINT Ovpn_gateway;				// 'vpn_gateway' for OpenVPN Connect
 };
 
 // DHCP lease entry

--- a/src/Mayaqua/Mayaqua.c
+++ b/src/Mayaqua/Mayaqua.c
@@ -1069,6 +1069,9 @@ void PrintDebugInformation()
 	MEMORY_STATUS memory_status;
 	GetMemoryStatus(&memory_status);
 
+#ifdef OS_WIN32
+	bool bc = MyAllocConsole();
+#endif
 	// Header
 	Print("====== " CEDAR_PRODUCT_STR " VPN System Debug Information ======\n");
 
@@ -1087,6 +1090,14 @@ void PrintDebugInformation()
 		// Show a debug menu because memory leaks suspected
 		MemoryDebugMenu();
 	}
+
+#ifdef OS_WIN32
+	if (bc)
+	{
+		FreeConsole();
+	}
+#endif
+
 }
 
 

--- a/src/Mayaqua/TcpIp.h
+++ b/src/Mayaqua/TcpIp.h
@@ -527,6 +527,7 @@ struct ICMPV6_HEADER_INFO
 #define	DHCP_ID_CLASSLESS_ROUTE		0x79
 #define	DHCP_ID_MS_CLASSLESS_ROUTE	0xF9
 #define	DHCP_ID_PRIVATE				0xFA
+#define	DHCP_ID_VENDOR_SPECIFIC		0x2B
 
 
 // DHCP client action
@@ -696,6 +697,7 @@ struct DHCP_CLASSLESS_ROUTE_TABLE
 {
 	UINT NumExistingRoutes;			// Number of existing routing table entries
 	DHCP_CLASSLESS_ROUTE Entries[MAX_DHCP_CLASSLESS_ROUTE_ENTRIES];	// Entries
+	UINT Ovpn_gateway;			// vlue of 'vpn_gateway'  
 };
 
 #define	MAX_USER_CLASS_LEN	255

--- a/src/Mayaqua/Win32.c
+++ b/src/Mayaqua/Win32.c
@@ -25,6 +25,9 @@
 #include <timeapi.h>
 #include <winioctl.h>
 
+#include "dbghelp.h"
+#include "tracking.h"
+
 static HANDLE heap_handle = NULL;
 static HANDLE hstdout = INVALID_HANDLE_VALUE;
 static HANDLE hstdin = INVALID_HANDLE_VALUE;
@@ -3420,6 +3423,24 @@ void Win32PrintToFileW(wchar_t *str)
 	Free(utf);
 }
 
+bool MyAllocConsole()
+{
+	BOOL BC = AllocConsole();
+	if (BC == FALSE)
+	{
+		DWORD er = GetLastError();
+		return false;
+	}
+	if (hstdout == INVALID_HANDLE_VALUE || hstdout == NULL)
+	{
+		hstdout = GetStdHandle(STD_OUTPUT_HANDLE);
+	}
+	if (hstdin == INVALID_HANDLE_VALUE || hstdin == NULL)
+	{
+		hstdin = GetStdHandle(STD_INPUT_HANDLE);
+	}
+	return true;
+}
 
 #endif	// WIN32
 

--- a/src/Mayaqua/Win32.h
+++ b/src/Mayaqua/Win32.h
@@ -121,6 +121,8 @@ UINT Win32GetNumberOfCpuInner();
 
 void Win32SetThreadName(UINT thread_id, char *name);
 
+bool MyAllocConsole();
+
 #endif	// WIN32_H
 
 #endif	// OS_WIN32

--- a/src/PenCore/PenCore.rc
+++ b/src/PenCore/PenCore.rc
@@ -4645,13 +4645,15 @@ FONT 9, "MS Shell Dlg", 400, 0, 0x80
 BEGIN
     ICON            ICO_PROTOCOL,IDC_STATIC,7,5,18,18
     LTEXT           "@S1",S1,35,9,325,24,WS_TABSTOP
-    LTEXT           "@S2",S2,35,33,325,30
-    LTEXT           "@S3",S3,35,64,325,30
-    LTEXT           "@S4",S4,35,95,325,30
-    GROUPBOX        "@S5",S5,23,124,337,96
-    EDITTEXT        E_TEXT,35,173,315,36,ES_MULTILINE | WS_VSCROLL
-    LTEXT           "@S6",IDC_STATIC,35,136,315,36
-    DEFPUSHBUTTON   "@IDOK",IDOK,222,228,64,17
+        LTEXT           "@S2", S2, 35, 23, 325, 30
+        LTEXT           "@S3", S3, 35, 54, 325, 30
+        LTEXT           "@S4", S4, 35, 85, 325, 25
+        GROUPBOX        "@S5", S5, 23, 110, 337, 115
+        LTEXT           "@S6", IDC_STATIC, 35, 120, 315, 45
+        EDITTEXT        E_TEXT, 35, 166, 315, 36, ES_MULTILINE | WS_VSCROLL
+        LTEXT           "@S_VPN_GW", IDC_STATIC, 35, 208, 164, 12
+        CONTROL         "", E_IP, "SysIPAddress32", WS_TABSTOP, 222, 206, 80, 12
+        DEFPUSHBUTTON   "@IDOK",IDOK,222,228,64,17
     PUSHBUTTON      "@IDCANCEL",IDCANCEL,296,228,64,17
     LTEXT           "@S7",IDC_STATIC,35,233,185,12
 END

--- a/src/PenCore/resource.h
+++ b/src/PenCore/resource.h
@@ -1143,6 +1143,9 @@
 #define D_DEFAULT3                      2097
 #define D_NM_PUSH                       2097
 #define D_CM_PROXY_HTTP_HEADER          2098
+
+#define S_VPN_GW						2200
+
 #define ID_Menu40011                    40011
 #define CMD_CONNECT                     40020
 #define CMD_STATUS                      40021

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -1736,6 +1736,7 @@ DHCP_IP_ADDRESS				分配的 IP
 DHCP_HOSTNAME				客户端主机名
 NM_PASSWORD_MSG				管理员密码设定完成。
 NM_PUSH_ROUTE_WARNING		静态路由表中指定的文本可能有语法错误。
+NM_PUSH_ROUTE_VPNGW_WARN	If you are using 'vpn_gateway' keyword as the IP address of the gateway in the static routing table, you must set its value also.
 
 
 #关于版本信息
@@ -4248,8 +4249,10 @@ S2						VPN 客户端是否能够识别无类静态路由 (RFC 3442) 取决于�
 S3						如果你清除了虚拟 DHCP 服务器选项的默认网关字段，您就可以实现拆分隧道。在客户端一侧，为了使用拆分隧道， L2TP/IPSec 和 MS-SSTP 客户端需要配置为不创建默认网关。
 S4						您还可以通过现有的外部 DHCP 服务器推送无类静态路由 (RFC 3442)。在这种情况下，在 SecureNAT 禁用虚拟 DHCP 服务器功能，在这一屏幕上你不需要设置无类路由。
 S5						编辑该静态路由表以推送
-S6						例如: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\n用逗号或空格字符来拆分多条目 (最多 64 条目)。\r\n每个条目必须以 "IP 网络地址 / 子网掩码 / 网关 IP 地址" 的格式来指定。
+#S6						例如: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\n用逗号或空格字符来拆分多条目 (最多 64 条目)。\r\n每个条目必须以 "IP 网络地址 / 子网掩码 / 网关 IP 地址" 的格式来指定。
+S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n    OR     192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway      for OpenVPN Connect\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format,\r\n   OR  you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients.
 S7						请参阅 RFC3442 以了解无类路由。
+S_VPN_GW				IP address of "vpn_gateway" for OpenVPN Connect
 IDOK					确定(&O)
 IDCANCEL				取消
 
@@ -4491,6 +4494,7 @@ CMD_KEYPAIR_FAILED			X.509 证书和私钥的组合指定不正确。证书和�
 CMD_CERT_NOT_EXISTS			证书未登记。
 CMD_NO_SETTINGS				－
 CMD_DISCONNECTED_MSG		\n---Error---\n\n与您正管理的主机通信会话被中断了。从现在开始，如果您运行任何命令将出现错误。\n\n为了重新连接到您管理的主机，首先输入 "EXIT" 的离本开提示，然后重新连接。\n\n
+CMD_BOOL_EVAL_FAILED	The boolean value should be: YES  or NO
 
 
 # VPN CMD 命令
@@ -6170,6 +6174,7 @@ CMD_DhcpGet_Column_DNS		DNS 服务器地址 1
 CMD_DhcpGet_Column_DNS2		DNS 服务器地址 2
 CMD_DhcpGet_Column_DOMAIN	域名
 CMD_DhcpGet_Column_PUSHROUTE	静态路由表推送
+CMD_DhcpGet_Column_OVPNGATEWAY	'vpn_gateway' value for OVPN
 
 
 # DhcpEnable 命令
@@ -6185,9 +6190,11 @@ CMD_DhcpDisable_Args		DhcpDisable
 
 
 # DhcpSet 命令
-CMD_DhcpSet					更改安全网络功能的虚拟 DHCP 服务器功能的设置
+#CMD_DhcpSet					更改安全网络功能的虚拟 DHCP 服务器功能的设置
+CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function. Press <Enter> to keep a current value; type '' to clear it. 
 CMD_DhcpSet_Help			在现在管理的虚拟 HUB 内，更改虚拟 DHCP 服务器的设置。虚拟 DHCP 服务器设置包括: 分配 IP 地址范围，子网掩码，出租期限，及分配给客户端的选项值。\n该指令在作为进群操作的 VPN Server 的虚拟服务器上不能执行。
-CMD_DhcpSet_Args			DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2] [/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+#CMD_DhcpSet_Args			DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2] [/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"] [/OVPNGW:ovpngwip] 
 CMD_DhcpSet_START			指定地址范围的开始点，以分发给客户。(例如: 192.168.30.10)
 CMD_DhcpSet_END				指定地址范围的结束点，以分发给客户。(例如: 192.168.30.200)
 CMD_DhcpSet_MASK			指定对客户指定的子网掩码。(例如: 255.255.255.0)
@@ -6197,7 +6204,9 @@ CMD_DhcpSet_DNS				指定被通知到客户端的主 DNS 服务器的 IP 地址�
 CMD_DhcpSet_DNS2			指定被通知到客户端的次要 DNS 服务器 IP 地址。当 SecureNAT 功能的虚拟 NAT 功能已经启用并正在运行时，您可以为此指定一个 SecureNAT 虚拟主机 IP 地址。如果您指定的是 0 或者 none，那么客户端就不会被 DNS 服务器地址通知。
 CMD_DhcpSet_DOMAIN			指定域名通知客户。如果指定 none，该域名不通知客户。
 CMD_DhcpSet_LOG				指定是否将虚拟 DHCP 服务器运行保存为安全日志。指定 "yes" 则保存。此值与虚拟 NAT 功能的日志保存设置是联动的。
-CMD_DhcpSet_PUSHROUTE	指定静态路由表推送。\n例如: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n用逗号或空格字符来拆分多条目 (最多 64 条目)。每个条目必须以 "IP 网络地址/子网掩码/网关 IP 地址" 的格式来指定。 \n这个虚拟 DHCP 服务器可以推送带DHCP应答消息的无类静态路由 (RFC 3442) 至 VPN 客户端。\nVPN 客户端是否能够识别无类静态路由 (RFC 3442) 取决于目标VPN客户端软件。SoftEther VPN 客户端和 OpenVPN 客户端都支持无类静态路由。在 L2TP/IPSec 和 MS-SSTP 协议上，兼容性取决于客户端软件的实施。如果你清除了虚拟 DHCP 服务器选项的默认网关字段，您就可以实现拆分隧道。在客户端一侧，为了使用拆分隧道，L2TP/IPSec 和 MS-SSTP 客户端需要配置为不创建默认网关。\n您还可以通过现有的外部 DHCP 服务器推送无类静态路由 (RFC 3442)。在这种情况下，在 SecureNAT 禁用虚拟 DHCP 服务器功能，在这一屏幕上你不需要设置无类路由。\n请参阅 RFC 3442 以了解无类路由。
+#CMD_DhcpSet_PUSHROUTE	指定静态路由表推送。\n例如: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n用逗号或空格字符来拆分多条目 (最多 64 条目)。每个条目必须以 "IP 网络地址/子网掩码/网关 IP 地址" 的格式来指定。 \n这个虚拟 DHCP 服务器可以推送带DHCP应答消息的无类静态路由 (RFC 3442) 至 VPN 客户端。\nVPN 客户端是否能够识别无类静态路由 (RFC 3442) 取决于目标VPN客户端软件。SoftEther VPN 客户端和 OpenVPN 客户端都支持无类静态路由。在 L2TP/IPSec 和 MS-SSTP 协议上，兼容性取决于客户端软件的实施。如果你清除了虚拟 DHCP 服务器选项的默认网关字段，您就可以实现拆分隧道。在客户端一侧，为了使用拆分隧道，L2TP/IPSec 和 MS-SSTP 客户端需要配置为不创建默认网关。\n您还可以通过现有的外部 DHCP 服务器推送无类静态路由 (RFC 3442)。在这种情况下，在 SecureNAT 禁用虚拟 DHCP 服务器功能，在这一屏幕上你不需要设置无类路由。\n请参阅 RFC 3442 以了解无类路由。
+CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n  OR   "192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway"  for OpenVPN clients\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format, OR you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_OVPNGW			Specify the IP address of 'vpn_gateway' parameter to be notified to the client. If you specify 0 or none, then the client will not be notified of the vpn_gateway value. If you use the 'vpn_gateway' keyword in the classless static routing table, you must specify this value also.
 CMD_DhcpSet_Prompt_START	分发地址范围的开始: 
 CMD_DhcpSet_Prompt_END		分发地址范围的结束: 
 CMD_DhcpSet_Prompt_MASK		子网掩码: 
@@ -6206,6 +6215,11 @@ CMD_DhcpSet_Prompt_GW		默认网关 (可以不设定):
 CMD_DhcpSet_Prompt_DNS		DNS 服务器 1 (可以不设定): 
 CMD_DhcpSet_Prompt_DNS2		DNS 服务器 2 (可以不设定): 
 CMD_DhcpSet_Prompt_DOMAIN	域名: 
+CMD_DhcpSet_Prompt1_GW		Default Gateway: 
+CMD_DhcpSet_Prompt1_DNS		DNS Server 1: 
+CMD_DhcpSet_Prompt1_DNS2	DNS Server 2: 
+CMD_DhcpSet_Prompt_PUSHROUTE	Static routing table to push:
+CMD_DhcpSet_Prompt_OVPNGW	'vpn_gateway' parmeter for OpenVPN: 
 
 
 # DhcpTable 命令

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -1722,6 +1722,7 @@ DHCP_IP_ADDRESS			Allocated IP
 DHCP_HOSTNAME			Client Host Name
 NM_PASSWORD_MSG			The administration password has been set.
 NM_PUSH_ROUTE_WARNING	The specified text of the static routing table may have a syntax error.
+NM_PUSH_ROUTE_VPNGW_WARN	If you are using 'vpn_gateway' keyword as the IP address of the gateway in the static routing table, you must set its value also.
 
 
 # Concerning version information
@@ -4236,8 +4237,10 @@ S2						Whether or not a VPN client can recognize the classless static routes (R
 S3						You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.
 S4						You can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this screen.
 S5						Edit the static routing table to push
-S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format.
+#S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format.
+S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n    OR     192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway      for OpenVPN Connect\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format,\r\n   OR  you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients.
 S7						See the RFC 3442 to understand the classless routes.
+S_VPN_GW				IP address of "vpn_gateway" for OpenVPN Connect
 IDOK					&OK
 IDCANCEL				Cancel
 
@@ -4479,6 +4482,7 @@ CMD_KEYPAIR_FAILED		The X.509 certificate and private key combination has been i
 CMD_CERT_NOT_EXISTS		The certificate is not registered.
 CMD_NO_SETTINGS			-
 CMD_DISCONNECTED_MSG	\n--- Error ---\n\nThe communication session with the host you were managing has been disconnected. From now on, if you run any commands an error will occur. \n\nTo reconnect to the host you were managing, first leave the prompt by inputting "EXIT" and then reconnect. \n\n
+CMD_BOOL_EVAL_FAILED	The boolean value should be: YES  or NO
 
 
 # VPNCMD コマンド
@@ -6155,6 +6159,7 @@ CMD_DhcpGet_Column_DNS	DNS Server Address 1
 CMD_DhcpGet_Column_DNS2	DNS Server Address 2
 CMD_DhcpGet_Column_DOMAIN	Domain Name
 CMD_DhcpGet_Column_PUSHROUTE	Static Routing Table to Push
+CMD_DhcpGet_Column_OVPNGATEWAY	'vpn_gateway' value for OVPN
 
 
 # DhcpEnable command
@@ -6170,9 +6175,11 @@ CMD_DhcpDisable_Args	DhcpDisable
 
 
 # DhcpSet command
-CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function
+# CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function
+CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function. Press <Enter> to keep a current value; type '' to clear it. 
 CMD_DhcpSet_Help		Use this to change the Virtual DHCP Server setting of the currently managed Virtual Hub. The Virtual DHCP Server settings include the following items: distribution address band, subnet mask, lease limit, and option values assigned to clients. \nYou cannot execute this command for Virtual Hubs of VPN Servers operating as a cluster.
-CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+# CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"] [/OVPNGW:ovpngwip] 
 CMD_DhcpSet_START		Specify the start point of the address band to be distributed to the client. (Example: 192.168.30.10)
 CMD_DhcpSet_END			Specify the end point of the address band to be distributed to the client. (Example: 192.168.30.200)
 CMD_DhcpSet_MASK		Specify the subnet mask to be specified for the client. (Example: 255.255.255.0)
@@ -6182,7 +6189,9 @@ CMD_DhcpSet_DNS			Specify the IP address of the primary DNS Server to be notifie
 CMD_DhcpSet_DNS2		Specify the IP address of the secondary DNS Server to be notified to the client. You can specify a SecureNAT Virtual Host IP address for this when the SecureNAT Function's Virtual NAT Function has been enabled and is being used also. If you specify 0 or none, then the client will not be notified of the DNS Server address.
 CMD_DhcpSet_DOMAIN		Specify the domain name to be notified to the client. If you specify none, then the client will not be notified of the domain name.
 CMD_DhcpSet_LOG			Specify whether or not to save the Virtual DHCP Server operation in the Virtual Hub security log. Specify "yes" to save it. This value is interlinked with the Virtual NAT Function log save setting.
-CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format.\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+# CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format.\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n  OR   "192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway"  for OpenVPN clients\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format, OR you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_OVPNGW			Specify the IP address of 'vpn_gateway' parameter to be notified to the client. If you specify 0 or none, then the client will not be notified of the vpn_gateway value. If you use the 'vpn_gateway' keyword in the classless static routing table, you must specify this value also.
 CMD_DhcpSet_Prompt_START	Start Point for Distributed Address Band: 
 CMD_DhcpSet_Prompt_END		End Point for Distributed Address Band: 
 CMD_DhcpSet_Prompt_MASK		Subnet Mask: 
@@ -6191,6 +6200,11 @@ CMD_DhcpSet_Prompt_GW		Default Gateway ('none' to not set this):
 CMD_DhcpSet_Prompt_DNS		DNS Server 1 ('none' to not set this): 
 CMD_DhcpSet_Prompt_DNS2		DNS Server 2 ('none' to not set this): 
 CMD_DhcpSet_Prompt_DOMAIN	Domain Name: 
+CMD_DhcpSet_Prompt1_GW		Default Gateway: 
+CMD_DhcpSet_Prompt1_DNS		DNS Server 1: 
+CMD_DhcpSet_Prompt1_DNS2	DNS Server 2: 
+CMD_DhcpSet_Prompt_PUSHROUTE	Static routing table to push:
+CMD_DhcpSet_Prompt_OVPNGW	'vpn_gateway' parmeter for OpenVPN: 
 
 
 # DhcpTable command

--- a/src/bin/hamcore/strtable_id.stb
+++ b/src/bin/hamcore/strtable_id.stb
@@ -1722,6 +1722,7 @@ DHCP_IP_ADDRESS			IP yang Dialokasikan
 DHCP_HOSTNAME			Nama Host Klien
 NM_PASSWORD_MSG			Kata sandi administrasi telah disetel.
 NM_PUSH_ROUTE_WARNING	Teks yang ditentukan pada tabel routing statis mungkin mengandung kesalahan sintaks.
+NM_PUSH_ROUTE_VPNGW_WARN	If you are using 'vpn_gateway' keyword as the IP address of the gateway in the static routing table, you must set its value also.
 
 
 # Concerning version information
@@ -4236,8 +4237,10 @@ S2						Apakah klien VPN dapat mengenali rute statis tanpa kelas (RFC 3442) terg
 S3						Anda dapat mewujudkan split tunneling jika Anda menghapus kolom gateway default pada opsi Server DHCP Virtual. Di sisi klien, klien L2TP/IPsec dan MS-SSTP perlu dikonfigurasi untuk tidak mengatur gateway default untuk penggunaan split tunneling.
 S4						Anda juga dapat mendorong rute statis tanpa kelas (RFC 3442) menggunakan server DHCP eksternal Anda yang ada. Dalam hal ini, nonaktifkan fungsi Server DHCP Virtual pada SecureNAT, dan Anda tidak perlu mengatur rute tanpa kelas di layar ini.
 S5						Edit tabel routing statis untuk mendorong
-S6						Contoh: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\nPisahkan entri yang berbeda (maksimum: 64 entri) dengan koma atau karakter spasi.\r\nSetiap entri harus ditentukan dalam format "alamat jaringan IP/masker subnet/alamat IP gateway".
+#S6						Contoh: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\nPisahkan entri yang berbeda (maksimum: 64 entri) dengan koma atau karakter spasi.\r\nSetiap entri harus ditentukan dalam format "alamat jaringan IP/masker subnet/alamat IP gateway".
+S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n    OR     192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway      for OpenVPN Connect\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format,\r\n   OR  you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients.
 S7						Lihat RFC 3442 untuk memahami rute tanpa kelas.
+S_VPN_GW				IP address of "vpn_gateway" for OpenVPN Connect
 IDOK					&OK
 IDCANCEL				Batal
 
@@ -4479,6 +4482,7 @@ CMD_KEYPAIR_FAILED		Perpaduan sertifikat X.509 dan kunci pribadi telah ditentuka
 CMD_CERT_NOT_EXISTS		Sertifikat tidak terdaftar.
 CMD_NO_SETTINGS			-
 CMD_DISCONNECTED_MSG	\n--- Kesalahan ---\n\nSesi komunikasi dengan host yang Anda kelola telah terputus. Mulai sekarang, jika Anda menjalankan perintah apa pun, kesalahan akan terjadi. \n\nUntuk menyambung kembali ke host yang Anda kelola, keluar dari prompt dengan memasukkan "EXIT" dan kemudian sambungkan kembali. \n\n
+CMD_BOOL_EVAL_FAILED	The boolean value should be: YES  or NO
 
 
 # VPNCMD コマンド
@@ -6155,6 +6159,7 @@ CMD_DhcpGet_Column_DNS	Alamat Server DNS 1
 CMD_DhcpGet_Column_DNS2	Alamat Server DNS 2
 CMD_DhcpGet_Column_DOMAIN	Nama Domain
 CMD_DhcpGet_Column_PUSHROUTE	Tabel Routing Statis untuk Dikirim
+CMD_DhcpGet_Column_OVPNGATEWAY	'vpn_gateway' value for OVPN
 
 
 # DhcpEnable command
@@ -6170,9 +6175,11 @@ CMD_DhcpDisable_Args	DhcpDisable
 
 
 # DhcpSet command
-CMD_DhcpSet				Ubah Pengaturan Fungsi Server DHCP Virtual dari Fungsi SecureNAT
+#CMD_DhcpSet				Ubah Pengaturan Fungsi Server DHCP Virtual dari Fungsi SecureNAT
+CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function. Press <Enter> to keep a current value; type '' to clear it. 
 CMD_DhcpSet_Help		Gunakan perintah ini untuk mengubah pengaturan Server DHCP Virtual pada Virtual Hub yang sedang dikelola. Pengaturan Server DHCP Virtual mencakup hal-hal berikut: rentang alamat distribusi, subnet mask, batas waktu sewa, dan nilai opsi yang diberikan kepada klien. \nPerintah ini tidak dapat dijalankan untuk Virtual Hub dari VPN Server yang beroperasi dalam mode kluster.
-CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+#CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"] [/OVPNGW:ovpngwip] 
 CMD_DhcpSet_START		Tentukan titik awal dari rentang alamat yang akan didistribusikan kepada klien. (Contoh: 192.168.30.10)
 CMD_DhcpSet_END			Tentukan titik akhir dari rentang alamat yang akan didistribusikan kepada klien. (Contoh: 192.168.30.200)
 CMD_DhcpSet_MASK		Tentukan subnet mask yang akan diberikan kepada klien. (Contoh: 255.255.255.0)
@@ -6182,7 +6189,9 @@ CMD_DhcpSet_DNS			Tentukan alamat IP dari DNS Server utama yang akan diberitahuk
 CMD_DhcpSet_DNS2		Tentukan alamat IP dari DNS Server sekunder yang akan diberitahukan kepada klien. Anda bisa menentukan alamat IP Virtual Host SecureNAT untuk ini jika Fungsi NAT Virtual SecureNAT telah diaktifkan dan sedang digunakan juga. Jika Anda menetapkan 0 atau none, maka klien tidak akan diberitahukan tentang alamat DNS Server.
 CMD_DhcpSet_DOMAIN		Tentukan nama domain yang akan diberitahukan kepada klien. Jika Anda menetapkan none, maka klien tidak akan diberitahukan tentang nama domain.
 CMD_DhcpSet_LOG			Tentukan apakah akan menyimpan operasi Server DHCP Virtual dalam log keamanan Virtual Hub. Tentukan "yes" untuk menyimpannya. Nilai ini terkait dengan pengaturan log simpanan Fungsi NAT Virtual.
-CMD_DhcpSet_PUSHROUTE	Tentukan tabel routing statis yang akan dipush.\nContoh: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\nPisahkan entri-entri ganda (maksimal: 64 entri) dengan koma atau spasi. Setiap entri harus ditentukan dalam format "alamat jaringan IP/subnet mask/alamat gateway IP".\nServer DHCP Virtual ini dapat mempush static routes kelasless (RFC 3442) dengan pesan balasan DHCP kepada klien VPN.\nApakah klien VPN dapat mengenali static routes kelasless (RFC 3442) bergantung pada perangkat lunak klien VPN target. SoftEther VPN Client dan OpenVPN Client mendukung static routes kelasless. Pada protokol L2TP/IPsec dan MS-SSTP, kompatibilitas bergantung pada implementasi perangkat lunak klien. Anda dapat merealisasikan split tunneling jika Anda menghapus field gateway default pada opsi Server DHCP Virtual. Di sisi klien, L2TP/IPsec dan MS-SSTP klien perlu dikonfigurasi agar tidak menetapkan gateway default untuk penggunaan split tunneling.\nAnda juga dapat mempush static routes kelasless (RFC 3442) melalui server DHCP eksternal yang ada. Dalam hal ini, nonaktifkan fungsi Server DHCP Virtual pada SecureNAT, dan Anda tidak perlu menetapkan static routes pada perintah ini.\nLihat RFC 3442 untuk memahami static routes kelasless.
+#CMD_DhcpSet_PUSHROUTE	Tentukan tabel routing statis yang akan dipush.\nContoh: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\nPisahkan entri-entri ganda (maksimal: 64 entri) dengan koma atau spasi. Setiap entri harus ditentukan dalam format "alamat jaringan IP/subnet mask/alamat gateway IP".\nServer DHCP Virtual ini dapat mempush static routes kelasless (RFC 3442) dengan pesan balasan DHCP kepada klien VPN.\nApakah klien VPN dapat mengenali static routes kelasless (RFC 3442) bergantung pada perangkat lunak klien VPN target. SoftEther VPN Client dan OpenVPN Client mendukung static routes kelasless. Pada protokol L2TP/IPsec dan MS-SSTP, kompatibilitas bergantung pada implementasi perangkat lunak klien. Anda dapat merealisasikan split tunneling jika Anda menghapus field gateway default pada opsi Server DHCP Virtual. Di sisi klien, L2TP/IPsec dan MS-SSTP klien perlu dikonfigurasi agar tidak menetapkan gateway default untuk penggunaan split tunneling.\nAnda juga dapat mempush static routes kelasless (RFC 3442) melalui server DHCP eksternal yang ada. Dalam hal ini, nonaktifkan fungsi Server DHCP Virtual pada SecureNAT, dan Anda tidak perlu menetapkan static routes pada perintah ini.\nLihat RFC 3442 untuk memahami static routes kelasless.
+CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n  OR   "192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway"  for OpenVPN clients\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format, OR you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_OVPNGW			Specify the IP address of 'vpn_gateway' parameter to be notified to the client. If you specify 0 or none, then the client will not be notified of the vpn_gateway value. If you use the 'vpn_gateway' keyword in the classless static routing table, you must specify this value also.
 CMD_DhcpSet_Prompt_START	Poin Awal untuk Rentang Alamat yang Didistribusikan: 
 CMD_DhcpSet_Prompt_END		Poin Akhir untuk Rentang Alamat yang Didistribusikan: 
 CMD_DhcpSet_Prompt_MASK		Subnet Mask: 
@@ -6191,6 +6200,11 @@ CMD_DhcpSet_Prompt_GW		Gateway Default ('none' untuk tidak menetapkan ini):
 CMD_DhcpSet_Prompt_DNS		DNS Server 1 ('none' untuk tidak menetapkan ini): 
 CMD_DhcpSet_Prompt_DNS2		DNS Server 2 ('none' untuk tidak menetapkan ini): 
 CMD_DhcpSet_Prompt_DOMAIN	Nama Domain: 
+CMD_DhcpSet_Prompt1_GW		Default Gateway: 
+CMD_DhcpSet_Prompt1_DNS		DNS Server 1: 
+CMD_DhcpSet_Prompt1_DNS2	DNS Server 2: 
+CMD_DhcpSet_Prompt_PUSHROUTE	Static routing table to push:
+CMD_DhcpSet_Prompt_OVPNGW	'vpn_gateway' parmeter for OpenVPN: 
 
 
 # DhcpTable command

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -1724,6 +1724,7 @@ DHCP_IP_ADDRESS			割り当て IP
 DHCP_HOSTNAME			クライアントホスト名
 NM_PASSWORD_MSG			管理パスワードを設定しました。
 NM_PUSH_ROUTE_WARNING	指定された静的ルーティングテーブルのテキストには文法エラーがある可能性があります。
+NM_PUSH_ROUTE_VPNGW_WARN	If you are using 'vpn_gateway' keyword as the IP address of the gateway in the static routing table, you must set its value also.
 
 
 # バージョン情報系
@@ -4241,8 +4242,10 @@ S2						VPN クライアントがクラスレス静的ルート (RFC 3442) を�
 S3						仮想 DHCP サーバーのオプションでデフォルトゲートウェイを空欄に設定することで、スプリットトンネリングが実現できます。L2TP/IPsec および MS-SSTP クライアントを使用している場合は、IPv4 の設定画面でデフォルトゲートウェイを VPN サーバーに向けないようにする設定が必要です。
 S4						ローカルブリッジ経由で外部に DHCP サーバーがある場合は、その DHCP サーバーでクラスレス静的ルート (RFC 3442) をプッシュするよう設定することもできます。その場合は、SecureNAT の仮想 DHCP サーバー機能は無効にしてください。また、この画面での設定は必要ありません。
 S5						プッシュする静的ルーティングテーブルの編集
-S6						例: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\n複数のエントリ (最大 64 個) はカンマまたはスペースで区切ります。\r\n各エントリは、"IP ネットワークアドレス/サブネットマスク/ゲートウェイ IP アドレス" の書式で記述します。
+#S6						例: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\n複数のエントリ (最大 64 個) はカンマまたはスペースで区切ります。\r\n各エントリは、"IP ネットワークアドレス/サブネットマスク/ゲートウェイ IP アドレス" の書式で記述します。
+S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n    OR     192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway      for OpenVPN Connect\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format,\r\n   OR  you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients.
 S7						クラスレス静的ルートについては、RFC 3442 をお読みください。
+S_VPN_GW				IP address of "vpn_gateway" for OpenVPN Connect
 IDOK					&OK
 IDCANCEL				キャンセル
 
@@ -4480,6 +4483,7 @@ CMD_KEYPAIR_FAILED		指定された X.509 証明書と秘密鍵の組合せは�
 CMD_CERT_NOT_EXISTS		証明書は登録されていません。
 CMD_NO_SETTINGS			－
 CMD_DISCONNECTED_MSG	\n--- エラー ---\n\n管理対象のホストとの通信セッションが切断されました。この後のコマンドを実行してもエラーになります。\n\n管理対象のホストに再接続するには、EXIT と入力して一度プロンプトから抜けてから再接続してください。\n\n
+CMD_BOOL_EVAL_FAILED	The boolean value should be: YES  or NO
 
 
 # VPNCMD コマンド
@@ -6162,6 +6166,7 @@ CMD_DhcpGet_Column_DNS	DNS サーバー アドレス 1
 CMD_DhcpGet_Column_DNS2	DNS サーバー アドレス 2
 CMD_DhcpGet_Column_DOMAIN	ドメイン名
 CMD_DhcpGet_Column_PUSHROUTE	プッシュする静的ルーティングテーブル
+CMD_DhcpGet_Column_OVPNGATEWAY	'vpn_gateway' value for OVPN
 
 
 # DhcpEnable コマンド
@@ -6177,9 +6182,11 @@ CMD_DhcpDisable_Args	DhcpDisable
 
 
 # DhcpSet コマンド
-CMD_DhcpSet				SecureNAT 機能の仮想 DHCP サーバー機能の設定の変更
+# CMD_DhcpSet				SecureNAT 機能の仮想 DHCP サーバー機能の設定の変更
+CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function. Press <Enter> to keep a current value; type '' to clear it. 
 CMD_DhcpSet_Help		現在管理している仮想 HUB 内の、仮想 DHCP サーバーの設定を変更します。仮想 DHCP サーバーの設定には、配布 IP アドレス帯、サブネットマスク、リース期限、およびクライアントに割り当てるオプション値が含まれます。\nこのコマンドは、クラスタとして動作している VPN Server の仮想 HUB では実行できません。
-CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2] [/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+#CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2] [/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"] [/OVPNGW:ovpngwip] 
 CMD_DhcpSet_START		クライアントに対して配布するアドレス帯の開始点を指定します。(例: 192.168.30.10)
 CMD_DhcpSet_END			クライアントに対して配布するアドレス帯の終了点を指定します。(例: 192.168.30.200)
 CMD_DhcpSet_MASK		クライアントに対して指定するサブネットマスクを指定します。(例: 255.255.255.0)
@@ -6189,7 +6196,9 @@ CMD_DhcpSet_DNS			クライアントに対して通知する DNS サーバー (�
 CMD_DhcpSet_DNS2		クライアントに対して通知する DNS サーバー (セカンダリ) の IP アドレスを指定します。SecureNAT 機能の仮想 NAT 機能と共に有効にして使用する場合は、SecureNAT の仮想ホストの IP アドレスを指定することもできます。0 または none を指定すると、DNS サーバー アドレスをクライアントに対して通知しません。
 CMD_DhcpSet_DOMAIN		クライアントに対して通知するドメイン名を指定します。none を指定すると、ドメイン名をクライアントに対して通知しません。
 CMD_DhcpSet_LOG			仮想 DHCP サーバーの動作を仮想 HUB のセキュリティログに保存するかどうかを指定します。"yes" を指定すると保存します。この値は、仮想 NAT 機能のログ保存設定と連動しています。
-CMD_DhcpSet_PUSHROUTE	プッシュする静的ルーティングテーブルを指定します。\n例: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n複数のエントリ (最大 64 個) はカンマまたはスペースで区切ります。各エントリは、"IP ネットワークアドレス/サブネットマスク/ゲートウェイ IP アドレス" の書式で記述します。\nVPN クライアントに対してこの仮想 DHCP サーバーから DHCP 応答を送信する際に、クラスレス静的ルート (RFC 3442) を併せて送信することができます。\nVPN クライアントがクラスレス静的ルート (RFC 3442) を認識できるかどうかは、VPN クライアントソフトウェアによって異なります。SoftEther VPN Client および OpenVPN Client はクラスレス静的ルートに対応しています。L2TP/IPsec および MS-SSTP においては、利用の可否はクライアントソフトウェアに依存します。\n仮想 DHCP サーバーのオプションでデフォルトゲートウェイを空欄に設定することで、スプリットトンネリングが実現できます。L2TP/IPsec および MS-SSTP クライアントを使用している場合は、IPv4 の設定画面でデフォルトゲートウェイを VPN サーバーに向けないようにする設定が必要です。\nローカルブリッジ経由で外部に DHCP サーバーがある場合は、その DHCP サーバーでクラスレス静的ルート (RFC 3442) をプッシュするよう設定することもできます。その場合は、SecureNAT の仮想 DHCP サーバー機能は無効にしてください。また、このコマンドでの設定は必要ありません。\nクラスレス静的ルートについては、RFC 3442 をお読みください。
+#CMD_DhcpSet_PUSHROUTE	プッシュする静的ルーティングテーブルを指定します。\n例: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n複数のエントリ (最大 64 個) はカンマまたはスペースで区切ります。各エントリは、"IP ネットワークアドレス/サブネットマスク/ゲートウェイ IP アドレス" の書式で記述します。\nVPN クライアントに対してこの仮想 DHCP サーバーから DHCP 応答を送信する際に、クラスレス静的ルート (RFC 3442) を併せて送信することができます。\nVPN クライアントがクラスレス静的ルート (RFC 3442) を認識できるかどうかは、VPN クライアントソフトウェアによって異なります。SoftEther VPN Client および OpenVPN Client はクラスレス静的ルートに対応しています。L2TP/IPsec および MS-SSTP においては、利用の可否はクライアントソフトウェアに依存します。\n仮想 DHCP サーバーのオプションでデフォルトゲートウェイを空欄に設定することで、スプリットトンネリングが実現できます。L2TP/IPsec および MS-SSTP クライアントを使用している場合は、IPv4 の設定画面でデフォルトゲートウェイを VPN サーバーに向けないようにする設定が必要です。\nローカルブリッジ経由で外部に DHCP サーバーがある場合は、その DHCP サーバーでクラスレス静的ルート (RFC 3442) をプッシュするよう設定することもできます。その場合は、SecureNAT の仮想 DHCP サーバー機能は無効にしてください。また、このコマンドでの設定は必要ありません。\nクラスレス静的ルートについては、RFC 3442 をお読みください。
+CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n  OR   "192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway"  for OpenVPN clients\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format, OR you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_OVPNGW			Specify the IP address of 'vpn_gateway' parameter to be notified to the client. If you specify 0 or none, then the client will not be notified of the vpn_gateway value. If you use the 'vpn_gateway' keyword in the classless static routing table, you must specify this value also.
 CMD_DhcpSet_Prompt_START	配布するアドレス帯の開始点: 
 CMD_DhcpSet_Prompt_END		配布するアドレス帯の終了点: 
 CMD_DhcpSet_Prompt_MASK		サブネットマスク: 
@@ -6198,6 +6207,11 @@ CMD_DhcpSet_Prompt_GW		デフォルトゲートウェイ (未設定可):
 CMD_DhcpSet_Prompt_DNS		DNS サーバー 1 (未設定可): 
 CMD_DhcpSet_Prompt_DNS2		DNS サーバー 2 (未設定可): 
 CMD_DhcpSet_Prompt_DOMAIN	ドメイン名: 
+CMD_DhcpSet_Prompt1_GW		Default Gateway: 
+CMD_DhcpSet_Prompt1_DNS		DNS Server 1: 
+CMD_DhcpSet_Prompt1_DNS2	DNS Server 2: 
+CMD_DhcpSet_Prompt_PUSHROUTE	Static routing table to push:
+CMD_DhcpSet_Prompt_OVPNGW	'vpn_gateway' parmeter for OpenVPN: 
 
 
 # DhcpTable コマンド

--- a/src/bin/hamcore/strtable_ko.stb
+++ b/src/bin/hamcore/strtable_ko.stb
@@ -1705,6 +1705,7 @@ DHCP_IP_ADDRESS 할당 IP
 DHCP_HOSTNAME 클라이언트 호스트 이름
 NM_PASSWORD_MSG 관리 암호를 설정했습니다.
 NM_PUSH_ROUTE_WARNING 지정된 정적 라우팅 테이블의 텍스트에 문법 오류가있을 수 있습니다.
+NM_PUSH_ROUTE_VPNGW_WARN	If you are using 'vpn_gateway' keyword as the IP address of the gateway in the static routing table, you must set its value also.
 
 
 # 정보 계
@@ -4219,8 +4220,10 @@ S2 VPN 클라이언트가 클래스없는 고정 경로 (RFC 3442)을 인식 할
 S3 가상 DHCP 서버 옵션에서 기본 게이트웨이를 공백으로 설정하여 분할 터널링이 가능합니다. L2TP/IPsec 및 MS-SSTP 클라이언트를 사용하는 경우에는 IPv4 설정 화면에서 기본 게이트웨이를 VPN 서버로 향하지 않도록 설정해야합니다.
 S4 로컬 브리지를 통해 외부에 DHCP 서버가있는 경우 해당 DHCP 서버에서 클래스없는 고정 경로 (RFC 3442)을 추진하도록 설정할 수도 있습니다. 이 경우 SecureNAT 가상 DHCP 서버 기능을 비활성화하십시오. 또한이 화면에서의 설정은 필요하지 않습니다.
 S5 밀어 정적 라우팅 테이블 편집
-S6 예:192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\n 여러 항목 (최대 64 개)은 쉼표 또는 공백으로 구분합니다. \r \n 각 항목은 "IP 네트워크 주소/서브넷 마스크/게이트웨이 IP 주소"형식으로 작성합니다.
+#S6 예:192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\n 여러 항목 (최대 64 개)은 쉼표 또는 공백으로 구분합니다. \r \n 각 항목은 "IP 네트워크 주소/서브넷 마스크/게이트웨이 IP 주소"형식으로 작성합니다.
+S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n    OR     192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway      for OpenVPN Connect\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format,\r\n   OR  you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients.
 S7 클래스없는 고정 경로 내용은 RFC 3442을 참조하십시오.
+S_VPN_GW				IP address of "vpn_gateway" for OpenVPN Connect
 IDOK & OK
 IDCANCEL 취소
 
@@ -4458,6 +4461,7 @@ CMD_KEYPAIR_FAILED 지정된 X.509 인증서 및 개인 키 조합은 유효하�
 CMD_CERT_NOT_EXISTS 인증서는 등록되어 있지 않습니다.
 CMD_NO_SETTINGS -
 CMD_DISCONNECTED_MSG \n --- 오류 --- \n \n 관리 호스트와의 통신 세션이 끊어졌습니다. 이 후 명령을 실행하면 오류가 발생합니다. \n \n 관리 호스트에 다시 연결하려면 EXIT를 입력하고 한 번 프롬프트에서 빠져 다시 연결하십시오. \n \n
+CMD_BOOL_EVAL_FAILED	The boolean value should be: YES  or NO
 
 
 # VPNCMD 명령
@@ -6137,6 +6141,7 @@ CMD_DhcpGet_Column_DNS DNS 서버 주소 1
 CMD_DhcpGet_Column_DNS2 DNS 서버 주소 2
 CMD_DhcpGet_Column_DOMAIN 도메인 이름
 CMD_DhcpGet_Column_PUSHROUTE 밀어 정적 라우팅 테이블
+CMD_DhcpGet_Column_OVPNGATEWAY	'vpn_gateway' value for OVPN
 
 
 # DhcpEnable 명령
@@ -6152,9 +6157,11 @@ CMD_DhcpDisable_Args DhcpDisable
 
 
 # DhcpSet 명령
-CMD_DhcpSet SecureNAT 기능의 가상 DHCP 서버 기능의 설정 변경
+#CMD_DhcpSet SecureNAT 기능의 가상 DHCP 서버 기능의 설정 변경
+CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function. Press <Enter> to keep a current value; type '' to clear it. 
 CMD_DhcpSet_Help 현재 관리하고있는 가상 HUB의 가상 DHCP 서버 설정을 변경합니다. 가상 DHCP 서버의 설정에는 배포 IP 주소 범위, 서브넷 마스크, 임대 기간 및 클라이언트에 할당 옵션 값이 포함됩니다. \n이 명령은 클러스터로 작동하는 VPN Server의 가상 HUB에서는 실행되지 않습니다.
-CMD_DhcpSet_Args DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2] [/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+#CMD_DhcpSet_Args DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2] [/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"] [/OVPNGW:ovpngwip] 
 CMD_DhcpSet_START 클라이언트에 배포 할 주소 범위의 시작점을 지정합니다. (예:192.168.30.10)
 CMD_DhcpSet_END 클라이언트에 배포 할 주소 범위의 끝점을 지정합니다. (예:192.168.30.200)
 CMD_DhcpSet_MASK 클라이언트에 지정 서브넷 마스크를 지정합니다. (예:255.255.255.0)
@@ -6164,7 +6171,9 @@ CMD_DhcpSet_DNS 클라이언트에 통지하는 DNS 서버 (주)의 IP 주소를
 CMD_DhcpSet_DNS2 클라이언트에 통지하는 DNS 서버 (보조)의 IP 주소를 지정합니다. SecureNAT 기능의 가상 NAT 기능과 함께 사용하여 사용하는 경우 SecureNAT 가상 호스트의 IP 주소를 지정할 수도 있습니다. 0 또는 none을 지정하면 DNS 서버 주소를 클라이언트에 통지하지 않습니다.
 CMD_DhcpSet_DOMAIN 클라이언트에 통지하는 도메인 이름을 지정합니다. none을 지정하면 도메인 이름을 클라이언트에게 통지하지 않습니다.
 CMD_DhcpSet_LOG 가상 DHCP 서버의 동작을 가상 HUB의 보안 로그에 저장할지 여부를 지정합니다. "yes"를 지정하면 저장합니다. 이 값은 가상 NAT 기능의 로그 저장 설정과 함께하고 있습니다.
-CMD_DhcpSet_PUSHROUTE 밀어 정적 라우팅 테이블을 지정합니다. \n 예:"192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n 여러 항목 (최대 64 개)은 쉼표 또는 공백으로 구분합니다. 각 항목은 "IP 네트워크 주소/서브넷 마스크/게이트웨이 IP 주소"형식으로 작성합니다. \nVPN 클라이언트에이 가상 DHCP 서버에서 DHCP 응답을 보낼 때, 클래스없는 고정 경로 (RFC 3442)을 함께 보낼 수 있습니다. \nVPN 클라이언트가 클래스없는 고정 경로 (RFC 3442)을 인식 할 수 있는지 여부는 VPN 클라이언트 소프트웨어에 따라 다릅니다. SoftEther VPN Client 및 OpenVPN Client는 클래스없는 고정 경로에 해당합니다. L2TP/IPsec 및 MS-SSTP에서는 이용 여부는 클라이언트 소프트웨어에 따라 달라집니다. \n 가상 DHCP 서버 옵션에서 기본 게이트웨이를 공백으로 설정하여 분할 터널링이 가능합니다. L2TP/IPsec 및 MS-SSTP 클라이언트를 사용하는 경우에는 IPv4 설정 화면에서 기본 게이트웨이를 VPN 서버로 향하지 않도록 설정해야합니다. \n 로컬 브리지를 통해 외부에 DHCP 서버가있는 경우 해당 DHCP 서버에서 클래스없는 고정 경로 (RFC 3442)을 추진하도록 설정할 수도 있습니다. 이 경우 SecureNAT 가상 DHCP 서버 기능을 비활성화하십시오. 또한이 명령의 설정은 필요하지 않습니다. \n 클래스없는 고정 경로 내용은 RFC 3442을 참조하십시오.
+#CMD_DhcpSet_PUSHROUTE 밀어 정적 라우팅 테이블을 지정합니다. \n 예:"192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n 여러 항목 (최대 64 개)은 쉼표 또는 공백으로 구분합니다. 각 항목은 "IP 네트워크 주소/서브넷 마스크/게이트웨이 IP 주소"형식으로 작성합니다. \nVPN 클라이언트에이 가상 DHCP 서버에서 DHCP 응답을 보낼 때, 클래스없는 고정 경로 (RFC 3442)을 함께 보낼 수 있습니다. \nVPN 클라이언트가 클래스없는 고정 경로 (RFC 3442)을 인식 할 수 있는지 여부는 VPN 클라이언트 소프트웨어에 따라 다릅니다. SoftEther VPN Client 및 OpenVPN Client는 클래스없는 고정 경로에 해당합니다. L2TP/IPsec 및 MS-SSTP에서는 이용 여부는 클라이언트 소프트웨어에 따라 달라집니다. \n 가상 DHCP 서버 옵션에서 기본 게이트웨이를 공백으로 설정하여 분할 터널링이 가능합니다. L2TP/IPsec 및 MS-SSTP 클라이언트를 사용하는 경우에는 IPv4 설정 화면에서 기본 게이트웨이를 VPN 서버로 향하지 않도록 설정해야합니다. \n 로컬 브리지를 통해 외부에 DHCP 서버가있는 경우 해당 DHCP 서버에서 클래스없는 고정 경로 (RFC 3442)을 추진하도록 설정할 수도 있습니다. 이 경우 SecureNAT 가상 DHCP 서버 기능을 비활성화하십시오. 또한이 명령의 설정은 필요하지 않습니다. \n 클래스없는 고정 경로 내용은 RFC 3442을 참조하십시오.
+CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n  OR   "192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway"  for OpenVPN clients\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format, OR you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_OVPNGW			Specify the IP address of 'vpn_gateway' parameter to be notified to the client. If you specify 0 or none, then the client will not be notified of the vpn_gateway value. If you use the 'vpn_gateway' keyword in the classless static routing table, you must specify this value also.
 CMD_DhcpSet_Prompt_START 배포 할 주소 범위의 시작점:
 CMD_DhcpSet_Prompt_END 배포 할 주소 범위의 끝:
 CMD_DhcpSet_Prompt_MASK 서브넷 마스크:
@@ -6173,6 +6182,11 @@ CMD_DhcpSet_Prompt_GW 기본 게이트웨이 (미 설정 가능):
 CMD_DhcpSet_Prompt_DNS DNS 서버 1 (미 설정 가능):
 CMD_DhcpSet_Prompt_DNS2 DNS 서버 2 (미 설정 가능):
 CMD_DhcpSet_Prompt_DOMAIN 도메인 이름:
+CMD_DhcpSet_Prompt1_GW		Default Gateway: 
+CMD_DhcpSet_Prompt1_DNS		DNS Server 1: 
+CMD_DhcpSet_Prompt1_DNS2	DNS Server 2: 
+CMD_DhcpSet_Prompt_PUSHROUTE	Static routing table to push:
+CMD_DhcpSet_Prompt_OVPNGW	'vpn_gateway' parmeter for OpenVPN: 
 
 
 # DhcpTable 명령

--- a/src/bin/hamcore/strtable_pt_br.stb
+++ b/src/bin/hamcore/strtable_pt_br.stb
@@ -1718,6 +1718,7 @@ DHCP_IP_ADDRESS	IP alocado
 DHCP_HOSTNAME	Nome do Host do Cliente
 NM_PASSWORD_MSG	The administration password has been set.
 NM_PUSH_ROUTE_WARNING	The specified text of the static routing table may have a syntax error.
+NM_PUSH_ROUTE_VPNGW_WARN	If you are using 'vpn_gateway' keyword as the IP address of the gateway in the static routing table, you must set its value also.
 
 
 # Concerning version information
@@ -3951,8 +3952,10 @@ S2	Whether or not a VPN client can recognize the classless static routes (RFC 34
 S3	You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.
 S4	You can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this screen.
 S5	Edit the static routing table to push
-S6	Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format.
+#S6	Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format.
+S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n    OR     192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway      for OpenVPN Connect\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format,\r\n   OR  you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients.
 S7	See the RFC 3442 to understand the classless routes.
+S_VPN_GW				IP address of "vpn_gateway" for OpenVPN Connect
 IDOK	&OK
 IDCANCEL	Cancelar
 
@@ -4192,6 +4195,7 @@ CMD_KEYPAIR_FAILED	The X.509 certificate and private key combination has been in
 CMD_CERT_NOT_EXISTS	The certificate is not registered.
 CMD_NO_SETTINGS	-
 CMD_DISCONNECTED_MSG	\n--- Error ---\n\nThe communication session with the host you were managing has been disconnected. From now on, if you run any commands an error will occur. \n\nTo reconnect to the host you were managing, first leave the prompt by inputting "EXIT" and then reconnect. \n\n
+CMD_BOOL_EVAL_FAILED	The boolean value should be: YES  or NO
 
 
 # VPNCMD ã‚³ãƒžãƒ³ãƒ‰
@@ -5881,6 +5885,7 @@ CMD_DhcpGet_Column_DNS	DNS Server Address 1
 CMD_DhcpGet_Column_DNS2	DNS Server Address 2
 CMD_DhcpGet_Column_DOMAIN	Nome do domínio
 CMD_DhcpGet_Column_PUSHROUTE	Static Routing Table to Push
+CMD_DhcpGet_Column_OVPNGATEWAY	'vpn_gateway' value for OVPN
 
 
 # DhcpEnable command
@@ -5896,9 +5901,11 @@ CMD_DhcpDisable_Args	DhcpDisable
 
 
 # DhcpSet command
-CMD_DhcpSet	Change Virtual DHCP Server Function Setting of SecureNAT Function
+#CMD_DhcpSet	Change Virtual DHCP Server Function Setting of SecureNAT Function
+CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function. Press <Enter> to keep a current value; type '' to clear it. 
 CMD_DhcpSet_Help	Use this to change the Virtual DHCP Server setting of the currently managed Virtual Hub. The Virtual DHCP Server settings include the following items: distribution address band, subnet mask, lease limit, and option values assigned to clients. \nYou cannot execute this command for Virtual Hubs of VPN Servers operating as a cluster.
-CMD_DhcpSet_Args	DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+#CMD_DhcpSet_Args	DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"] [/OVPNGW:ovpngwip] 
 CMD_DhcpSet_START	Specify the start point of the address band to be distributed to the client. (Example: 192.168.30.10)
 CMD_DhcpSet_END	Specify the end point of the address band to be distributed to the client. (Example: 192.168.30.200)
 CMD_DhcpSet_MASK	Specify the subnet mask to be specified for the client. (Example: 255.255.255.0)
@@ -5908,7 +5915,9 @@ CMD_DhcpSet_DNS	Specify the IP address of the primary DNS Server to be notified 
 CMD_DhcpSet_DNS2	Specify the IP address of the secondary DNS Server to be notified to the client. You can specify a SecureNAT Virtual Host IP address for this when the SecureNAT Function's Virtual NAT Function has been enabled and is being used also. If you specify 0 or none, then the client will not be notified of the DNS Server address.
 CMD_DhcpSet_DOMAIN	Specify the domain name to be notified to the client. If you specify none, then the client will not be notified of the domain name.
 CMD_DhcpSet_LOG	Specify whether or not to save the Virtual DHCP Server operation in the Virtual Hub security log. Specify "yes" to save it. This value is interlinked with the Virtual NAT Function log save setting.
-CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format.\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+#CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format.\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n  OR   "192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway"  for OpenVPN clients\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format, OR you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_OVPNGW			Specify the IP address of 'vpn_gateway' parameter to be notified to the client. If you specify 0 or none, then the client will not be notified of the vpn_gateway value. If you use the 'vpn_gateway' keyword in the classless static routing table, you must specify this value also.
 CMD_DhcpSet_Prompt_START	Start Point for Distributed Address Band: 
 CMD_DhcpSet_Prompt_END	End Point for Distributed Address Band: 
 CMD_DhcpSet_Prompt_MASK	Máscara de sub-rede: 
@@ -5917,6 +5926,11 @@ CMD_DhcpSet_Prompt_GW	Default Gateway ('none' to not set this):
 CMD_DhcpSet_Prompt_DNS	DNS Server 1 ('none' to not set this): 
 CMD_DhcpSet_Prompt_DNS2	DNS Server 2 ('none' to not set this): 
 CMD_DhcpSet_Prompt_DOMAIN	Nome do domínio: 
+CMD_DhcpSet_Prompt1_GW		Default Gateway: 
+CMD_DhcpSet_Prompt1_DNS		DNS Server 1: 
+CMD_DhcpSet_Prompt1_DNS2	DNS Server 2: 
+CMD_DhcpSet_Prompt_PUSHROUTE	Static routing table to push:
+CMD_DhcpSet_Prompt_OVPNGW	'vpn_gateway' parmeter for OpenVPN: 
 
 
 # DhcpTable command

--- a/src/bin/hamcore/strtable_ru.stb
+++ b/src/bin/hamcore/strtable_ru.stb
@@ -1722,6 +1722,7 @@ DHCP_IP_ADDRESS			Выделенный IP
 DHCP_HOSTNAME			Имя хоста клиента
 NM_PASSWORD_MSG			Пароль администратора установлен.
 NM_PUSH_ROUTE_WARNING	В указанном тексте статической таблицы маршрутизации может быть синтаксическая ошибка.
+NM_PUSH_ROUTE_VPNGW_WARN	If you are using 'vpn_gateway' keyword as the IP address of the gateway in the static routing table, you must set its value also.
 
 
 # Concerning version information
@@ -4236,8 +4237,10 @@ S2						Сможет ли VPN клиент распознавать бескла
 S3						Вы можете реализовать разделение маршрутов, если очистите поле "шлюза по умолчанию" в настройках виртуального DHCP-сервера. L2TP/IPsec и MS-SSTP на стороне клиента должны быть настроены так, чтобы они не устанавливали шлюз по умолчанию.
 S4						Вы также можете передать бесклассовые статические маршруты (RFC 3442) с помощью существующего внешнего DHCP-сервера. В этом случае отключите виртуальный DHCP-сервер в SecureNAT и не настраивайте бесклассовые маршруты на этом экране.
 S5						Редактирование статической таблицы маршрутизации
-S6						Пример: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\nРазделяйте несколько записей (максимум: 64) запятыми или пробелами.\r\nКаждая запись должна быть указана в формате "IP-адрес сети/маска подсети/IP-адрес шлюза".
+#S6						Пример: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\nРазделяйте несколько записей (максимум: 64) запятыми или пробелами.\r\nКаждая запись должна быть указана в формате "IP-адрес сети/маска подсети/IP-адрес шлюза".
+S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n    OR     192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway      for OpenVPN Connect\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format,\r\n   OR  you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients.
 S7						См. RFC 3442, чтобы понять бесклассовые маршруты.
+S_VPN_GW				IP address of "vpn_gateway" for OpenVPN Connect
 IDOK					&OK
 IDCANCEL				Отмена
 
@@ -4479,6 +4482,7 @@ CMD_KEYPAIR_FAILED		The X.509 certificate and private key combination has been i
 CMD_CERT_NOT_EXISTS		The certificate is not registered.
 CMD_NO_SETTINGS			-
 CMD_DISCONNECTED_MSG	\n--- Error ---\n\nThe communication session with the host you were managing has been disconnected. From now on, if you run any commands an error will occur. \n\nTo reconnect to the host you were managing, first leave the prompt by inputting "EXIT" and then reconnect. \n\n
+CMD_BOOL_EVAL_FAILED	The boolean value should be: YES  or NO
 
 
 # VPNCMD コマンド
@@ -6155,6 +6159,7 @@ CMD_DhcpGet_Column_DNS	DNS Server Address 1
 CMD_DhcpGet_Column_DNS2	DNS Server Address 2
 CMD_DhcpGet_Column_DOMAIN	Domain Name
 CMD_DhcpGet_Column_PUSHROUTE	Static Routing Table to Push
+CMD_DhcpGet_Column_OVPNGATEWAY	'vpn_gateway' value for OVPN
 
 
 # DhcpEnable command
@@ -6170,9 +6175,11 @@ CMD_DhcpDisable_Args	DhcpDisable
 
 
 # DhcpSet command
-CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function
+#CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function
+CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function. Press <Enter> to keep a current value; type '' to clear it. 
 CMD_DhcpSet_Help		Use this to change the Virtual DHCP Server setting of the currently managed Virtual Hub. The Virtual DHCP Server settings include the following items: distribution address band, subnet mask, lease limit, and option values assigned to clients. \nYou cannot execute this command for Virtual Hubs of VPN Servers operating as a cluster.
-CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+#CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"] [/OVPNGW:ovpngwip] 
 CMD_DhcpSet_START		Specify the start point of the address band to be distributed to the client. (Example: 192.168.30.10)
 CMD_DhcpSet_END			Specify the end point of the address band to be distributed to the client. (Example: 192.168.30.200)
 CMD_DhcpSet_MASK		Specify the subnet mask to be specified for the client. (Example: 255.255.255.0)
@@ -6182,7 +6189,9 @@ CMD_DhcpSet_DNS			Specify the IP address of the primary DNS Server to be notifie
 CMD_DhcpSet_DNS2		Specify the IP address of the secondary DNS Server to be notified to the client. You can specify a SecureNAT Virtual Host IP address for this when the SecureNAT Function's Virtual NAT Function has been enabled and is being used also. If you specify 0 or none, then the client will not be notified of the DNS Server address.
 CMD_DhcpSet_DOMAIN		Specify the domain name to be notified to the client. If you specify none, then the client will not be notified of the domain name.
 CMD_DhcpSet_LOG			Specify whether or not to save the Virtual DHCP Server operation in the Virtual Hub security log. Specify "yes" to save it. This value is interlinked with the Virtual NAT Function log save setting.
-CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format.\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+#CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format.\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n  OR   "192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway"  for OpenVPN clients\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format, OR you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_OVPNGW			Specify the IP address of 'vpn_gateway' parameter to be notified to the client. If you specify 0 or none, then the client will not be notified of the vpn_gateway value. If you use the 'vpn_gateway' keyword in the classless static routing table, you must specify this value also.
 CMD_DhcpSet_Prompt_START	Start Point for Distributed Address Band: 
 CMD_DhcpSet_Prompt_END		End Point for Distributed Address Band: 
 CMD_DhcpSet_Prompt_MASK		Subnet Mask: 
@@ -6191,6 +6200,11 @@ CMD_DhcpSet_Prompt_GW		Default Gateway ('none' to not set this):
 CMD_DhcpSet_Prompt_DNS		DNS Server 1 ('none' to not set this): 
 CMD_DhcpSet_Prompt_DNS2		DNS Server 2 ('none' to not set this): 
 CMD_DhcpSet_Prompt_DOMAIN	Domain Name: 
+CMD_DhcpSet_Prompt1_GW		Default Gateway: 
+CMD_DhcpSet_Prompt1_DNS		DNS Server 1: 
+CMD_DhcpSet_Prompt1_DNS2	DNS Server 2: 
+CMD_DhcpSet_Prompt_PUSHROUTE	Static routing table to push:
+CMD_DhcpSet_Prompt_OVPNGW	'vpn_gateway' parmeter for OpenVPN: 
 
 
 # DhcpTable command

--- a/src/bin/hamcore/strtable_tr.stb
+++ b/src/bin/hamcore/strtable_tr.stb
@@ -1722,6 +1722,7 @@ DHCP_IP_ADDRESS			Tahsis Edilen IP
 DHCP_HOSTNAME			İstemci Ana Bilgisayar Adı
 NM_PASSWORD_MSG			Yönetim parolası belirlenmiştir.
 NM_PUSH_ROUTE_WARNING	Statik yönlendirme tablosunun belirtilen metninde bir sözdizimi hatası olabilir.
+NM_PUSH_ROUTE_VPNGW_WARN	If you are using 'vpn_gateway' keyword as the IP address of the gateway in the static routing table, you must set its value also.
 
 
 # Concerning version information
@@ -4236,8 +4237,10 @@ S2						Bir VPN istemcisinin sınıfsız statik rotaları (RFC 3442) tanıyıp t
 S3						Sanal DHCP Sunucusu seçeneklerindeki varsayılan ağ geçidi alanını temizlerseniz bölünmüş tünellemeyi gerçekleştirebilirsiniz. İstemci tarafında, L2TP/IPsec ve MS-SSTP istemcilerinin bölünmüş tünelleme kullanımı için varsayılan ağ geçidini ayarlamayacak şekilde yapılandırılması gerekir.
 S4						Sınıfsız statik rotaları (RFC 3442) mevcut harici DHCP sunucunuz tarafından da gönderebilirsiniz. Bu durumda, SecureNAT üzerindeki Sanal DHCP Sunucusu işlevini devre dışı bırakın ve bu ekranda sınıfsız rotaları ayarlamanıza gerek yoktur.
 S5						Statik yönlendirme tablosunu itmek için düzenleyin
-S6						Örnek: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\nBirden fazla girişi (maksimum: 64 giriş) virgül veya boşluk karakterleriyle bölün.\r\nHer giriş "IP ağ adresi/alt ağ maskesi/ağ geçidi IP adresi" biçiminde belirtilmelidir.
+#S6						Örnek: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\nBirden fazla girişi (maksimum: 64 giriş) virgül veya boşluk karakterleriyle bölün.\r\nHer giriş "IP ağ adresi/alt ağ maskesi/ağ geçidi IP adresi" biçiminde belirtilmelidir.
+S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n    OR     192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway      for OpenVPN Connect\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format,\r\n   OR  you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients.
 S7						Sınıfsız rotaları anlamak için RFC 3442'ye bakın.
+S_VPN_GW			IP address of "vpn_gateway" for OpenVPN Connect
 IDOK					&TAMAM
 IDCANCEL				İptal
 
@@ -4479,6 +4482,7 @@ CMD_KEYPAIR_FAILED		X.509 sertifikası ve özel anahtar kombinasyonu yanlış be
 CMD_CERT_NOT_EXISTS		Sertifika kayıtlı değildir.
 CMD_NO_SETTINGS			-
 CMD_DISCONNECTED_MSG	\n--- Hata ---\n\nYönetmekte olduğunuz ana bilgisayar ile iletişim oturumu kesildi. Şu andan itibaren, herhangi bir komut çalıştırırsanız bir hata oluşacaktır. \n\nYönetmekte olduğunuz ana bilgisayara yeniden bağlanmak için, önce "EXIT" yazarak istemden çıkın ve ardından yeniden bağlanın. \n\n
+CMD_BOOL_EVAL_FAILED	The boolean value should be: YES  or NO
 
 
 # VPNCMD コマンド
@@ -6155,6 +6159,7 @@ CMD_DhcpGet_Column_DNS	DNS Sunucu Adresi 1
 CMD_DhcpGet_Column_DNS2	DNS Sunucu Adresi 2
 CMD_DhcpGet_Column_DOMAIN	Alan Adı
 CMD_DhcpGet_Column_PUSHROUTE	İtmek için Statik Yönlendirme Tablosu
+CMD_DhcpGet_Column_OVPNGATEWAY	'vpn_gateway' value for OVPN
 
 
 # DhcpEnable command
@@ -6170,9 +6175,11 @@ CMD_DhcpDisable_Args	DhcpDisable
 
 
 # DhcpSet command
-CMD_DhcpSet				SecureNAT İşlevinin Sanal DHCP Sunucusu İşlev Ayarını Değiştirme
+#CMD_DhcpSet				SecureNAT İşlevinin Sanal DHCP Sunucusu İşlev Ayarını Değiştirme
+CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function. Press <Enter> to keep a current value; type '' to clear it. 
 CMD_DhcpSet_Help		Yönetilmekte olan Sanal Hub'ın Sanal DHCP Sunucusu ayarını değiştirmek için bunu kullanın. Sanal DHCP Sunucusu ayarları aşağıdaki öğeleri içerir: dağıtım adres bandı, alt ağ maskesi, kiralama sınırı ve istemcilere atanan seçenek değerleri. \nBu komutu bir küme olarak çalışan VPN Sunucularının Sanal Merkezleri için çalıştıramazsınız.
-CMD_DhcpSet_Args		DhcpSet [/START:başlangıç_ip] [/END:bitiş_ip] [/MASK:alt_ağ_maskesi] [/EXPIRE:saniye] [/GW:ağ_geçidi_ip] [/DNS:dns] [/DNS2:dns2] [/DOMAIN:etki_alanı] [/LOG:yes|no] [/PUSHROUTE:"yönlendirme_tablosu"]
+#CMD_DhcpSet_Args		DhcpSet [/START:başlangıç_ip] [/END:bitiş_ip] [/MASK:alt_ağ_maskesi] [/EXPIRE:saniye] [/GW:ağ_geçidi_ip] [/DNS:dns] [/DNS2:dns2] [/DOMAIN:etki_alanı] [/LOG:yes|no] [/PUSHROUTE:"yönlendirme_tablosu"]
+CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"] [/OVPNGW:ovpngwip] 
 CMD_DhcpSet_START		İstemciye dağıtılacak adres bandının başlangıç noktasını belirtin. (Örnek: 192.168.30.10)
 CMD_DhcpSet_END			İstemciye dağıtılacak adres bandının uç noktasını belirtin. (Örnek: 192.168.30.200)
 CMD_DhcpSet_MASK		İstemci için belirtilecek alt ağ maskesini belirtin. (Örnek: 255.255.255.0)
@@ -6182,7 +6189,9 @@ CMD_DhcpSet_DNS			İstemciye bildirilecek birincil DNS Sunucusunun IP adresini b
 CMD_DhcpSet_DNS2		İstemciye bildirilecek ikincil DNS Sunucusunun IP adresini belirtin. SecureNAT İşlevinin Sanal NAT İşlevi etkinleştirildiğinde ve kullanıldığında bunun için bir SecureNAT Sanal Ana Bilgisayar IP adresi belirtebilirsiniz. Eğer 0 veya hiçbiri olarak belirtirseniz, istemciye DNS Sunucusu adresi bildirilmeyecektir.
 CMD_DhcpSet_DOMAIN		İstemciye bildirilecek alan adını belirtin. Hiçbiri olarak belirtirseniz, istemciye alan adı bildirilmez.
 CMD_DhcpSet_LOG			Sanal DHCP Sunucusu işleminin Sanal Hub güvenlik günlüğüne kaydedilip kaydedilmeyeceğini belirtin. Kaydetmek için "evet" olarak belirtin. Bu değer Sanal NAT İşlevi günlük kaydetme ayarı ile bağlantılıdır.
-CMD_DhcpSet_PUSHROUTE	Gönderilecek statik yönlendirme tablosunu belirtin.\nÖrnek: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\nBirden fazla girişi (maksimum: 64 giriş) virgül veya boşluk karakterleriyle bölün. Her giriş "IP ağ adresi/alt ağ maskesi/ağ geçidi IP adresi" biçiminde belirtilmelidir.\nBu Sanal DHCP Sunucusu, VPN istemcilerine DHCP yanıt mesajlarıyla sınıfsız statik rotaları (RFC 3442) gönderebilir.\nBir VPN istemcisinin sınıfsız statik rotaları (RFC 3442) tanıyıp tanımayacağı hedef VPN istemci yazılımına bağlıdır. SoftEther VPN İstemcisi ve OpenVPN İstemcisi sınıfsız statik rotaları desteklemektedir. L2TP/IPsec ve MS-SSTP protokollerinde, uyumluluk istemci yazılımının uygulanmasına bağlıdır. Sanal DHCP Sunucusu seçeneklerindeki varsayılan ağ geçidi alanını temizlerseniz bölünmüş tünellemeyi gerçekleştirebilirsiniz. İstemci tarafında, L2TP/IPsec ve MS-SSTP istemcilerinin bölünmüş tünelleme kullanımı için varsayılan ağ geçidini ayarlamayacak şekilde yapılandırılması gerekir.\nSınıfsız statik rotaları (RFC 3442) mevcut harici DHCP sunucunuz tarafından da gönderebilirsiniz. Bu durumda, SecureNAT üzerindeki Sanal DHCP Sunucusu işlevini devre dışı bırakın ve bu komutta sınıfsız rotaları ayarlamanıza gerek yoktur.\nSınıfsız rotaları anlamak için RFC 3442'ye bakın.
+#CMD_DhcpSet_PUSHROUTE	Gönderilecek statik yönlendirme tablosunu belirtin.\nÖrnek: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\nBirden fazla girişi (maksimum: 64 giriş) virgül veya boşluk karakterleriyle bölün. Her giriş "IP ağ adresi/alt ağ maskesi/ağ geçidi IP adresi" biçiminde belirtilmelidir.\nBu Sanal DHCP Sunucusu, VPN istemcilerine DHCP yanıt mesajlarıyla sınıfsız statik rotaları (RFC 3442) gönderebilir.\nBir VPN istemcisinin sınıfsız statik rotaları (RFC 3442) tanıyıp tanımayacağı hedef VPN istemci yazılımına bağlıdır. SoftEther VPN İstemcisi ve OpenVPN İstemcisi sınıfsız statik rotaları desteklemektedir. L2TP/IPsec ve MS-SSTP protokollerinde, uyumluluk istemci yazılımının uygulanmasına bağlıdır. Sanal DHCP Sunucusu seçeneklerindeki varsayılan ağ geçidi alanını temizlerseniz bölünmüş tünellemeyi gerçekleştirebilirsiniz. İstemci tarafında, L2TP/IPsec ve MS-SSTP istemcilerinin bölünmüş tünelleme kullanımı için varsayılan ağ geçidini ayarlamayacak şekilde yapılandırılması gerekir.\nSınıfsız statik rotaları (RFC 3442) mevcut harici DHCP sunucunuz tarafından da gönderebilirsiniz. Bu durumda, SecureNAT üzerindeki Sanal DHCP Sunucusu işlevini devre dışı bırakın ve bu komutta sınıfsız rotaları ayarlamanıza gerek yoktur.\nSınıfsız rotaları anlamak için RFC 3442'ye bakın.
+CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n  OR   "192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway"  for OpenVPN clients\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format, OR you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_OVPNGW			Specify the IP address of 'vpn_gateway' parameter to be notified to the client. If you specify 0 or none, then the client will not be notified of the vpn_gateway value. If you use the 'vpn_gateway' keyword in the classless static routing table, you must specify this value also.
 CMD_DhcpSet_Prompt_START	Dağıtılmış Adres Bandı için Başlangıç Noktası:
 CMD_DhcpSet_Prompt_END		Dağıtılmış Adres Bandı için Bitiş Noktası:
 CMD_DhcpSet_Prompt_MASK		Alt Ağ Maskesi:
@@ -6191,6 +6200,11 @@ CMD_DhcpSet_Prompt_GW		Varsayılan Ağ Geçidi (bunu ayarlamamak için 'yok'):
 CMD_DhcpSet_Prompt_DNS		DNS Sunucusu 1 (bunu ayarlamamak için 'yok'):
 CMD_DhcpSet_Prompt_DNS2		DNS Sunucusu 2 (bunu ayarlamamak için 'yok'):
 CMD_DhcpSet_Prompt_DOMAIN	Alan Adı:
+CMD_DhcpSet_Prompt1_GW		Default Gateway: 
+CMD_DhcpSet_Prompt1_DNS		DNS Server 1: 
+CMD_DhcpSet_Prompt1_DNS2	DNS Server 2: 
+CMD_DhcpSet_Prompt_PUSHROUTE	Static routing table to push:
+CMD_DhcpSet_Prompt_OVPNGW	'vpn_gateway' parmeter for OpenVPN: 
 
 
 # DhcpTable command

--- a/src/bin/hamcore/strtable_tw.stb
+++ b/src/bin/hamcore/strtable_tw.stb
@@ -1739,6 +1739,7 @@ DHCP_IP_ADDRESS			分配的 IP
 DHCP_HOSTNAME			用戶端主機名稱
 NM_PASSWORD_MSG			管理員密碼設定完成。
 NM_PUSH_ROUTE_WARNING	靜態路由表中指定的文本可能有語法錯誤。
+NM_PUSH_ROUTE_VPNGW_WARN	If you are using 'vpn_gateway' keyword as the IP address of the gateway in the static routing table, you must set its value also.
 
 
 #關於版本資訊
@@ -4249,8 +4250,10 @@ S2						VPN 用戶端是否能夠識別無類靜態路由 (RFC 3442) 取決於�
 S3						如果你清除了虛擬 DHCP 伺服器選項的預設閘道器欄位，您就可以實現拆分隧道。在用戶端一側，為了使用拆分隧道， L2TP/IPSec 和 MS-SSTP 用戶端需要配置為不創建預設閘道器。
 S4						您還可以通過現有的外部 DHCP 伺服器推送無類靜態路由 (RFC 3442)。在這種情況下，在 SecureNAT 禁用虛擬 DHCP 伺服器功能，在這一螢幕上你不需要設置無類路由。
 S5						編輯該靜態路由表以推送
-S6						例如: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\n用逗號或空格字元來拆分多條目 (最多 64 條目)。\r\n每個條目必須以 "IP 網路位址 / 子網路遮罩 / 閘道 IP 地址" 的格式來指定。
+#S6						例如: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n\r\n用逗號或空格字元來拆分多條目 (最多 64 條目)。\r\n每個條目必須以 "IP 網路位址 / 子網路遮罩 / 閘道 IP 地址" 的格式來指定。
+S6						Example: 192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253\r\n    OR     192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway      for OpenVPN Connect\r\nSplit multiple entries (maximum: 64 entries) by comma or space characters.\r\nEach entry must be specified in the "IP network address/subnet mask/gateway IP address" format,\r\n   OR  you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients.
 S7						請參閱 RFC3442 以瞭解無類路由。
+S_VPN_GW				IP address of "vpn_gateway" for OpenVPN Connect
 IDOK					確定(&O)
 IDCANCEL				取消
 
@@ -4492,6 +4495,7 @@ CMD_KEYPAIR_FAILED			X.509 證書和私密金鑰的組合指定不正確。證�
 CMD_CERT_NOT_EXISTS			證書未登記。
 CMD_NO_SETTINGS				－
 CMD_DISCONNECTED_MSG		\n---Error---\n\n與您正管理的主機通信會話被中斷了。從現在開始，如果您運行任何命令將出現錯誤。\n\n為了重新連接到您管理的主機，首先輸入 "EXIT" 的離開本提示，然後重新連接。\n\n
+CMD_BOOL_EVAL_FAILED	The boolean value should be: YES  or NO
 
 
 # VPN CMD 命令
@@ -6172,6 +6176,7 @@ CMD_DhcpGet_Column_DNS		DNS 伺服器地址 1
 CMD_DhcpGet_Column_DNS2		DNS 伺服器地址 2
 CMD_DhcpGet_Column_DOMAIN	功能變數名稱
 CMD_DhcpGet_Column_PUSHROUTE	靜態路由表推送
+CMD_DhcpGet_Column_OVPNGATEWAY	'vpn_gateway' value for OVPN
 
 
 # DhcpEnable 命令
@@ -6187,9 +6192,11 @@ CMD_DhcpDisable_Args		DhcpDisable
 
 
 # DhcpSet 命令
-CMD_DhcpSet					更改安全網路功能的虛擬 DHCP 伺服器功能的設置
+#CMD_DhcpSet					更改安全網路功能的虛擬 DHCP 伺服器功能的設置
+CMD_DhcpSet				Change Virtual DHCP Server Function Setting of SecureNAT Function. Press <Enter> to keep a current value; type '' to clear it. 
 CMD_DhcpSet_Help			在現在管理的虛擬 HUB 內，更改虛擬 DHCP 伺服器的設置。虛擬 DHCP 伺服器設置包括: 分配 IP 地址範圍，子網路遮罩，出租期限，及分配給用戶端的選項值。\n該指令在作為進群操作的 VPN Server 的虛擬伺服器上不能執行。
-CMD_DhcpSet_Args			DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2] [/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+#CMD_DhcpSet_Args			DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2] [/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"]
+CMD_DhcpSet_Args		DhcpSet [/START:start_ip] [/END:end_ip] [/MASK:subnetmask] [/EXPIRE:sec] [/GW:gwip] [/DNS:dns] [/DNS2:dns2][/DOMAIN:domain] [/LOG:yes|no] [/PUSHROUTE:"routing_table"] [/OVPNGW:ovpngwip] 
 CMD_DhcpSet_START			指定地址範圍的開始點，以分發給客戶。(例如: 192.168.30.10)
 CMD_DhcpSet_END				指定地址範圍的結束點，以分發給客戶。(例如: 192.168.30.200)
 CMD_DhcpSet_MASK			指定對客戶指定的子網路遮罩。(例如: 255.255.255.0)
@@ -6199,7 +6206,9 @@ CMD_DhcpSet_DNS				指定被通知到用戶端的主 DNS 伺服器的 IP 地址�
 CMD_DhcpSet_DNS2			指定被通知到用戶端的次要 DNS 伺服器 IP 地址。當 SecureNAT 功能的虛擬 NAT 功能已經啟用並正在運行時，您可以為此指定一個 SecureNAT 虛擬主機 IP 位址。如果您指定的是 0 或者 none，那麼用戶端就不會被 DNS 伺服器地址通知。
 CMD_DhcpSet_DOMAIN			指定功能變數名稱通知客戶。如果指定 none，該功能變數名稱不通知客戶。
 CMD_DhcpSet_LOG				指定是否將虛擬 DHCP 伺服器運行保存為安全性記錄檔。指定 "yes" 則保存。此值與虛擬 NAT 功能的日誌保存設置是聯動的。
-CMD_DhcpSet_PUSHROUTE	指定靜態路由表推送。\n例如: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n用逗號或空格字元來拆分多條目 (最多 64 條目)。每個條目必須以 "IP 網路位址/子網路遮罩/閘道 IP 地址" 的格式來指定。 \n這個虛擬 DHCP 伺服器可以推送帶DHCP應答消息的無類靜態路由 (RFC 3442) 至 VPN 用戶端。\nVPN 用戶端是否能夠識別無類靜態路由 (RFC 3442) 取決於目標VPN用戶端軟體。SoftEther VPN 用戶端和 OpenVPN 用戶端都支援無類靜態路由。在 L2TP/IPSec 和 MS-SSTP 協議上，相容性取決於用戶端軟體的實施。如果你清除了虛擬 DHCP 伺服器選項的預設閘道器欄位，您就可以實現拆分隧道。在用戶端一側，為了使用拆分隧道，L2TP/IPSec 和 MS-SSTP 用戶端需要配置為不創建預設閘道器。\n您還可以通過現有的外部 DHCP 伺服器推送無類靜態路由 (RFC 3442)。在這種情況下，在 SecureNAT 禁用虛擬 DHCP 伺服器功能，在這一螢幕上你不需要設置無類路由。\n請參閱 RFC 3442 以瞭解無類路由。
+#CMD_DhcpSet_PUSHROUTE	指定靜態路由表推送。\n例如: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n用逗號或空格字元來拆分多條目 (最多 64 條目)。每個條目必須以 "IP 網路位址/子網路遮罩/閘道 IP 地址" 的格式來指定。 \n這個虛擬 DHCP 伺服器可以推送帶DHCP應答消息的無類靜態路由 (RFC 3442) 至 VPN 用戶端。\nVPN 用戶端是否能夠識別無類靜態路由 (RFC 3442) 取決於目標VPN用戶端軟體。SoftEther VPN 用戶端和 OpenVPN 用戶端都支援無類靜態路由。在 L2TP/IPSec 和 MS-SSTP 協議上，相容性取決於用戶端軟體的實施。如果你清除了虛擬 DHCP 伺服器選項的預設閘道器欄位，您就可以實現拆分隧道。在用戶端一側，為了使用拆分隧道，L2TP/IPSec 和 MS-SSTP 用戶端需要配置為不創建預設閘道器。\n您還可以通過現有的外部 DHCP 伺服器推送無類靜態路由 (RFC 3442)。在這種情況下，在 SecureNAT 禁用虛擬 DHCP 伺服器功能，在這一螢幕上你不需要設置無類路由。\n請參閱 RFC 3442 以瞭解無類路由。
+CMD_DhcpSet_PUSHROUTE	Specify the static routing table to push.\nExample: "192.168.5.0/255.255.255.0/192.168.4.254, 10.0.0.0/255.0.0.0/192.168.4.253"\n  OR   "192.168.5.0/255.255.255.0/vpn_gateway, 10.0.0.0/255.0.0.0/net_gateway"  for OpenVPN clients\nSplit multiple entries (maximum: 64 entries) by comma or space characters. Each entry must be specified in the "IP network address/subnet mask/gateway IP address" format, OR you should use 'vpn_gateway' or/and 'net_gateway' keywords instead of  "gateway IP address" for OpenVPN clients\nThis Virtual DHCP Server can push the classless static routes (RFC 3442) with DHCP reply messages to VPN clients.\nWhether or not a VPN client can recognize the classless static routes (RFC 3442) depends on the target VPN client software. SoftEther VPN Client and OpenVPN Client are supporting the classless static routes. On L2TP/IPsec and MS-SSTP protocols, the compatibility depends on the implementation of the client software. You can realize the split tunneling if you clear the default gateway field on the Virtual DHCP Server options. On the client side, L2TP/IPsec and MS-SSTP clients need to be configured not to set up the default gateway for the split tunneling usage.\nYou can also push the classless static routes (RFC 3442) by your existing external DHCP server. In that case, disable the Virtual DHCP Server function on SecureNAT, and you need not to set up the classless routes on this command.\nSee the RFC 3442 to understand the classless routes.
+CMD_DhcpSet_OVPNGW			Specify the IP address of 'vpn_gateway' parameter to be notified to the client. If you specify 0 or none, then the client will not be notified of the vpn_gateway value. If you use the 'vpn_gateway' keyword in the classless static routing table, you must specify this value also.
 CMD_DhcpSet_Prompt_START	分發地址範圍的開始: 
 CMD_DhcpSet_Prompt_END		分發地址範圍的結束: 
 CMD_DhcpSet_Prompt_MASK		子網路遮罩: 
@@ -6208,6 +6217,11 @@ CMD_DhcpSet_Prompt_GW		預設閘道器 (可以不設定):
 CMD_DhcpSet_Prompt_DNS		DNS 伺服器 1 (可以不設定): 
 CMD_DhcpSet_Prompt_DNS2		DNS 伺服器 2 (可以不設定): 
 CMD_DhcpSet_Prompt_DOMAIN	功能變數名稱: 
+CMD_DhcpSet_Prompt1_GW		Default Gateway: 
+CMD_DhcpSet_Prompt1_DNS		DNS Server 1: 
+CMD_DhcpSet_Prompt1_DNS2	DNS Server 2: 
+CMD_DhcpSet_Prompt_PUSHROUTE	Static routing table to push:
+CMD_DhcpSet_Prompt_OVPNGW	'vpn_gateway' parmeter for OpenVPN: 
 
 
 # DhcpTable 命令


### PR DESCRIPTION
Hello,
I propose some modifications to the OpenVPN Clone Server functionality to allow pushing classless static routing table entries 
in the form of "network/mask/vpn_gateway" or "network/mask/net_gateway". This is necessary for the OpenVPN Connect client, as it only accepts the 'vpn_gateway' or 'net_gateway' keywords in its split-tunnel routing configuration.
After applying these modifications, static routing table entries can be defined (via Virtual DHCP Server Settings) in the following formats:
a) network_ip/mask/dest_ip — e.g.: 10.0.0.0/255.255.255.0/10.0.0.1
b) network_ip/mask/net_gateway — e.g.: 10.0.0.0/255.255.255.0/net_gateway
c) network_ip/mask/vpn_gateway — e.g.: 10.0.0.0/255.255.255.0/vpn_gateway

The OpenVPN Connect client only accepts formats b) and c), and ignores format a).
The OpenVPN GUI client accepts all formats.
SoftEther and L2TP/IPsec clients only accept format a), and ignore formats b) and c).

I have also modified the DhcpSet command of the vpncmd program. It now displays the current value of the parameter on the prompt line, for example:

Start Point for Distributed Address Band: [10.0.0.101]: _

When you press <Enter>, the current value will be saved. If you type two apostrophes (''), the current value will be reset to an empty or zero value.
