### PR TITLE
Fix pointer key hashing regression

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -735,7 +735,7 @@ UINT HashPtrToUINT(void *p)
 
 	Zero(hash_src, sizeof(hash_src));
 	Copy(hash_src + 0, GetCanaryRand(CANARY_RAND_ID_PTR_KEY_HASH), CANARY_RAND_SIZE);
-	Copy(hash_src + CANARY_RAND_SIZE, p, sizeof(void *));
+	Copy(hash_src + CANARY_RAND_SIZE, &p, sizeof(void *));
 
 	Sha2_256(hash_data, hash_src, sizeof(hash_src));
 


### PR DESCRIPTION
## Summary

Fix `HashPtrToUINT()` so it hashes the pointer value rather than the first
`sizeof(void *)` bytes of the pointed-to object.

The SHA-256 and per-process canary added by #1911 are retained. The only
change is passing `&p` to `Copy()`, restoring the function's original pointer
identity semantics without exposing raw pointer values.

## Impact

The regression caused deterministic management-key collisions whenever two
objects had the same initial bytes. In particular:

- all IPv4 table entries received the same key;
- all farm members on a controller received the same ID;
- CRL entries without serial numbers received the same key;
- MAC entries could collide based on their address prefix.

These keys are used by administration RPCs to resolve an enumerated item back
to its in-process object. A collision can therefore make a get, edit, or
delete operation act on a different item from the one selected.

Normal authentication, session establishment, packet forwarding, and cluster
load balancing do not use these pointer-derived keys directly.

## Regression

Introduced by #1911 when the previous pointer hash was changed from
`MD5(&p, sizeof(p))` to a canary-prefixed SHA-256 hash. The new input
accidentally used `p` instead of `&p`.

## Verification

A minimal AArch64 reproduction of the hash input confirmed that two distinct
objects with identical prefixes:

- always collide with the current implementation;
- produce different keys after this change;
- keep a stable key after their contents are modified.

The combined fixes were successfully built as an RPM package. The resulting
package was installed and tested and is running on multiple systems.
