### PR TITLE
Fix AddressSanitizer errors including  UB, memory leaks, and data race

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -4757,7 +4757,7 @@ static void MY_SHA0_Transform(MY_SHA0_CTX* ctx) {
 	UCHAR* p = ctx->buf;
 	int t;
 	for(t = 0; t < 16; ++t) {
-		UINT tmp =  *p++ << 24;
+		UINT tmp =  (UINT)*p++ << 24;
 		tmp |= *p++ << 16;
 		tmp |= *p++ << 8;
 		tmp |= *p++;

--- a/src/Mayaqua/Kernel.c
+++ b/src/Mayaqua/Kernel.c
@@ -880,11 +880,11 @@ void ThreadPoolProc(THREAD *t, void *param)
 
 		pd->Thread->Stopped = true;
 
-		thread->PoolHalting = true;
-
 		// Set the waiting event list
 		LockList(thread->PoolWaitList);
 		{
+			thread->PoolHalting = true;
+
 			num = LIST_NUM(thread->PoolWaitList);
 			ee = ToArray(thread->PoolWaitList);
 

--- a/src/Mayaqua/Kernel.c
+++ b/src/Mayaqua/Kernel.c
@@ -63,7 +63,7 @@ static int ydays[] =
 	0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365
 };
 
-static UINT current_num_thread = 0;
+static COUNTER *current_num_thread = NULL;
 static UINT cached_number_of_cpus = 0;
 
 
@@ -776,6 +776,7 @@ void InitThreading()
 {
 	thread_pool = NewSk();
 	thread_count = NewCounter();
+	current_num_thread = NewCounter();
 }
 
 // Release of thread pool
@@ -821,6 +822,9 @@ void FreeThreading()
 
 	DeleteCounter(thread_count);
 	thread_count = NULL;
+
+	DeleteCounter(current_num_thread);
+	current_num_thread = NULL;
 }
 
 // Thread pool procedure
@@ -1028,7 +1032,7 @@ THREAD *NewThreadNamed(THREAD_PROC *thread_proc, void *param, char *name)
 
 	Wait(pd->InitFinishEvent, INFINITE);
 
-	current_num_thread++;
+	Inc(current_num_thread);
 
 //	Debug("current_num_thread = %u\n", current_num_thread);
 
@@ -1055,7 +1059,7 @@ void CleanupThread(THREAD *t)
 
 	Free(t);
 
-	current_num_thread--;
+	Dec(current_num_thread);
 	//Debug("current_num_thread = %u\n", current_num_thread);
 }
 

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -825,7 +825,6 @@ struct CONNECT_SERIAL_PARAM
 	char HintStr[MAX_SIZE];
 	bool No_Get_Hostname;
 	bool *CancelFlag;
-	bool *NoDelayFlag;
 	UINT *NatT_ErrorCode;
 	char NatT_SvcName[MAX_SIZE];
 	SOCK *Sock;
@@ -835,6 +834,7 @@ struct CONNECT_SERIAL_PARAM
 	EVENT *FinishEvent;
 	UINT Delay;
 	UINT RetryDelay;
+	EVENT *NoDelayEvent;
 	bool Tcp_TryStartSsl;
 	SSL_VERIFY_OPTION *SslOption;
 	UINT *SslErr;

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -841,6 +841,7 @@ struct CONNECT_SERIAL_PARAM
 	bool Use_NatT;
 	bool Force_NatT;
 	IP *Ret_Ip;
+	LOCK *StateLock;				// Protects Finished, Ok, and FinishedTick.
 };
 
 // Data for the thread for concurrent connection attempts for the R-UDP and TCP

