### PR TITLE
macOS: default vpncmd path to /opt/homebrew/bin

### DIFF
--- a/developer_tools/macos/Sources/ServerManagerApp/main.swift
+++ b/developer_tools/macos/Sources/ServerManagerApp/main.swift
@@ -1,0 +1,363 @@
+import SwiftUI
+import AppKit
+import SoftEtherMacShared
+
+@main
+struct SoftEtherVPNServerManagerAppMain: App {
+    @StateObject private var vm = ServerManagerViewModel()
+    @StateObject private var lang = LanguageManager.shared
+    var body: some Scene {
+        WindowGroup(I18N.t("app.server.title")) {
+            ServerManagerView().environmentObject(vm).environmentObject(lang).frame(minWidth: 1400, minHeight: 860)
+        }
+    }
+}
+
+@MainActor
+final class ServerManagerViewModel: ObservableObject {
+    @Published var vpncmdPath: String = "/opt/homebrew/bin/vpncmd"
+    @Published var host: String = "127.0.0.1"
+    @Published var portText: String = "5555"
+    @Published var password: String = ""
+    @Published var hubName: String = "DEFAULT"
+    @Published var output: String = ""
+
+    @Published var hubs: [NamedRow] = []
+    @Published var users: [NamedRow] = []
+    @Published var sessions: [NamedRow] = []
+
+    @Published var selectedHubName: String = ""
+    @Published var selectedUserName: String = ""
+    @Published var selectedSessionNames: Set<String> = []
+
+    @Published var newHubName: String = ""
+    @Published var newHubPassword: String = ""
+    @Published var newHubPasswordForSelected: String = ""
+
+    @Published var newUserName: String = ""
+    @Published var newUserPassword: String = ""
+    @Published var newPasswordForSelectedUser: String = ""
+
+    @Published var filterHub: String = ""
+    @Published var filterUser: String = ""
+    @Published var filterSession: String = ""
+
+    @Published var logFiles: [NamedRow] = []
+    @Published var selectedLogName: String = ""
+    @Published var downloadLogRemotePath: String = ""
+    @Published var downloadLogLocalPath: String = ""
+
+    @Published var caRows: [NamedRow] = []
+    @Published var selectedCaKey: String = ""
+
+    private var cli: SoftEtherCLI { SoftEtherCLI(vpncmdPath: vpncmdPath) }
+    private var port: Int { Int(portText) ?? 5555 }
+
+    var filteredSessions: [NamedRow] {
+        filterSession.isEmpty ? sessions : sessions.filter { $0.values.values.joined(separator: " ").localizedCaseInsensitiveContains(filterSession) }
+    }
+
+    var selectedHub: NamedRow? { hubs.first(where: { $0.name == selectedHubName }) }
+    var selectedUser: NamedRow? { users.first(where: { $0.name == selectedUserName }) }
+
+    private func runServer(_ cmd: [String]) throws -> String {
+        try cli.runServerCommand(host: host, port: port, password: password, cmd: cmd)
+    }
+
+    func healthCheck() {
+        action {
+            var issues: [String] = []
+            if !FileManager.default.isExecutableFile(atPath: vpncmdPath) { issues.append(String(format: I18N.t("msg.vpncmd.not_executable"), vpncmdPath)) }
+            do { _ = try runServer(["ServerStatusGet"]) } catch { issues.append(error.localizedDescription) }
+            do { _ = try runServer(["HubList"]) } catch { issues.append(error.localizedDescription) }
+            if issues.isEmpty { return I18N.t("msg.health.ok") }
+            return I18N.t("msg.health.fail") + "\n- " + issues.joined(separator: "\n- ")
+        }
+    }
+
+    func status() { action { try runServer(["ServerStatusGet"]) } }
+
+    func loadHubs() {
+        action {
+            let txt = try runServer(["HubList"])
+            hubs = VpnCmdParser.parseRows(txt, preferredNameKeys: ["Virtual Hub Name", "HubName", "Name"])
+            if selectedHubName.isEmpty { selectedHubName = hubs.first?.name ?? "" }
+            return txt
+        }
+    }
+
+    func loadUsers() {
+        action {
+            let txt = try cli.runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["UserList"])
+            users = VpnCmdParser.parseRows(txt, preferredNameKeys: ["User Name", "UserName", "Name"])
+            if selectedUserName.isEmpty { selectedUserName = users.first?.name ?? "" }
+            return txt
+        }
+    }
+
+    func loadSessions() {
+        action {
+            let txt = try cli.runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["SessionList"])
+            sessions = VpnCmdParser.parseRows(txt, preferredNameKeys: ["Session Name", "Name"])
+            selectedSessionNames = []
+            return txt
+        }
+    }
+
+    func createHub() {
+        guard !newHubName.isEmpty else { return }
+        action {
+            try cli.createHub(host: host, port: port, password: password, hubName: newHubName, hubPassword: newHubPassword)
+            loadHubs()
+            return String(format: I18N.t("msg.created.hub"), newHubName)
+        }
+    }
+
+    func deleteSelectedHub() {
+        guard !selectedHubName.isEmpty else { return }
+        action {
+            try cli.deleteHub(host: host, port: port, password: password, hubName: selectedHubName)
+            loadHubs()
+            return String(format: I18N.t("msg.deleted.hub"), selectedHubName)
+        }
+    }
+
+    func setSelectedHubPassword() {
+        guard !selectedHubName.isEmpty, !newHubPasswordForSelected.isEmpty else { return }
+        action {
+            try cli.setHubPassword(host: host, port: port, password: password, hubName: selectedHubName, newPassword: newHubPasswordForSelected)
+            return String(format: I18N.t("msg.updated.hub_password"), selectedHubName)
+        }
+    }
+
+    func createUser() {
+        guard !newUserName.isEmpty, !hubName.isEmpty else { return }
+        action {
+            try cli.createUser(host: host, port: port, password: password, hubName: hubName, userName: newUserName, userPassword: newUserPassword)
+            loadUsers()
+            return String(format: I18N.t("msg.created.user"), newUserName)
+        }
+    }
+
+    func deleteSelectedUser() {
+        guard !selectedUserName.isEmpty, !hubName.isEmpty else { return }
+        action {
+            try cli.deleteUser(host: host, port: port, password: password, hubName: hubName, userName: selectedUserName)
+            loadUsers()
+            return String(format: I18N.t("msg.deleted.user"), selectedUserName)
+        }
+    }
+
+    func setSelectedUserPassword() {
+        guard !selectedUserName.isEmpty, !newPasswordForSelectedUser.isEmpty, !hubName.isEmpty else { return }
+        action {
+            try cli.setUserPassword(host: host, port: port, password: password, hubName: hubName, userName: selectedUserName, newPassword: newPasswordForSelectedUser)
+            return String(format: I18N.t("msg.updated.user_password"), selectedUserName)
+        }
+    }
+
+    func disconnectSelectedSessions() {
+        guard !selectedSessionNames.isEmpty else { return }
+        action {
+            for name in selectedSessionNames {
+                try cli.disconnectSession(host: host, port: port, password: password, hubName: hubName, sessionName: name)
+            }
+            loadSessions()
+            return String(format: I18N.t("msg.disconnected.sessions"), selectedSessionNames.count)
+        }
+    }
+
+    func loadLogFiles() {
+        action {
+            let txt = try runServer(["LogFileList"])
+            logFiles = VpnCmdParser.parseRows(txt, preferredNameKeys: ["Name", "Log File Name", "Filename"])
+            selectedLogName = logFiles.first?.name ?? ""
+            return txt
+        }
+    }
+
+    func downloadLogFile() {
+        guard !downloadLogRemotePath.isEmpty else { return }
+        if downloadLogLocalPath.isEmpty {
+            let panel = NSSavePanel()
+            panel.nameFieldStringValue = URL(fileURLWithPath: downloadLogRemotePath).lastPathComponent
+            guard panel.runModal() == .OK, let url = panel.url else { return }
+            downloadLogLocalPath = url.path
+        }
+        action {
+            let txt = try runServer(["LogFileSave", downloadLogRemotePath, downloadLogLocalPath])
+            return txt
+        }
+    }
+
+    func loadCa() {
+        action {
+            caRows = try cli.listCa(host: host, port: port, password: password, hubName: hubName)
+            selectedCaKey = caRows.first?.name ?? ""
+            return String(format: I18N.t("msg.loaded.ca"), caRows.count)
+        }
+    }
+
+    func addCa() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        action {
+            try cli.addCa(host: host, port: port, password: password, hubName: hubName, certPath: url.path)
+            loadCa()
+            return String(format: I18N.t("msg.added.ca"), url.path)
+        }
+    }
+
+    func deleteSelectedCa() {
+        guard !selectedCaKey.isEmpty else { return }
+        action {
+            try cli.deleteCa(host: host, port: port, password: password, hubName: hubName, key: selectedCaKey)
+            loadCa()
+            return String(format: I18N.t("msg.deleted.ca_key"), selectedCaKey)
+        }
+    }
+
+    func checkServerCertificate() {
+        action { try cli.checkServerCert(host: host, port: port) }
+    }
+
+    private func action(_ block: () throws -> String) {
+        do { output = try block() } catch {
+            output = I18N.t("msg.action.failed") + ": " + I18N.explainVpnCmdError(error.localizedDescription)
+        }
+    }
+}
+
+struct ServerManagerView: View {
+    @EnvironmentObject var vm: ServerManagerViewModel
+    @EnvironmentObject var lang: LanguageManager
+
+    var body: some View {
+        VStack(spacing: 10) {
+            GroupBox(I18N.t("section.server_connection")) {
+                HStack {
+                    TextField(I18N.t("label.vpncmd"), text: $vm.vpncmdPath)
+                    TextField(I18N.t("field.host"), text: $vm.host).frame(width: 150)
+                    TextField(I18N.t("field.port"), text: $vm.portText).frame(width: 80)
+                    TextField(I18N.t("field.hub"), text: $vm.hubName).frame(width: 150)
+                    SecureField(I18N.t("field.password"), text: $vm.password).frame(width: 200)
+                    Picker(lang.t("label.language"), selection: $lang.languageCode) {
+                        ForEach(lang.supportedLanguages, id: \.self) { code in
+                            Text(lang.languageDisplayName(code)).tag(code)
+                        }
+                    }
+                    .frame(width: 170)
+                    Button(I18N.t("btn.use_system")) { lang.useSystemLanguage() }
+                    Button(I18N.t("btn.use_english")) { lang.useEnglishLanguage() }
+                    Button(I18N.t("btn.health_check")) { vm.healthCheck() }
+                    Button(I18N.t("btn.status")) { vm.status() }
+                }
+            }
+
+            HSplitView {
+                VStack(alignment: .leading, spacing: 8) {
+                    GroupBox(I18N.t("section.hubs")) {
+                        VStack {
+                            HStack { Button(I18N.t("btn.reload")) { vm.loadHubs() } }
+                            HStack { TextField(I18N.t("field.new_hub"), text: $vm.newHubName); SecureField(I18N.t("field.hub_password"), text: $vm.newHubPassword); Button(I18N.t("btn.create")) { vm.createHub() } }
+                            HStack { SecureField(I18N.t("field.set_selected_hub_password"), text: $vm.newHubPasswordForSelected); Button(I18N.t("btn.apply")) { vm.setSelectedHubPassword() }; Button(I18N.t("btn.delete")) { vm.deleteSelectedHub() } }
+                            SortableRowTable(title: I18N.t("section.hub_list"), rows: vm.hubs, preferredNameKeys: ["Virtual Hub Name", "HubName", "Name"], selectedName: $vm.selectedHubName, filterText: $vm.filterHub)
+                        }
+                    }
+
+                    GroupBox(I18N.t("section.users")) {
+                        VStack {
+                            HStack { Button(I18N.t("btn.reload")) { vm.loadUsers() } }
+                            HStack { TextField(I18N.t("field.new_user"), text: $vm.newUserName); SecureField(I18N.t("field.user_password"), text: $vm.newUserPassword); Button(I18N.t("btn.create")) { vm.createUser() } }
+                            HStack { SecureField(I18N.t("field.set_selected_user_password"), text: $vm.newPasswordForSelectedUser); Button(I18N.t("btn.apply")) { vm.setSelectedUserPassword() }; Button(I18N.t("btn.delete")) { vm.deleteSelectedUser() } }
+                            SortableRowTable(title: I18N.t("section.user_list"), rows: vm.users, preferredNameKeys: ["User Name", "UserName", "Name"], selectedName: $vm.selectedUserName, filterText: $vm.filterUser)
+                        }
+                    }
+                }
+                .frame(minWidth: 460)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    GroupBox(I18N.t("section.sessions")) {
+                        VStack {
+                            HStack { TextField(I18N.t("field.filter_sessions"), text: $vm.filterSession); Button(I18N.t("btn.reload")) { vm.loadSessions() }; Button(I18N.t("btn.disconnect_selected")) { vm.disconnectSelectedSessions() } }
+                            List(vm.filteredSessions, id: \.id, selection: $vm.selectedSessionNames) { row in
+                                Text(row.name).tag(row.name)
+                            }
+                        }
+                    }
+
+                    GroupBox(I18N.t("section.logs")) {
+                        VStack(alignment: .leading) {
+                            HStack { Button(I18N.t("btn.reload_logs")) { vm.loadLogFiles() } }
+                            List(vm.logFiles, id: \.id, selection: $vm.selectedLogName) { row in
+                                Text(row.name).tag(row.name)
+                            }
+                            HStack {
+                                TextField(I18N.t("field.remote_log"), text: $vm.downloadLogRemotePath)
+                                TextField(I18N.t("field.local_log"), text: $vm.downloadLogLocalPath)
+                                Button(I18N.t("btn.download")) { vm.downloadLogFile() }
+                            }
+                        }
+                    }
+
+                    GroupBox(I18N.t("section.cert_ca")) {
+                        VStack(alignment: .leading) {
+                            HStack {
+                                Button(I18N.t("btn.reload_ca")) { vm.loadCa() }
+                                Button(I18N.t("btn.add_ca")) { vm.addCa() }
+                                Button(I18N.t("btn.delete_selected_ca")) { vm.deleteSelectedCa() }
+                                Button(I18N.t("btn.check_server_cert")) { vm.checkServerCertificate() }
+                            }
+                            List(vm.caRows, id: \.id, selection: $vm.selectedCaKey) { row in
+                                Text(row.name).tag(row.name)
+                            }
+                        }
+                    }
+
+                    GroupBox(I18N.t("section.details")) {
+                        HSplitView {
+                            KeyValueView(title: "Hub", values: vm.selectedHub?.values ?? [:])
+                            KeyValueView(title: "User", values: vm.selectedUser?.values ?? [:])
+                        }
+                        .frame(minHeight: 180)
+                    }
+
+                    GroupBox(I18N.t("section.output")) {
+                        TextEditor(text: $vm.output).font(.system(.caption, design: .monospaced)).frame(minHeight: 220)
+                    }
+                }
+            }
+        }
+        .padding(10)
+        .toolbar {
+            ToolbarItemGroup {
+                Button(I18N.t("btn.health_check")) { vm.healthCheck() }
+                Button(I18N.t("btn.reload_hubs")) { vm.loadHubs() }
+                Button(I18N.t("btn.reload_users")) { vm.loadUsers() }
+                Button(I18N.t("btn.reload_sessions")) { vm.loadSessions() }
+            }
+        }
+    }
+}
+
+struct KeyValueView: View {
+    let title: String
+    let values: [String: String]
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(title).font(.headline)
+            ScrollView {
+                VStack(alignment: .leading) {
+                    ForEach(values.keys.sorted(), id: \.self) { k in
+                        Text("\(k): \(values[k] ?? "")").font(.system(.caption, design: .monospaced))
+                    }
+                }
+            }
+        }
+        .padding(6)
+    }
+}

