### PR TITLE
configure: select TGZ rather than DEB for CPack on macOS

### DIFF
--- a/configure
+++ b/configure
@@ -40,6 +40,9 @@ fi
 if [ ! -z ${CPACK_GENERATOR+x} ]; then
 	echo "CPACK_GENERATOR is set, CPack will generate ${CPACK_GENERATOR} packages."
 	CMAKE_FLAGS="-DCPACK_GENERATOR=${CPACK_GENERATOR} ${CMAKE_FLAGS}"
+elif [ "$(uname -s)" = "Darwin" ]; then
+	echo "Darwin detected, CPack will generate TGZ archives."
+	CMAKE_FLAGS="-DCPACK_GENERATOR='TGZ' ${CMAKE_FLAGS}"
 elif [ -x "$(command -v rpm)" ]; then
 	echo "'rpm' executable found, CPack will generate RPM packages."
 	CMAKE_FLAGS="-DCPACK_GENERATOR='RPM' ${CMAKE_FLAGS}"


### PR DESCRIPTION
`configure` chooses the CPack generator by probing for an `rpm` executable:

```sh
elif [ -x "$(command -v rpm)" ]; then   # -> RPM
else                                     # -> DEB
```

macOS has neither, so it falls through to **DEB**, which is not a meaningful package format there. The root `CMakeLists.txt` likewise defines only DEB and RPM settings; there is no macOS packaging configuration in the tree.

This adds a Darwin branch selecting `TGZ`, which always works. An explicit `CPACK_GENERATOR` in the environment still takes precedence, so anyone wanting `productbuild` or `DragNDrop` can ask for it.

Scope is small: `CPACK_GENERATOR` is only read by `cpack`, so this affects `make package` alone and never an ordinary `make -C build`. That is why macOS CI is green today despite the wrong default.

Found while building `master` on macOS 26.6.2, Apple M4 Pro.