--- a/src/Mayaqua/Object.h
+++ b/src/Mayaqua/Object.h
@@ -19,10 +19,6 @@ struct LOCK
 {
 	void *pData;
 	bool Ready;
-#ifdef	OS_UNIX
-	UINT thread_id;
-	UINT locked_count;
-#endif	// OS_UNIX
 #ifdef	_DEBUG
 	char *FileName;
 	UINT Line;

--- a/src/Mayaqua/Table.c
+++ b/src/Mayaqua/Table.c
@@ -470,6 +470,7 @@ LIST *LoadLangList()
 	b = ReadDump(filename);
 	if (b == NULL)
 	{
+		ReleaseList(o);
 		return NULL;
 	}
 

--- a/src/Mayaqua/Tick64.c
+++ b/src/Mayaqua/Tick64.c
@@ -139,6 +139,7 @@ void Tick64Thread(THREAD *thread, void *param)
 	{
 		UINT tick;
 		UINT64 tick64;
+		bool halt;
 
 #ifndef	OS_WIN32
 		tick = TickRealtime();		// Get the current system clock
@@ -228,7 +229,13 @@ void Tick64Thread(THREAD *thread, void *param)
 			n = 0;
 		}
 
-		if (tk64->Halt)
+		Lock(tk64->TickLock);
+		{
+			halt = tk64->Halt;
+		}
+		Unlock(tk64->TickLock);
+
+		if (halt)
 		{
 			break;
 		}
@@ -286,7 +293,11 @@ void FreeTick64()
 	}
 
 	// Termination process
-	tk64->Halt = true;
+	Lock(tk64->TickLock);
+	{
+		tk64->Halt = true;
+	}
+	Unlock(tk64->TickLock);
 	Set(halt_tick_event);
 	WaitThread(tk64->Thread, INFINITE);
 	ReleaseThread(tk64->Thread);

--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -51,6 +51,10 @@
 #include <sys/statvfs.h>
 #endif
 
+#ifndef PTHREAD_MUTEX_RECURSIVE
+#define PTHREAD_MUTEX_RECURSIVE PTHREAD_MUTEX_RECURSIVE_NP
+#endif
+
 #ifdef	UNIX_MACOS
 #ifdef	NO_VLAN
 // Struct statfs for MacOS X
@@ -1836,13 +1840,6 @@ void UnixUnlockEx(LOCK *lock, bool inner)
 	}
 	mutex = (pthread_mutex_t *)lock->pData;
 
-	if ((--lock->locked_count) > 0)
-	{
-		return;
-	}
-
-	lock->thread_id = INFINITE;
-
 	pthread_mutex_unlock(mutex);
 
 	return;
@@ -1852,25 +1849,15 @@ void UnixUnlockEx(LOCK *lock, bool inner)
 bool UnixLock(LOCK *lock)
 {
 	pthread_mutex_t *mutex;
-	UINT thread_id = UnixThreadId();
 	if (lock->Ready == false)
 	{
 		// State is invalid
 		return false;
 	}
 
-	if (lock->thread_id == thread_id)
-	{
-		lock->locked_count++;
-		return true;
-	}
-
 	mutex = (pthread_mutex_t *)lock->pData;
 
 	pthread_mutex_lock(mutex);
-
-	lock->thread_id = thread_id;
-	lock->locked_count++;
 
 	return true;
 }
@@ -1879,6 +1866,7 @@ bool UnixLock(LOCK *lock)
 LOCK *UnixNewLock()
 {
 	pthread_mutex_t *mutex;
+	pthread_mutexattr_t attr;
 	// Memory allocation
 	LOCK *lock = UnixMemoryAlloc(sizeof(LOCK));
 	if (lock == NULL)
@@ -1895,13 +1883,13 @@ LOCK *UnixNewLock()
 	}
 
 	// Initialization of the mutex
-	pthread_mutex_init(mutex, NULL);
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	pthread_mutex_init(mutex, &attr);
+	pthread_mutexattr_destroy(&attr);
 
 	lock->pData = (void *)mutex;
 	lock->Ready = true;
-
-	lock->thread_id = INFINITE;
-	lock->locked_count = 0;
 
 	return lock;
 }

--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -2128,9 +2128,13 @@ void UnixMemoryFree(void *addr)
 // SIGCHLD handler
 void UnixSigChldHandler(int sig)
 {
+	int old_errno = errno;
+
 	// Recall the zombie processes
 	while (waitpid(-1, NULL, WNOHANG) > 0);
 	signal(SIGCHLD, UnixSigChldHandler);
+
+	errno = old_errno;
 }
 
 // Disable core dump

--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -51,8 +51,10 @@
 #include <sys/statvfs.h>
 #endif
 
+#ifdef UNIX_LINUX
 #ifndef PTHREAD_MUTEX_RECURSIVE
 #define PTHREAD_MUTEX_RECURSIVE PTHREAD_MUTEX_RECURSIVE_NP
+#endif
 #endif
 
 #ifdef	UNIX_MACOS