--- a/developer_tools/macos/Sources/Shared/SoftEtherCLI.swift
+++ b/developer_tools/macos/Sources/Shared/SoftEtherCLI.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+public struct SoftEtherCLI {
+    public let vpncmdPath: String
+    public let serviceBinaryPath: String
+
+    public init(vpncmdPath: String = "/opt/homebrew/bin/vpncmd", serviceBinaryPath: String = "/opt/homebrew/bin/vpnclient") {
+        self.vpncmdPath = vpncmdPath
+        self.serviceBinaryPath = serviceBinaryPath
+    }
+
+    @discardableResult
+    public func runVpncmd(arguments: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: vpncmdPath)
+        process.arguments = arguments
+
+        let out = Pipe()
+        let err = Pipe()
+        process.standardOutput = out
+        process.standardError = err
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let error = String(data: err.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            throw NSError(domain: "SoftEtherCLI", code: Int(process.terminationStatus), userInfo: [NSLocalizedDescriptionKey: error.isEmpty ? output : error])
+        }
+
+        return output
+    }
+
+    public func runClientCommand(_ cmd: [String]) throws -> String {
+        try runVpncmd(arguments: ["localhost", "/CLIENT", "/CMD"] + cmd)
+    }
+
+    public func runServerCommand(host: String, port: Int, password: String, cmd: [String]) throws -> String {
+        try runVpncmd(arguments: ["\(host):\(port)", "/SERVER", "/PASSWORD:\(password)", "/CMD"] + cmd)
+    }
+
+    public func runHubCommand(host: String, port: Int, password: String, hubName: String, cmd: [String]) throws -> String {
+        try runVpncmd(arguments: ["\(host):\(port)", "/SERVER", "/HUB:\(hubName)", "/PASSWORD:\(password)", "/CMD"] + cmd)
+    }
+
+    public func listClientAccountsStructured() throws -> [ClientAccount] {
+        let output = try runClientCommand(["AccountList"])
+        return VpnCmdParser.parseNamedRows(output).map(ClientAccount.from).filter { !$0.name.isEmpty }
+    }
+
+    public func createAccount(name: String, host: String, port: Int, hub: String, user: String) throws {
+        _ = try runClientCommand(["AccountCreate", name, "/SERVER:\(host):\(port)", "/HUB:\(hub)", "/USERNAME:\(user)", "/NICNAME:VPN"])
+    }
+
+    public func connect(accountName: String) throws { _ = try runClientCommand(["AccountConnect", accountName]) }
+    public func disconnect(accountName: String) throws { _ = try runClientCommand(["AccountDisconnect", accountName]) }
+    public func accountStatus(accountName: String) throws -> String { try runClientCommand(["AccountStatusGet", accountName]) }
+    public func deleteAccount(accountName: String) throws { _ = try runClientCommand(["AccountDelete", accountName]) }
+    public func renameAccount(oldName: String, newName: String) throws { _ = try runClientCommand(["AccountRename", oldName, "/NEW:\(newName)"]) }
+    public func setAccountHostPort(accountName: String, host: String, port: Int) throws { _ = try runClientCommand(["AccountSet", accountName, "/SERVER:\(host)", "/PORT:\(port)"]) }
+    public func importAccount(path: String) throws { _ = try runClientCommand(["AccountImport", path]) }
+    public func exportAccount(accountName: String, path: String) throws { _ = try runClientCommand(["AccountExport", accountName, path]) }
+
+    public func serverStatus(host: String, port: Int, password: String) throws -> String {
+        try runServerCommand(host: host, port: port, password: password, cmd: ["ServerStatusGet"])
+    }
+
+    public func createHub(host: String, port: Int, password: String, hubName: String, hubPassword: String) throws {
+        _ = try runServerCommand(host: host, port: port, password: password, cmd: ["HubCreate", hubName, "/PASSWORD:\(hubPassword)"])
+    }
+    public func deleteHub(host: String, port: Int, password: String, hubName: String) throws {
+        _ = try runServerCommand(host: host, port: port, password: password, cmd: ["HubDelete", hubName])
+    }
+    public func setHubPassword(host: String, port: Int, password: String, hubName: String, newPassword: String) throws {
+        _ = try runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["SetHubPassword", "/PASSWORD:\(newPassword)"])
+    }
+
+    public func createUser(host: String, port: Int, password: String, hubName: String, userName: String, userPassword: String) throws {
+        _ = try runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["UserCreate", userName, "/GROUP:none", "/REALNAME:none", "/NOTE:none"])
+        _ = try runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["UserPasswordSet", userName, "/PASSWORD:\(userPassword)"])
+    }
+    public func deleteUser(host: String, port: Int, password: String, hubName: String, userName: String) throws {
+        _ = try runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["UserDelete", userName])
+    }
+    public func setUserPassword(host: String, port: Int, password: String, hubName: String, userName: String, newPassword: String) throws {
+        _ = try runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["UserPasswordSet", userName, "/PASSWORD:\(newPassword)"])
+    }
+    public func disconnectSession(host: String, port: Int, password: String, hubName: String, sessionName: String) throws {
+        _ = try runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["SessionDisconnect", sessionName])
+    }
+
+    public func listCa(host: String, port: Int, password: String, hubName: String) throws -> [NamedRow] {
+        let txt = try runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["CaList"])
+        return VpnCmdParser.parseRows(txt, preferredNameKeys: ["Key", "Name", "Subject"])
+    }
+
+    public func addCa(host: String, port: Int, password: String, hubName: String, certPath: String) throws {
+        _ = try runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["CaAdd", certPath])
+    }
+
+    public func deleteCa(host: String, port: Int, password: String, hubName: String, key: String) throws {
+        _ = try runHubCommand(host: host, port: port, password: password, hubName: hubName, cmd: ["CaDelete", key])
+    }
+
+    public func checkServerCert(host: String, port: Int) throws -> String {
+        try runVpncmd(arguments: ["\(host):\(port)", "/CMD", "Check"])
+    }
+}
+

