### PR TITLE
Fix preserve errno in SIGCHLD signal handler

### DIFF
--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -2140,9 +2140,13 @@ void UnixMemoryFree(void *addr)
 // SIGCHLD handler
 void UnixSigChldHandler(int sig)
 {
+	int old_errno = errno;
+
 	// Recall the zombie processes
 	while (waitpid(-1, NULL, WNOHANG) > 0);
 	signal(SIGCHLD, UnixSigChldHandler);
+
+	errno = old_errno;
 }
 
 // Disable core dump


### PR DESCRIPTION
The Sanitizer detected `signal handler spoils errno`:
```
WARNING: ThreadSanitizer: signal handler spoils errno (pid=5147)
  Signal 17 handler invoked at:
    #0 UnixSigChldHandler /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:2142 (libmayaqua.so+0x266d2d) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 CheckKernel /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:749 (libcedar.so+0x3b8193) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #2 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #3 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #4 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #5 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #6 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #7 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #8 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #9 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

SUMMARY: ThreadSanitizer: signal handler spoils errno /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:2142 in UnixSigChldHandler
```

A signal handler may interrupt code that depends on errno, and waitpid() may modify value.
To address this, I ensured that errno is saved and restored before returning. 

Related #2211

Changes proposed in this pull request:
 - Fix preserve errno in SIGCHLD signal handler
