### PR TITLE
Replace manual lock with PTHREAD_MUTEX_RECURSIVE

### DIFF
--- a/src/Mayaqua/Object.h
+++ b/src/Mayaqua/Object.h
@@ -19,10 +19,6 @@ struct LOCK
 {
 	void *pData;
 	bool Ready;
-#ifdef	OS_UNIX
-	UINT thread_id;
-	UINT locked_count;
-#endif	// OS_UNIX
 #ifdef	_DEBUG
 	char *FileName;
 	UINT Line;


### PR DESCRIPTION
The Sanitizer Detected data race:
```
WARNING: ThreadSanitizer: data race (pid=5147)
  Read of size 4 at 0x720c00000b1c by main thread:
    #0 UnixLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1862 (libmayaqua.so+0x2678db) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 OSLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:361 (libmayaqua.so+0x217aec) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 LockKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1051 (libmayaqua.so+0x1a21d4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 Zero /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:4048 (libmayaqua.so+0x1a9175) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 InitNetwork /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Network.c:16315 (libmayaqua.so+0x1d5b69) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:463 (libmayaqua.so+0x1a1e8e) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Previous write of size 4 at 0x720c00000b1c by thread T1 (mutexes: write M0):
    #0 UnixLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1872 (libmayaqua.so+0x26792d) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 OSLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:361 (libmayaqua.so+0x217aec) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 LockKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1051 (libmayaqua.so+0x1a21d4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 Zero /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:4048 (libmayaqua.so+0x1a9175) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 SystemToTm /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1683 (libmayaqua.so+0x19db17) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 SystemToTime /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1719 (libmayaqua.so+0x19e071) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 SystemToUINT64 /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1917 (libmayaqua.so+0x19e0cb) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 SystemTime64 /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1946 (libmayaqua.so+0x19e8d3) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 Tick64Thread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Tick64.c:196 (libmayaqua.so+0x260d21) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #9 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:872 (libmayaqua.so+0x198a35) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #10 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Location is heap block of size 40 at 0x720c00000b10 allocated by main thread:
    #0 malloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:665 (libtsan.so.2+0x54b3f) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixMemoryAlloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:2117 (libmayaqua.so+0x2668f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1883 (libmayaqua.so+0x266b57) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 InitKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1022 (libmayaqua.so+0x1a1c31) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:439 (libmayaqua.so+0x1a1e40) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Mutex M0 (0x720c00000b40) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1315 (libtsan.so.2+0x594cd) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1898 (libmayaqua.so+0x266b86) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 InitKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1022 (libmayaqua.so+0x1a1c31) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:439 (libmayaqua.so+0x1a1e40) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Thread T1 (tid=5149, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1685 (libmayaqua.so+0x267323) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:313 (libmayaqua.so+0x2176f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewThreadInternal /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1200 (libmayaqua.so+0x19f5c8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:997 (libmayaqua.so+0x19fb8c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 InitTick64 /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Tick64.c:274 (libmayaqua.so+0x2615b3) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:460 (libmayaqua.so+0x1a1e84) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

SUMMARY: ThreadSanitizer: data race /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1862 in UnixLock
```

<details>
<summary> related detection </summary>

```

WARNING: ThreadSanitizer: data race (pid=5147)
  Write of size 4 at 0x720c00000b7c by thread T32 (mutexes: write M0, write M1):
    #0 UnixLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1872 (libmayaqua.so+0x26792d) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 OSLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:361 (libmayaqua.so+0x217aec) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 LockKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1051 (libmayaqua.so+0x1a21d4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 Copy /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:3979 (libmayaqua.so+0x1a8735) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 CopyToArray /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:1340 (libmayaqua.so+0x1a889a) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 ToArrayEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:1367 (libmayaqua.so+0x1a8a38) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 ToArray /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:1346 (libmayaqua.so+0x1a8ae8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:885 (libmayaqua.so+0x198b79) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Previous read of size 4 at 0x720c00000b7c by thread T30 (mutexes: write M2):
    #0 UnixLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1862 (libmayaqua.so+0x2678db) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 OSLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:361 (libmayaqua.so+0x217aec) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 LockKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1051 (libmayaqua.so+0x1a21d4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 Copy /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:3979 (libmayaqua.so+0x1a8735) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 StrCpy /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Str.c:2982 (libmayaqua.so+0x239b1c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 UnixUniToStr /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Internat.c:854 (libmayaqua.so+0x18ea4c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 UnixCalcUniToStr /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Internat.c:805 (libmayaqua.so+0x18eb96) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 CalcUniToStr /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Internat.c:1460 (libmayaqua.so+0x18ebdd) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 CopyUniToStr /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Internat.c:1283 (libmayaqua.so+0x18ec16) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #9 PrintArgs /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Str.c:2686 (libmayaqua.so+0x236a7a) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #10 DebugArgs /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Str.c:2721 (libmayaqua.so+0x236c08) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #11 Debug /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Str.c:2740 (libmayaqua.so+0x236d1f) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #12 SecureSend /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Network.c:12537 (libmayaqua.so+0x1f05f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #13 Send /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Network.c:12719 (libmayaqua.so+0x20ac2f) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #14 CheckNetworkAcceptThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:93 (libcedar.so+0x3b528f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #15 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:872 (libmayaqua.so+0x198a35) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #16 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Location is heap block of size 40 at 0x720c00000b70 allocated by main thread:
    #0 malloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:665 (libtsan.so.2+0x54b3f) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixMemoryAlloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:2117 (libmayaqua.so+0x2668f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1883 (libmayaqua.so+0x266b57) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 InitKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1022 (libmayaqua.so+0x1a1c31) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:439 (libmayaqua.so+0x1a1e40) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Mutex M0 (0x720c000d06e0) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1315 (libtsan.so.2+0x594cd) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1898 (libmayaqua.so+0x266b86) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewLockMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:88 (libmayaqua.so+0x217fdb) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:100 (libmayaqua.so+0x218016) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 NewListEx2 /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:2169 (libmayaqua.so+0x1a7bae) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 NewListEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:2152 (libmayaqua.so+0x1a7e50) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 NewList /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:2148 (libmayaqua.so+0x1a7ef0) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1013 (libmayaqua.so+0x19f95d) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #9 CheckNetworkListenThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:168 (libcedar.so+0x3b56c2) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:872 (libmayaqua.so+0x198a35) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #11 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Mutex M1 (0x720c00000ba0) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1315 (libtsan.so.2+0x594cd) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1898 (libmayaqua.so+0x266b86) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 InitKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1022 (libmayaqua.so+0x1a1c31) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:439 (libmayaqua.so+0x1a1e40) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Mutex M2 (0x720c00003a80) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1315 (libtsan.so.2+0x594cd) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1898 (libmayaqua.so+0x266b86) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewLockMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:88 (libmayaqua.so+0x217fdb) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 InitInternational /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Internat.c:706 (libmayaqua.so+0x18d2aa) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 InitStringLibrary /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Str.c:2124 (libmayaqua.so+0x23653d) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:451 (libmayaqua.so+0x1a1e66) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Thread T32 (tid=5183, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1685 (libmayaqua.so+0x267323) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:313 (libmayaqua.so+0x2176f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewThreadInternal /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1200 (libmayaqua.so+0x19f5c8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:997 (libmayaqua.so+0x19fb8c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 CheckThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:381 (libcedar.so+0x3b5efd) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #6 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #7 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #8 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #9 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #11 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #12 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #13 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #14 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Thread T30 (tid=5181, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1685 (libmayaqua.so+0x267323) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:313 (libmayaqua.so+0x2176f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewThreadInternal /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1200 (libmayaqua.so+0x19f5c8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:997 (libmayaqua.so+0x19fb8c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 CheckThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:381 (libcedar.so+0x3b5efd) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #6 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #7 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #8 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #9 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #11 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #12 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #13 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #14 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

SUMMARY: ThreadSanitizer: data race /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1872 in UnixLock

```

</details>

<details>
<summary> related detection </summary>

```

WARNING: ThreadSanitizer: data race (pid=5147)
  Write of size 4 at 0x720c00000cfc by thread T2 (mutexes: write M0, write M1, write M2):
    #0 UnixUnlockEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1844 (libmayaqua.so+0x26a112) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 UnixUnlock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1827 (libmayaqua.so+0x26a2da) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSUnlock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:367 (libmayaqua.so+0x217b69) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 UnlockKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1063 (libmayaqua.so+0x1a227f) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 UnlockInner /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:151 (libmayaqua.so+0x21868f) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 Inc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:237 (libmayaqua.so+0x21990a) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 NewRef /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:341 (libmayaqua.so+0x21ab3e) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 NewEvent /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:359 (libmayaqua.so+0x21af2e) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 WaitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1140 (libmayaqua.so+0x19798f) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #9 CheckNetworkListenThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:176 (libcedar.so+0x3b57c1) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:872 (libmayaqua.so+0x198a35) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #11 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Previous read of size 4 at 0x720c00000cfc by thread T30 (mutexes: write M3):
    #0 UnixLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1862 (libmayaqua.so+0x2678db) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 OSLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:361 (libmayaqua.so+0x217aec) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 LockKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1051 (libmayaqua.so+0x1a21d4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 UnlockInner /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:151 (libmayaqua.so+0x2185f6) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 Dec /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:272 (libmayaqua.so+0x21a04d) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 Release /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:296 (libmayaqua.so+0x21a4af) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 ReleaseEvent /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:379 (libmayaqua.so+0x21b1b2) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 CleanupThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1047 (libmayaqua.so+0x197030) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 ReleaseThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1086 (libmayaqua.so+0x1972d5) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #9 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:911 (libmayaqua.so+0x198811) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #10 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Location is heap block of size 40 at 0x720c00000cf0 allocated by main thread:
    #0 malloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:665 (libtsan.so.2+0x54b3f) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixMemoryAlloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:2117 (libmayaqua.so+0x2668f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1883 (libmayaqua.so+0x266b57) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 InitKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1022 (libmayaqua.so+0x1a1c31) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:439 (libmayaqua.so+0x1a1e40) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Mutex M0 (0x720c000d1610) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1315 (libtsan.so.2+0x594cd) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1898 (libmayaqua.so+0x266b86) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewLockMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:88 (libmayaqua.so+0x217fdb) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:100 (libmayaqua.so+0x218016) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 NewListEx2 /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:2169 (libmayaqua.so+0x1a7bae) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 NewListEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:2152 (libmayaqua.so+0x1a7e50) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 NewList /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:2148 (libmayaqua.so+0x1a7ef0) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1013 (libmayaqua.so+0x19f95d) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #9 CheckNetworkListenThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:168 (libcedar.so+0x3b56c2) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:872 (libmayaqua.so+0x198a35) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #11 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Mutex M1 (0x720c000d4820) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1315 (libtsan.so.2+0x594cd) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1898 (libmayaqua.so+0x266b86) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewLockMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:88 (libmayaqua.so+0x217fdb) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:100 (libmayaqua.so+0x218016) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 NewCounter /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:170 (libmayaqua.so+0x218cc3) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 NewRef /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:338 (libmayaqua.so+0x21ab14) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 NewEvent /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:359 (libmayaqua.so+0x21af2e) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 WaitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1140 (libmayaqua.so+0x19798f) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #9 CheckNetworkListenThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:176 (libcedar.so+0x3b57c1) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:872 (libmayaqua.so+0x198a35) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #11 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Mutex M2 (0x720c00000d20) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1315 (libtsan.so.2+0x594cd) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1898 (libmayaqua.so+0x266b86) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 InitKernelStatus /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:1022 (libmayaqua.so+0x1a1c31) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:439 (libmayaqua.so+0x1a1e40) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Mutex M3 (0x720c000d10a0) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1315 (libtsan.so.2+0x594cd) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1898 (libmayaqua.so+0x266b86) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewLockMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:88 (libmayaqua.so+0x217fdb) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:100 (libmayaqua.so+0x218016) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 NewCounter /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:170 (libmayaqua.so+0x218cc3) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 NewRef /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:338 (libmayaqua.so+0x21ab14) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 NewEvent /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:359 (libmayaqua.so+0x21af2e) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1011 (libmayaqua.so+0x19f8f0) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #9 CheckNetworkListenThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:168 (libcedar.so+0x3b56c2) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:872 (libmayaqua.so+0x198a35) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #11 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Thread T2 (tid=5153, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1685 (libmayaqua.so+0x267323) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:313 (libmayaqua.so+0x2176f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewThreadInternal /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1200 (libmayaqua.so+0x19f5c8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:997 (libmayaqua.so+0x19fb8c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 CheckThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:375 (libcedar.so+0x3b5ea0) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #6 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #7 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #8 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #9 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #11 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #12 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #13 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #14 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Thread T30 (tid=5181, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1685 (libmayaqua.so+0x267323) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:313 (libmayaqua.so+0x2176f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewThreadInternal /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1200 (libmayaqua.so+0x19f5c8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:997 (libmayaqua.so+0x19fb8c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 CheckThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:381 (libcedar.so+0x3b5efd) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #6 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #7 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #8 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #9 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #11 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #12 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #13 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #14 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

SUMMARY: ThreadSanitizer: data race /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1844 in UnixUnlockEx

```

</details>


In the previous implementation, thread_id and locked_count could be accessed by multiple threads, which could lead to data races. Replacing this with the pthread mutex attribute `PTHREAD_MUTEX_RECURSIVE` simplifies the structure and solves the problem.

Related #2211

Changes proposed in this pull request:
 - Replace manual lock with PTHREAD_MUTEX_RECURSIVE

