### PR TITLE
Fix: Kernel-mode NAT not available

### DIFF
--- a/src/Cedar/IPC.c
+++ b/src/Cedar/IPC.c
@@ -567,6 +567,9 @@ IPC *NewIPCBySock(CEDAR *cedar, SOCK *s, void *mac_address)
 	ipc->Sock = s;
 	AddRef(s->ref);
 
+	// Initialize to pass the validity check on the source IP address performed by IPCSendIPv4()
+	ZeroIP4(&ipc->ClientIPAddress);
+
 	Copy(ipc->MacAddress, mac_address, 6);
 
 	ipc->Interrupt = NewInterruptManager();


### PR DESCRIPTION
Changes proposed in this pull request:
 - 
 - Secure NAT does not work in kernel mode.
Run vpntest.exe as server
Enable secure NAT
Secure NAT mode never gets into kernel mode


Attached A
Before modification
<img width="672" height="602" alt="KERNELNAT_NO20260104" src="https://github.com/user-attachments/assets/0ded6bae-f27d-42fb-8212-822997e74791" />

Attached B
After modification
<img width="672" height="602" alt="KERNELNAT_YES20260104" src="https://github.com/user-attachments/assets/825a19d9-a1f0-4dee-8cdf-340ea2ba959b" />

 - 

