### PR TITLE
Fix clustered IP deletion and SecureNAT session listing

### DIFF
--- a/src/Cedar/Command.c
+++ b/src/Cedar/Command.c
@@ -18899,11 +18899,11 @@ UINT PsSessionList(CONSOLE *c, char *cmd_name, wchar_t *str, void *param)
 			}
 			else if (e->SecureNATMode)
 			{
-				/*if (free_tmp2)
+				if (free_tmp2)
 				{
 					Free(tmp2);
 					free_tmp2 = false;
-				}*/
+				}
 				tmp2 = _UU("SM_SESS_SNAT");
 			}
 

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -7770,9 +7770,9 @@ void SiCalledDeleteIpTable(SERVER *s, PACK *p)
 
 	LockList(h->IpTable);
 	{
-		if (IsInList(h->IpTable, (void *)key))
+		IP_TABLE_ENTRY *e = ListKeyToPointer(h->IpTable, key);
+		if (e != NULL)
 		{
-			IP_TABLE_ENTRY *e = (IP_TABLE_ENTRY *)key;
 			Delete(h->IpTable, e);
 			Free(e);
 		}


### PR DESCRIPTION
## Summary

Fix two independent failures in clustered server administration:

- resolve an IP-table key to the receiving member's local entry before
  deleting it;
- release a dynamically allocated cluster-member label before replacing it
  with the static SecureNAT label during session enumeration.

The commits are kept separate so each fix can be reviewed or cherry-picked
independently.

## Details

### Remote IP-table deletion

An IP-table key sent by the controller is a hashed, process-local identifier,
not an address that can be dereferenced by another process. The receiving
member previously cast the key to `IP_TABLE_ENTRY *` and attempted to delete
and free it.

Resolve the key through `ListKeyToPointer()` while holding the IP-table lock,
matching the local administration path.

### Clustered SecureNAT session listing

Cluster session enumeration may allocate a label containing the member
location. For a SecureNAT session that pointer was replaced with the static
`SM_SESS_SNAT` translation without releasing the allocation or clearing its
ownership flag. Cleanup could then pass the static translation to `Free()`.

Release the owned label before replacing it, as the adjacent cascade-session
branch already does.

## Dependency

The remote IP-table behavior also requires the separate pointer-key hashing
regression fix in #2289 so distinct IPv4 table entries receive distinct keys.
This PR is intentionally based directly on `master`; merge #2289 first.

## Verification

The ownership and key-resolution paths were traced through controller and
member RPC handling. The combined fixes were successfully built as an RPM
package. The resulting package was installed and tested and is running on
multiple systems.
