### PR TITLE
Suppress Thread Sanitizer for ThreadPoolProc

### DIFF
--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -17,6 +17,10 @@ race_top:BindConnectThreadForIPv4
 race_top:BindConnectThreadForIPv6
 race_top:BindConnectEx5
 
+# Thread Sanitizer reports data races on PoolHalting in THREAD, shared between ThreadPoolProc and WaitThread.
+# But if WaitThread reads false, synchronization is ensured by Wait from the PoolWaitList. If it reads true,
+# WaitThread simply returns.
+race_top:ThreadPoolProc
 
 ## Manual PTHREAD_MUTEX_RECURSIVE
 # The Lock/Unlock mechanism on Unix is a manual, hand-coded implementation of PTHREAD_MUTEX_RECURSIVE.


### PR DESCRIPTION
Thread Sanitizer detected data race:

```
WARNING: ThreadSanitizer: data race (pid=5147)
  Write of size 1 at 0x722800013f38 by thread T2:
    #0 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:879 (libmayaqua.so+0x198acd) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Previous read of size 1 at 0x722800013f38 by thread T34 (mutexes: write M0):
    #0 WaitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1132 (libmayaqua.so+0x197904) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #1 CheckThread1 /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:314 (libcedar.so+0x3b8738) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #2 ThreadPoolProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:872 (libmayaqua.so+0x198a35) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 UnixDefaultThreadProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1606 (libmayaqua.so+0x2664f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)

  Location is heap block of size 160 at 0x722800013ec0 allocated by main thread:
    #0 malloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:665 (libtsan.so.2+0x54b3f) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixMemoryAlloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:2117 (libmayaqua.so+0x2668f9) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSMemoryAlloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:319 (libmayaqua.so+0x217771) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 InternalMalloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:3866 (libmayaqua.so+0x1a739b) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 MallocEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:3643 (libmayaqua.so+0x1a7459) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 ZeroMallocEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:3841 (libmayaqua.so+0x1b148b) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 ZeroMalloc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:3837 (libmayaqua.so+0x1b14ca) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1006 (libmayaqua.so+0x19f819) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 CheckThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:375 (libcedar.so+0x3b5ea0) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #9 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #11 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #12 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #13 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #14 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #15 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #16 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #17 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Mutex M0 (0x720c000965d0) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1315 (libtsan.so.2+0x594cd) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1898 (libmayaqua.so+0x266b86) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSNewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:355 (libmayaqua.so+0x217a6c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewLockMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:88 (libmayaqua.so+0x217fdb) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewLock /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Object.c:100 (libmayaqua.so+0x218016) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 NewListEx2 /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:2169 (libmayaqua.so+0x1a7bae) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #6 NewListEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:2152 (libmayaqua.so+0x1a7e50) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #7 NewList /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Memory.c:2148 (libmayaqua.so+0x1a7ef0) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #8 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1013 (libmayaqua.so+0x19f95d) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #9 CheckThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:375 (libcedar.so+0x3b5ea0) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #11 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #12 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #13 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #14 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #15 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #16 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #17 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #18 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Thread T2 (tid=5153, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1685 (libmayaqua.so+0x267323) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:313 (libmayaqua.so+0x2176f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewThreadInternal /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1200 (libmayaqua.so+0x19f5c8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:997 (libmayaqua.so+0x19fb8c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 CheckThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:375 (libcedar.so+0x3b5ea0) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #6 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #7 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #8 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #9 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #11 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #12 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #13 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #14 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

  Thread T34 (tid=5185, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 UnixInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Unix.c:1685 (libmayaqua.so+0x267323) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #2 OSInitThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/OS.c:313 (libmayaqua.so+0x2176f4) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #3 NewThreadInternal /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:1200 (libmayaqua.so+0x19f5c8) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #4 NewThreadNamed /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:997 (libmayaqua.so+0x19fb8c) (BuildId: 7647956240b597b45293d534cf6ea5b7ed2f8c4c)
    #5 CheckThread /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:381 (libcedar.so+0x3b5efd) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #6 SystemCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:782 (libcedar.so+0x3b8d77) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #7 PtCheck /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:818 (libcedar.so+0x3b8f2d) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #8 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #9 PtMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:862 (libcedar.so+0x3b94d7) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #10 PtConnect /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:929 (libcedar.so+0x3b9849) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #11 VpnCmdProc /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:24946 (libcedar.so+0x422d8f) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #12 DispatchNextCmdEx /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Console.c:888 (libcedar.so+0x443e38) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #13 CommandMain /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Cedar/Command.c:25014 (libcedar.so+0x423049) (BuildId: 4de447f621af6b86b1733a53772ce2c151f52dbe)
    #14 main /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/vpncmd/vpncmd.c:62 (vpncmd+0x14ad) (BuildId: ff15e15fc990216fcf75254ad7ec9ac4f810b244)

SUMMARY: ThreadSanitizer: data race /home/runner/work/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Kernel.c:879 in ThreadPoolProc
```

This is false positive:
Thread Sanitizer reports data races on PoolHalting in THREAD, shared between [ThreadPoolProc](https://github.com/SoftEtherVPN/SoftEtherVPN/blob/2dec52b875fec5ebc57fc57632f8b1dfdda9ccd2/src/Mayaqua/Kernel.c#L879) and [WaitThread](https://github.com/SoftEtherVPN/SoftEtherVPN/blob/2dec52b875fec5ebc57fc57632f8b1dfdda9ccd2/src/Mayaqua/Kernel.c#L1132). But synchronization is ensured by Set/Wait.

Changes proposed in this pull request:
 - Suppress Thread Sanitizer for ThreadPoolProc