--- a/developer_tools/macos/Sources/VPNClientApp/main.swift
+++ b/developer_tools/macos/Sources/VPNClientApp/main.swift
@@ -1,0 +1,245 @@
+import SwiftUI
+import AppKit
+import SoftEtherMacShared
+
+@main
+struct SoftEtherVPNClientAppMain: App {
+    @StateObject private var vm = ClientViewModel()
+    @StateObject private var lang = LanguageManager.shared
+    var body: some Scene {
+        WindowGroup(I18N.t("app.client.title")) {
+            ClientView().environmentObject(vm).environmentObject(lang).frame(minWidth: 1300, minHeight: 820)
+        }
+    }
+}
+
+@MainActor
+final class ClientViewModel: ObservableObject {
+    @Published var accounts: [ClientAccount] = []
+    @Published var selectedAccountName: String = ""
+    @Published var output: String = ""
+    @Published var vpncmdPath: String = "/opt/homebrew/bin/vpncmd"
+    @Published var filterText: String = ""
+
+    @Published var newName: String = ""
+    @Published var newHost: String = "127.0.0.1"
+    @Published var newPort: String = "443"
+    @Published var newHub: String = "DEFAULT"
+    @Published var newUser: String = ""
+
+    @Published var renameTo: String = ""
+    @Published var setHost: String = ""
+    @Published var setPort: String = "443"
+
+    private var cli: SoftEtherCLI { SoftEtherCLI(vpncmdPath: vpncmdPath) }
+
+    var filteredAccounts: [ClientAccount] {
+        if filterText.isEmpty { return accounts }
+        return accounts.filter { a in
+            a.name.localizedCaseInsensitiveContains(filterText)
+            || a.status.localizedCaseInsensitiveContains(filterText)
+            || a.server.localizedCaseInsensitiveContains(filterText)
+            || a.values.values.joined(separator: " ").localizedCaseInsensitiveContains(filterText)
+        }
+    }
+
+    var selectedAccount: ClientAccount? {
+        accounts.first(where: { $0.name == selectedAccountName })
+    }
+
+    func refresh() {
+        run {
+            accounts = try cli.listClientAccountsStructured()
+            if selectedAccountName.isEmpty { selectedAccountName = accounts.first?.name ?? "" }
+            return String(format: I18N.t("msg.loaded.accounts"), accounts.count)
+        }
+    }
+
+    func healthCheck() {
+        run {
+            var issues: [String] = []
+            if !FileManager.default.isExecutableFile(atPath: vpncmdPath) {
+                issues.append(String(format: I18N.t("msg.vpncmd.not_executable"), vpncmdPath))
+            }
+            do { _ = try cli.runClientCommand(["NicList"]) } catch { issues.append(error.localizedDescription) }
+            do { _ = try cli.runClientCommand(["AccountList"]) } catch { issues.append(error.localizedDescription) }
+            if issues.isEmpty { return I18N.t("msg.health.ok") }
+            return I18N.t("msg.health.fail") + "\n- " + issues.joined(separator: "\n- ")
+        }
+    }
+
+    func createAccount() {
+        guard let p = Int(newPort), !newName.isEmpty, !newUser.isEmpty else { return }
+        run {
+            try cli.createAccount(name: newName, host: newHost, port: p, hub: newHub, user: newUser)
+            refresh()
+            return String(format: I18N.t("msg.created.account"), newName)
+        }
+    }
+
+    func connect() { onSelected { try cli.connect(accountName: $0); return String(format: I18N.t("msg.connected.account"), $0) } }
+    func disconnect() { onSelected { try cli.disconnect(accountName: $0); return String(format: I18N.t("msg.disconnected.account"), $0) } }
+    func status() { onSelected { try cli.accountStatus(accountName: $0) } }
+    func delete() { onSelected { try cli.deleteAccount(accountName: $0); refresh(); return String(format: I18N.t("msg.deleted.account"), $0) } }
+
+    func rename() {
+        onSelected { name in
+            guard !renameTo.isEmpty else { return I18N.t("msg.rename_target_empty") }
+            try cli.renameAccount(oldName: name, newName: renameTo)
+            refresh()
+            return String(format: I18N.t("msg.renamed.account"), name, renameTo)
+        }
+    }
+
+    func editServer() {
+        onSelected { name in
+            guard let p = Int(setPort), !setHost.isEmpty else { return I18N.t("msg.invalid_host_port") }
+            try cli.setAccountHostPort(accountName: name, host: setHost, port: p)
+            refresh()
+            return String(format: I18N.t("msg.updated.server.account"), name)
+        }
+    }
+
+    func importAccount() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        run {
+            try cli.importAccount(path: url.path)
+            refresh()
+            return String(format: I18N.t("msg.imported.account_file"), url.path)
+        }
+    }
+
+    func exportAccount() {
+        onSelected { name in
+            let panel = NSSavePanel()
+            panel.nameFieldStringValue = "\(name).vpn"
+            guard panel.runModal() == .OK, let url = panel.url else { return I18N.t("msg.export_cancelled") }
+            try cli.exportAccount(accountName: name, path: url.path)
+            return String(format: I18N.t("msg.exported.account_to"), name, url.path)
+        }
+    }
+
+    private func run(_ op: () throws -> String) {
+        do { output = try op() } catch {
+            output = I18N.t("msg.action.failed") + ": " + I18N.explainVpnCmdError(error.localizedDescription)
+        }
+    }
+    private func onSelected(_ op: (String) throws -> String) {
+        guard !selectedAccountName.isEmpty else { return }
+        run { try op(selectedAccountName) }
+    }
+}
+
+struct ClientView: View {
+    @EnvironmentObject var vm: ClientViewModel
+    @EnvironmentObject var lang: LanguageManager
+
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack {
+                Text(I18N.t("label.vpncmd"))
+                TextField("/opt/homebrew/bin/vpncmd", text: $vm.vpncmdPath)
+                TextField(I18N.t("label.filter"), text: $vm.filterText).frame(width: 240)
+                Picker(lang.t("label.language"), selection: $lang.languageCode) {
+                    ForEach(lang.supportedLanguages, id: \.self) { code in
+                        Text(lang.languageDisplayName(code)).tag(code)
+                    }
+                }
+                .frame(width: 170)
+                Button(I18N.t("btn.use_system")) { lang.useSystemLanguage() }
+                Button(I18N.t("btn.use_english")) { lang.useEnglishLanguage() }
+                Button(I18N.t("btn.health_check")) { vm.healthCheck() }
+                Button(I18N.t("btn.refresh")) { vm.refresh() }
+            }
+
+            HSplitView {
+                VStack(alignment: .leading) {
+                    Text(I18N.t("section.accounts")).font(.headline)
+                    List(vm.filteredAccounts, id: \.name, selection: $vm.selectedAccountName) { a in
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack {
+                                Text(a.name).font(.headline)
+                                Spacer()
+                                Text(a.status)
+                                Text(a.server)
+                            }
+                            .font(.system(.body, design: .monospaced))
+                        }
+                        .contextMenu {
+                            Button(I18N.t("btn.connect")) { vm.selectedAccountName = a.name; vm.connect() }
+                            Button(I18N.t("btn.disconnect")) { vm.selectedAccountName = a.name; vm.disconnect() }
+                            Button(I18N.t("btn.status")) { vm.selectedAccountName = a.name; vm.status() }
+                            Divider()
+                            Button(I18N.t("btn.export")) { vm.selectedAccountName = a.name; vm.exportAccount() }
+                            Button(I18N.t("btn.delete"), role: .destructive) { vm.selectedAccountName = a.name; vm.delete() }
+                        }
+                    }
+                }
+                .padding(8)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    GroupBox(I18N.t("section.quick_actions")) {
+                        HStack {
+                            Button(I18N.t("btn.connect")) { vm.connect() }
+                            Button(I18N.t("btn.disconnect")) { vm.disconnect() }
+                            Button(I18N.t("btn.status")) { vm.status() }
+                            Button(I18N.t("btn.import")) { vm.importAccount() }
+                            Button(I18N.t("btn.export")) { vm.exportAccount() }
+                            Button(I18N.t("btn.delete")) { vm.delete() }
+                        }
+                    }
+
+                    GroupBox(I18N.t("section.create_account")) {
+                        HStack {
+                            TextField(I18N.t("field.name"), text: $vm.newName)
+                            TextField(I18N.t("field.host"), text: $vm.newHost)
+                            TextField(I18N.t("field.port"), text: $vm.newPort).frame(width: 80)
+                            TextField(I18N.t("field.hub"), text: $vm.newHub).frame(width: 140)
+                            TextField(I18N.t("field.username"), text: $vm.newUser)
+                            Button(I18N.t("btn.create")) { vm.createAccount() }
+                        }
+                    }
+
+                    GroupBox(I18N.t("section.edit_account")) {
+                        VStack {
+                            HStack { TextField(I18N.t("field.rename_to"), text: $vm.renameTo); Button(I18N.t("btn.rename")) { vm.rename() } }
+                            HStack { TextField(I18N.t("field.set_host"), text: $vm.setHost); TextField(I18N.t("field.set_port"), text: $vm.setPort).frame(width: 90); Button(I18N.t("btn.apply_host_port")) { vm.editServer() } }
+                        }
+                    }
+
+                    GroupBox(I18N.t("section.selected_details")) {
+                        ScrollView {
+                            let detail = vm.selectedAccount?.values ?? [:]
+                            VStack(alignment: .leading) {
+                                ForEach(detail.keys.sorted(), id: \.self) { k in
+                                    Text("\(k): \(detail[k] ?? "")").font(.system(.caption, design: .monospaced))
+                                }
+                            }
+                        }
+                        .frame(minHeight: 180)
+                    }
+
+                    GroupBox(I18N.t("section.output")) {
+                        TextEditor(text: $vm.output).font(.system(.caption, design: .monospaced)).frame(minHeight: 220)
+                    }
+                }
+                .padding(8)
+                .frame(minWidth: 620)
+            }
+        }
+        .padding(10)
+        .toolbar {
+            ToolbarItemGroup {
+                Button(I18N.t("btn.connect")) { vm.connect() }
+                Button(I18N.t("btn.disconnect")) { vm.disconnect() }
+                Button(I18N.t("btn.health_check")) { vm.healthCheck() }
+                Button(I18N.t("btn.refresh")) { vm.refresh() }
+            }
+        }
+        .onAppear { vm.refresh() }
+    }
+}


### PR DESCRIPTION
This PR aligns macOS tooling defaults with Apple Silicon Homebrew layout and local SoftEther runtime setup.\n\nChanges:\n- Set default vpncmd path to /opt/homebrew/bin/vpncmd in:\n  - /tmp/hermes-softether/softether-vpn/developer_tools/macos/Sources/Shared/SoftEtherCLI.swift\n  - /tmp/hermes-softether/softether-vpn/developer_tools/macos/Sources/VPNClientApp/main.swift\n  - /tmp/hermes-softether/softether-vpn/developer_tools/macos/Sources/ServerManagerApp/main.swift\n\nContext:\n- Local install uses wrappers in /opt/homebrew/bin to expose vpncmd/vpnserver/vpnclient with DYLD_LIBRARY_PATH for ~/.local/lib.\n- This avoids broken defaults pointing to /usr/local/bin on Apple Silicon.