### PR TITLE
Fix undefined behavior of left shift

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -4761,7 +4761,7 @@ static void MY_SHA0_Transform(MY_SHA0_CTX* ctx) {
 	UCHAR* p = ctx->buf;
 	int t;
 	for(t = 0; t < 16; ++t) {
-		UINT tmp =  *p++ << 24;
+		UINT tmp =  (UINT)*p++ << 24;
 		tmp |= *p++ << 16;
 		tmp |= *p++ << 8;
 		tmp |= *p++;


### PR DESCRIPTION
The Sanitizer detected the following Undefined Behavior:
```
/home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Encrypt.c:4764:20: runtime error: left shift of 128 by 24 places cannot be represented in type 'int'
```

This is caused by `UCHAR` being promoted to a signed integer during a left shift.
I fixed it by explicitly casting to `UINT`.

Related #2211

Changes proposed in this pull request:
 - Fix undefined behavior of left shift
