### PR TITLE
Fix memory leak in LoadLangList()

### DIFF
--- a/src/Mayaqua/Table.c
+++ b/src/Mayaqua/Table.c
@@ -470,6 +470,7 @@ LIST *LoadLangList()
 	b = ReadDump(filename);
 	if (b == NULL)
 	{
+		FreeLangList(o);
 		return NULL;
 	}
 


### PR DESCRIPTION
This leak is only triggered when `hamcore.se2` is corrupted or problematic, therefore, it is unlikely to affect most users in normal scenarios.

Changes proposed in this pull request:
 - Fix memory leak in LoadLangList()

