### PR TITLE
configure: ask brew for the OpenSSL prefix on macOS

### DIFF
--- a/configure
+++ b/configure
@@ -32,8 +32,16 @@ fi
 if [ -z ${OPENSSL_ROOT_DIR} ]; then
 	unameOut="$(uname -s)"
 	if [ "$unameOut" = "Darwin" ]; then
-		echo "Environment variable OPENSSL_ROOT_DIR not set, using default Homebrew path: /usr/local/opt/openssl/"
-		export OPENSSL_ROOT_DIR="/usr/local/opt/openssl/"
+		# Homebrew's prefix differs by architecture: /opt/homebrew on Apple
+		# Silicon, /usr/local on Intel. Ask brew rather than hardcoding one.
+		if command -v brew > /dev/null 2>&1; then
+			OPENSSL_ROOT_DIR="$(brew --prefix openssl@3 2>/dev/null || brew --prefix openssl 2>/dev/null)"
+		fi
+		if [ -z "${OPENSSL_ROOT_DIR}" ]; then
+			OPENSSL_ROOT_DIR="/usr/local/opt/openssl/"
+		fi
+		echo "Environment variable OPENSSL_ROOT_DIR not set, using ${OPENSSL_ROOT_DIR}"
+		export OPENSSL_ROOT_DIR
 	fi
 fi
 


### PR DESCRIPTION
On macOS `configure` exports a hardcoded prefix:

```sh
export OPENSSL_ROOT_DIR="/usr/local/opt/openssl/"
```

That is the Homebrew prefix on **Intel** Macs. On Apple Silicon, Homebrew installs to `/opt/homebrew`, so the exported directory does not exist.

**To be clear, this is not a build fix — nothing is broken today.** CMake's `FindOpenSSL` treats `OPENSSL_ROOT_DIR` as a hint rather than an exclusive search path, so it ignores the dead directory and finds OpenSSL anyway. Measured on macOS 26.6.2 / M4 Pro against unpatched `master`:

```
$ ls -d /usr/local/opt/openssl/
ls: /usr/local/opt/openssl/: No such file or directory

$ OPENSSL_ROOT_DIR=/usr/local/opt/openssl/ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-- Found OpenSSL: /opt/homebrew/Cellar/openssl@3/3.6.3/lib/libcrypto.dylib (found version "3.6.3")
```

The problem is that `configure` prints a confident, wrong line — `using default Homebrew path: /usr/local/opt/openssl/` — naming a path that exists on no Apple Silicon Mac. Anyone debugging an OpenSSL pickup on such a machine is sent down a false trail.

This asks `brew` for the real prefix, preferring `openssl@3` and falling back to `openssl`, and keeps the previous hardcoded value as a last resort so behaviour is unchanged where Homebrew is absent. After the patch it prints `/opt/homebrew/opt/openssl@3`, which is the directory actually used.