### PR TITLE
cmake: fix Darwin cpu_features check testing the wrong variable

### DIFF
--- a/src/Mayaqua/CMakeLists.txt
+++ b/src/Mayaqua/CMakeLists.txt
@@ -140,7 +140,7 @@ if(UNIX)
   elseif(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(amd64|i386)")
     message("cpu_features is not available on FreeBSD/${CMAKE_SYSTEM_PROCESSOR}")
     add_definitions(-DSKIP_CPU_FEATURES)
-  elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" AND NOT CMAKE_SYSTEM_NAME MATCHES "^(arm64|x86_64)")
+  elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|x86_64)")
     # macOS runs only on Intel or ARM architecrues, should not reach here
     add_definitions(-DSKIP_CPU_FEATURES)
   elseif(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")


### PR DESCRIPTION
`src/Mayaqua/CMakeLists.txt` has:

```cmake
elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" AND NOT CMAKE_SYSTEM_NAME MATCHES "^(arm64|x86_64)")
  # macOS runs only on Intel or ARM architecrues, should not reach here
  add_definitions(-DSKIP_CPU_FEATURES)
```

The second condition tests `CMAKE_SYSTEM_NAME` — which is `"Darwin"` inside this branch and therefore never matches `^(arm64|x86_64)` — where it clearly means `CMAKE_SYSTEM_PROCESSOR`. The `NOT` is consequently always true, so the branch the comment says we "should not reach" is the one always taken.

The FreeBSD branch three lines above gets this right:

```cmake
elseif(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(amd64|i386)")
```

In practice the effect is masked: macOS has no `sys/auxv.h`, so `HAVE_SYS_AUXV` is false and the *first* branch already defines `SKIP_CPU_FEATURES` before this one is reached. The condition is still wrong and worth correcting so it behaves as written if the auxv check ever changes.

Found while building `master` on macOS 26.6.2, Apple M4 Pro.