### PR TITLE
Add CI for LibreSSL and update some API

### DIFF
--- a/.github/workflows/libressl.yml
+++ b/.github/workflows/libressl.yml
@@ -1,0 +1,31 @@
+name: LibreSSL
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  libressl:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+
+    steps:
+      - name: Install dependencies
+        run: apk add binutils --no-cache build-base git readline-dev libressl-dev ncurses-dev git cmake zlib-dev libsodium-dev gnu-libiconv
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Configure
+        run: ./configure
+
+      - name: Make
+        run: make -j $(nproc)  -C build
+
+      - name: Test
+        run: |
+          .ci/memory-leak-test.sh
+          .ci/vpntools-check.sh

--- a/src/Mayaqua/Encrypt.h
+++ b/src/Mayaqua/Encrypt.h
@@ -129,7 +129,7 @@
 // Macro
 #define	HASHED_DATA(p)			(((UCHAR *)p) + 15)
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || LIBRESSL_VERSION_NUMBER >= 0x3080100L
 typedef struct PKCS12_st PKCS12;
 typedef struct evp_md_st EVP_MD;
 #else

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -11852,7 +11852,7 @@ bool StartSSLEx3(SOCK *sock, X *x, K *priv, LIST *chain, UINT ssl_timeout, char 
 			}
 		}
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) ||  LIBRESSL_VERSION_NUMBER >= 0x3060000L
 		if (sock->SslAcceptSettings.Override_Security_Level)
 		{
 			SSL_CTX_set_security_level(ssl_ctx, sock->SslAcceptSettings.Override_Security_Level_Value);
@@ -16262,7 +16262,7 @@ UINT GetOSSecurityLevel()
 	}
 
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || LIBRESSL_VERSION_NUMBER >= 0x3060000L
 	security_level_new = SSL_CTX_get_security_level(ctx);
 #endif
 

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -16346,7 +16346,7 @@ TOKEN_LIST *GetCipherList()
 		return ciphers;
 	}
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || LIBRESSL_VERSION_NUMBER >= 0x2090100L
 	sk = SSL_get1_supported_ciphers(ssl);
 #else
 	sk = SSL_get_ciphers(ssl);


### PR DESCRIPTION
Currently, building with LibreSSL results in an error:
```
[ 19%] Building C object src/Mayaqua/3rdparty/cpu_features/CMakeFiles/cpu_features.dir/src/impl_x86_windows.c.o
[ 20%] Linking C static library libcpu_features.a
[ 20%] Built target cpu_features
[ 21%] Building C object src/Mayaqua/CMakeFiles/mayaqua.dir/Cfg.c.o
In file included from /__w/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Cfg.h:11,
                 from /__w/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Cfg.c:8:
/__w/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Encrypt.h:137:26: error: conflicting types for 'EVP_MD'; have 'struct env_md_st'
  137 | typedef struct env_md_st EVP_MD;
      |                          ^~~~~~
In file included from /usr/include/openssl/crypto.h:130,
                 from /usr/include/openssl/bio.h:69,
                 from /usr/include/openssl/pkcs12.h:62,
                 from /__w/SoftEtherVPN/SoftEtherVPN/src/Mayaqua/Encrypt.h:136:
/usr/include/openssl/ossl_typ.h:114:26: note: previous declaration of 'EVP_MD' with type 'EVP_MD' {aka 'struct evp_md_st'}
  114 | typedef struct evp_md_st EVP_MD;
      |                          ^~~~~~
make[2]: *** [src/Mayaqua/CMakeFiles/mayaqua.dir/build.make:79: src/Mayaqua/CMakeFiles/mayaqua.dir/Cfg.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:405: src/Mayaqua/CMakeFiles/mayaqua.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
make: Leaving directory '/__w/SoftEtherVPN/SoftEtherVPN/build'
```

Therefore,  This PR adds LibreSSL to the CI and fixes the build.
It also adds support for several API currently supported by LibreSSL.

Changes proposed in this pull request:
 - [Add CI for LibreSSL](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/9d5efa309a3f959d42edb53ff3d8d4af34ce4398)
 This CI uses Alpine Linux. It supports LibreSSL, if the `libressl-dev` package is installed.

 - [Rename env_md_st to evp_md_st for LibreSSL above v3.8.1](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/576a627e60fe46f8f6b0e5b04561c3218aa8ae13)
This commit fixes the error. It looks like it was  introduced in  this  [commit](https://github.com/libressl/openbsd/commit/ccf80370e13df3645f5a40674dded2e94f8cb0e9).


 - [Support security level API on LibreSSL above v3.6.0](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/3fda39dc457af77e751715c60313cc90a0af3dde)
Support security level API. It is mentioned in the 3.6.0 [release note](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.6.0-relnotes.txt#:~:text=%2D%20The%20security%20level%20API%20(SSL_%7B%2CCTX%7D_%7Bget%2Cset%7D_security_level())%20is%0A%20%20%20%20%20now%20available.%20Callbacks%20and%20ex_data%20are%20not%20supported.%20Sane%0A%20%20%20%20%20software%20will%20not%20be%20using%20this.).

 - [Support SSL_get1_supported_ciphers() on LibreSSL above v2.9.1](https://github.com/SoftEtherVPN/SoftEtherVPN/commit/bfcb6788a79c4ad479dfb569e716311924228692)
Support `SSL_get1_supported_ciphers()`. It was introduced in this [commit](https://github.com/libressl/openbsd/commit/add79fb32686c1e8baf10def36ae00f8ab91a52b).