--- a/src/hamcorebuilder/FileSystem.c
+++ b/src/hamcorebuilder/FileSystem.c
@@ -50,6 +50,13 @@ ENTRIES *EnumEntries(const char *path)
 	}
 
 	tinydir_close(&dir);
+
+	if (!entries->List)
+	{
+		FreeEntries(entries);
+		return NULL;
+	}
+
 	return entries;
 }
 


### PR DESCRIPTION
Hi, there! 
I have adressed several errors detected by `AddressSanitizer`, focusing primarily on undefined behavior, memory leaks, and data races. These changes are strictly limited to bug fixes and do not involve any additions, deletions, or modifications to the existing functionality.

To reproduce the issues, please add the following flags to compile options:
`-fsanitize=undefined,thread -fno-omit-frame-pointer`
or
`-fsanitize=address,undefined,leak -fno-omit-frame-pointer`

Please let me know if you would prefer me to split this into multiple PRs for a better review process.


Changes proposed in this pull request:
- [Fix passing null pointer to memcpy](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/b1bdcb714bde2934d1135c64d9422ceb96bc473f)
When a directory contains no entires, should be return NULL.　Previous, passed NULL by memcpy at [src/hamcorebuilder/FileSystem.c:104](https://github.com/SoftEtherVPN/SoftEtherVPN/blob/10d6efcc5e3329e5a959a99c6e939648f41121bf/src/hamcorebuilder/FileSystem.c#L97)
- [Fix undefined behavior of left shift](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/cc1ab95f8723ee41b4f9abb8ec0db84fd2f9cb60)
Left shifting UCHAR promotes it to a signed integer. Large shift amounts could result in undefined behavior if they affect the sign bit. Fixes it by explicit casting to UINT.
- [Fix memory leak in LoadLangList()](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/a66fffccfd23a96f29bc704c518968fbc9ca3747)
-  [Replace manual lock with PTHREAD_MUTEX_RECURSIVE](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/8569222dc3ee4addbb3caabfb57701736b48736f)
In the previous implementation, thread_id and locked_count could be accessed by multiple threads, which could lead to data races. Replacing this with the pthread mutex attribute `PTHREAD_MUTEX_RECURSIVE` simplifies the structure and solves the problem. This commit closed #1477.
- [Fix race condition in thread counter](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/b30aa1a860f50c6a560b7851a0310bcf2c79e441)
To prevent data races caused by concurrent access from multiple threads, replace UINT with COUNTER.
- [Fix data race on Tick64](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/5a9651cf7104acf0472db309ea10fbf98f5e0750)
Add lock protection when reading/writing Halt flag to prevent data race.
- [Fix data race on bind connection](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/8731b0b78bd8665a892e27e74075664bf9651da6)
Add StateLock to protect Finished, Ok, FinishedTick fields in CONNECT_SERIAL_PARAM from data races between IPv4/IPv6 connection threads and main polling loop.
- [Replace shared flag with event-based signaling](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/b3af1f622004a966a00821649f99dec48a83ad3e)
no_delay_flag was shared by multiple threads, witch could lead to a data race. Replacing it with EVENT resolve this issue.
- [Fix data race on ThreadPoolProc](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/c49bc0d5db577347eb5384c9e98fb23cb4fde157)
Move writing PoolHalting inside the existing LockList section. WaitThread reads PoolHalting under this lock.
- [Fix preserve errno in SIGCHLD signal handler](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/69ed48d64ec34a4acda1c106dcbe596758c6555d)
Signal handler may interrupt code that depends on errno, and waitpid() may modify errno, therefore, errno must be saved and restored before returning.
- [Fix data race on sock->CallingThread on Unix](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/a31e825889793abbec74d0589cec23ebf9c9aebe)
Add proper locking around all accesses to sock->CallingThread. In SecureRecv, temporarily release sock->ssl_lock acquiring sock->lock to maintain consistent lock ordering and prevent deadlock.
- [Fix data race on socket accept cancellation](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/409a4747c290f3dc66b38f643adb22ec1e9f8bb6)
Add proper locking for CancelAccept and AcceptCanceled. Previously,  Accept(), Accept6 and Disconnect() are read/write it concurrently without synchronization. causing Disconnect() to potentially miss AcceptCanceled being set and perform unnecessary CheckTCPPort() wakeup calls.