### PR TITLE
Add ThreadSanitizer suppression file

### DIFF
--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,0 +1,12 @@
+# This file contains suppressions for Thread Sanitizer.
+# For the specification, refer to: https://github.com/google/sanitizers/wiki/threadsanitizersuppressions
+
+
+# Thread Sanitizer reports data races on Finished and NoDelayFlag in CONNECT_SERIAL_PARAM,
+# shared between BindConnectThreadForIPv4, BindConnectThreadForIPv6, and BindConnectEx5.
+# These are benign data races: the Set/Wait on FinishEvent provides synchronization
+# equivalent to a lock, but TSan cannot recognize it.
+# https://github.com/SoftEtherVPN/SoftEtherVPN/pull/2222
+race_top:BindConnectThreadForIPv4
+race_top:BindConnectThreadForIPv6
+race_top:BindConnectEx5


### PR DESCRIPTION
Using `__attribute__(no_sanitize("thread"))`disables instrumentation for the entire stack frame, meaning functions called within that scope are also not checked. By using `race_top` in a suppression file, we can suppress erros only when they occur at the top of the stack. This provides more granular control over errors suppression.

As an example, this suppression addresses #2222.


The configuration for applying the suppression file is as follows:
```
TSAN_OPTIONS="suppressions=./tsan_supressions.txt" ./build/vpncmd
```


Changes proposed in this pull request:
 - Add ThreadSanitizer suppression file
