### PR TITLE
Update macos runners

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [macos-15, macos-14, macos-13]
+        os: [macos-26, macos-15, macos-14]
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The macos-13 runner has been removed, and is causing failures, which you can see [here](https://github.com/SoftEtherVPN/SoftEtherVPN/actions/runs/20419671332/job/58668861734?pr=2161) for example.

This PR removes macos-13 and adds macos-26 (for the year 2026), that uses the newer version Apple is using. macos-26 is in preview.