### PR TITLE
Fix race condition in thread counter

### DIFF
--- a/src/Mayaqua/Kernel.c
+++ b/src/Mayaqua/Kernel.c
@@ -63,7 +63,7 @@ static int ydays[] =
 	0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365
 };
 
-static UINT current_num_thread = 0;
+static COUNTER *current_num_thread = NULL;
 static UINT cached_number_of_cpus = 0;
 
 
@@ -776,6 +776,7 @@ void InitThreading()
 {
 	thread_pool = NewSk();
 	thread_count = NewCounter();
+	current_num_thread = NewCounter();
 }
 
 // Release of thread pool
@@ -821,6 +822,9 @@ void FreeThreading()
 
 	DeleteCounter(thread_count);
 	thread_count = NULL;
+
+	DeleteCounter(current_num_thread);
+	current_num_thread = NULL;
 }
 
 // Thread pool procedure
@@ -1028,9 +1032,9 @@ THREAD *NewThreadNamed(THREAD_PROC *thread_proc, void *param, char *name)
 
 	Wait(pd->InitFinishEvent, INFINITE);
 
-	current_num_thread++;
+	Inc(current_num_thread);
 
-//	Debug("current_num_thread = %u\n", current_num_thread);
+//	Debug("current_num_thread = %u\n", Count(current_num_thread));
 
 	return ret;
 }
@@ -1055,8 +1059,8 @@ void CleanupThread(THREAD *t)
 
 	Free(t);
 
-	current_num_thread--;
-	//Debug("current_num_thread = %u\n", current_num_thread);
+	Dec(current_num_thread);
+	//Debug("current_num_thread = %u\n", Count(current_num_thread));
 }
 
 // Release thread (pool)


### PR DESCRIPTION
The Sanitizer detected data race:
```
WARNING: ThreadSanitizer: data race (pid=5147)
  Read of size 4 at 0x7f3ac0ab9b44 by thread T20:
    #0 CleanupThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1058 (libmayaqua.so+0x1970f2) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 ReleaseThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1086 (libmayaqua.so+0x1972d5) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:911 (libmayaqua.so+0x198811) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Previous write of size 4 at 0x7f3ac0ab9b44 by thread T21:
    #0 CleanupThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1058 (libmayaqua.so+0x197103) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 ReleaseThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1086 (libmayaqua.so+0x1972d5) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:911 (libmayaqua.so+0x198811) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Location is global 'current_num_thread' of size 4 at 0x7f3ac0ab9b44 (libmayaqua.so+0x4b9b44)

  Thread T20 (tid=5171, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1685 (libmayaqua.so+0x267323) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:313 (libmayaqua.so+0x2176f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewThreadInternal /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1200 (libmayaqua.so+0x19f5c8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:997 (libmayaqua.so+0x19fb8c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 CheckThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:381 (libcedar.so+0x3b5efd) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #6 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #7 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #8 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #9 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #11 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #12 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #13 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #14 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Thread T21 (tid=5172, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1685 (libmayaqua.so+0x267323) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:313 (libmayaqua.so+0x2176f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewThreadInternal /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1200 (libmayaqua.so+0x19f5c8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:997 (libmayaqua.so+0x19fb8c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 CheckThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:381 (libcedar.so+0x3b5efd) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #6 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #7 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #8 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #9 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #11 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #12 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #13 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #14 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

SUMMARY: ThreadSanitizer: data race /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1058 in CleanupThread
```

To prevent data races caused by concurrent access from multiple threads, replace UINT with COUNTER.

Related #2211

Changes proposed in this pull request:
 - Fix race condition in thread counter

