### PR TITLE
Fix data race on Tick64

### DIFF
--- a/src/Mayaqua/Tick64.c
+++ b/src/Mayaqua/Tick64.c
@@ -139,6 +139,7 @@ void Tick64Thread(THREAD *thread, void *param)
 	{
 		UINT tick;
 		UINT64 tick64;
+		bool halt;
 
 #ifndef	OS_WIN32
 		tick = TickRealtime();		// Get the current system clock
@@ -228,7 +229,13 @@ void Tick64Thread(THREAD *thread, void *param)
 			n = 0;
 		}
 
-		if (tk64->Halt)
+		Lock(tk64->TickLock);
+		{
+			halt = tk64->Halt;
+		}
+		Unlock(tk64->TickLock);
+
+		if (halt)
 		{
 			break;
 		}
@@ -286,7 +293,11 @@ void FreeTick64()
 	}
 
 	// Termination process
-	tk64->Halt = true;
+	Lock(tk64->TickLock);
+	{
+		tk64->Halt = true;
+	}
+	Unlock(tk64->TickLock);
 	Set(halt_tick_event);
 	WaitThread(tk64->Thread, INFINITE);
 	ReleaseThread(tk64->Thread);


### PR DESCRIPTION
Thread Sanitizer detected data race:
```
WARNING: ThreadSanitizer: data race (pid=5147)
  Write of size 1 at 0x721800000348 by main thread:
    #0 FreeTick64 /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Tick64.c:289 (libmayaqua.so+0x2616e0) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 FreeMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:577 (libmayaqua.so+0x1a253b) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:99 (vpncmd+0x143f) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Previous read of size 1 at 0x721800000348 by thread T1:
    #0 Tick64Thread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Tick64.c:231 (libmayaqua.so+0x26077d) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:872 (libmayaqua.so+0x198a35) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Location is heap block of size 96 at 0x721800000300 allocated by main thread:
    #0 malloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:665 (libtsan.so.2+0x54b3f) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixMemoryAlloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:2117 (libmayaqua.so+0x2668f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSMemoryAlloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:319 (libmayaqua.so+0x217771) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 InternalMalloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:3866 (libmayaqua.so+0x1a739b) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 MallocEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:3643 (libmayaqua.so+0x1a7459) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 ZeroMallocEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:3841 (libmayaqua.so+0x1b148b) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 ZeroMalloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:3837 (libmayaqua.so+0x1b14ca) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 InitTick64 /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Tick64.c:269 (libmayaqua.so+0x2614eb) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:460 (libmayaqua.so+0x1a1e84) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #9 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Thread T1 (tid=5149, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1685 (libmayaqua.so+0x267323) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:313 (libmayaqua.so+0x2176f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewThreadInternal /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1200 (libmayaqua.so+0x19f5c8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:997 (libmayaqua.so+0x19fb8c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 InitTick64 /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Tick64.c:274 (libmayaqua.so+0x2615b3) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 InitMayaqua /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Mayaqua.c:460 (libmayaqua.so+0x1a1e84) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:38 (vpncmd+0x13ee) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

SUMMARY: ThreadSanitizer: data race /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Tick64.c:289 in FreeTick64
```

Related #2211 

Add lock protection when reading/writing Halt flag to prevent data race.

Changes proposed in this pull request:
 - Fix data race on Tick64

